### PR TITLE
Fillable Comment Fix

### DIFF
--- a/stubs/app/Models/Team.php
+++ b/stubs/app/Models/Team.php
@@ -21,7 +21,7 @@ class Team extends JetstreamTeam
     ];
 
     /**
-     * The attributes that aren't mass assignable.
+     * The attributes that are mass assignable.
      *
      * @var array
      */


### PR DESCRIPTION
Had to do a double take on this one. 😄   Suggests that fillable attributes _are_ mass assignable.