### PR TITLE
Replace the "home" route by the "dashboard" route

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -42,6 +42,8 @@ class InstallCommand extends Command
 
         // "Home" Route...
         $this->replaceInFile('/home', '/dashboard', app_path('Providers/RouteServiceProvider.php'));
+        $this->replaceInFile('/home', '/dashboard', resource_path('views/welcome.blade.php'));
+        $this->replaceInFile('Home', 'Dashboard', resource_path('views/welcome.blade.php'));
 
         // Fortify Provider...
         $this->installFortifyServiceProvider();

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -42,8 +42,10 @@ class InstallCommand extends Command
 
         // "Home" Route...
         $this->replaceInFile('/home', '/dashboard', app_path('Providers/RouteServiceProvider.php'));
-        $this->replaceInFile('/home', '/dashboard', resource_path('views/welcome.blade.php'));
-        $this->replaceInFile('Home', 'Dashboard', resource_path('views/welcome.blade.php'));
+        if (file_exists(resource_path('views/welcome.blade.php'))) {
+            $this->replaceInFile('/home', '/dashboard', resource_path('views/welcome.blade.php'));
+            $this->replaceInFile('Home', 'Dashboard', resource_path('views/welcome.blade.php'));
+        }
 
         // Fortify Provider...
         $this->installFortifyServiceProvider();

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -42,6 +42,7 @@ class InstallCommand extends Command
 
         // "Home" Route...
         $this->replaceInFile('/home', '/dashboard', app_path('Providers/RouteServiceProvider.php'));
+
         if (file_exists(resource_path('views/welcome.blade.php'))) {
             $this->replaceInFile('/home', '/dashboard', resource_path('views/welcome.blade.php'));
             $this->replaceInFile('Home', 'Dashboard', resource_path('views/welcome.blade.php'));


### PR DESCRIPTION
Since the package updates the "home" route, I think we should also update the link on the welcome page.

I know that this page is not really used in real applications but I think it would be nice to have a working link.