### PR TITLE
use numeric ids for users

### DIFF
--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -14,7 +14,7 @@ class CreateUsersTable extends Migration
     public function up()
     {
         Schema::create('users', function (Blueprint $table) {
-            $table->uuid('id')->primary();
+            $table->id();
             $table->string('name');
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();

--- a/database/migrations/2020_05_21_100000_create_teams_table.php
+++ b/database/migrations/2020_05_21_100000_create_teams_table.php
@@ -15,7 +15,7 @@ class CreateTeamsTable extends Migration
     {
         Schema::create('teams', function (Blueprint $table) {
             $table->uuid('id')->primary();
-            $table->uuid('user_id')->index();
+            $table->foreignId('user_id')->index();
             $table->string('name');
             $table->boolean('personal_team');
             $table->timestamps();

--- a/database/migrations/2020_05_21_200000_create_team_user_table.php
+++ b/database/migrations/2020_05_21_200000_create_team_user_table.php
@@ -16,7 +16,7 @@ class CreateTeamUserTable extends Migration
         Schema::create('team_user', function (Blueprint $table) {
             $table->id();
             $table->uuid('team_id');
-            $table->uuid('user_id');
+            $table->foreignId('user_id');
             $table->string('role')->nullable();
             $table->timestamps();
 

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -98,14 +98,6 @@ class InstallCommand extends Command
         $this->replaceInFile("'SESSION_DRIVER', 'file'", "'SESSION_DRIVER', 'database'", config_path('session.php'));
         $this->replaceInFile('SESSION_DRIVER=file', 'SESSION_DRIVER=database', base_path('.env'));
         $this->replaceInFile('SESSION_DRIVER=file', 'SESSION_DRIVER=database', base_path('.env.example'));
-
-        foreach ((new Filesystem)->files(database_path('migrations')) as $file) {
-            if (Str::contains($file->getRealPath(), 'create_sessions_table')) {
-                $this->replaceInFile("foreignId('user_id')", "uuid('user_id')", $file->getRealPath());
-
-                break;
-            }
-        }
     }
 
     /**
@@ -126,8 +118,6 @@ class InstallCommand extends Command
                 ->run(function ($type, $output) {
                     $this->output->write($output);
                 });
-
-        $this->replaceInFile('morphs', 'uuidMorphs', database_path('migrations/2019_12_14_000001_create_personal_access_tokens_table.php'));
 
         // Update Configuration...
         $this->replaceInFile('inertia', 'livewire', config_path('jetstream.php'));
@@ -273,8 +263,6 @@ EOF;
                 ->run(function ($type, $output) {
                     $this->output->write($output);
                 });
-
-        $this->replaceInFile('morphs', 'uuidMorphs', database_path('migrations/2019_12_14_000001_create_personal_access_tokens_table.php'));
 
         // Update Configuration...
         $this->replaceInFile("'guard' => 'web'", "'guard' => 'sanctum'", config_path('auth.php'));

--- a/src/HasTeams.php
+++ b/src/HasTeams.php
@@ -80,7 +80,7 @@ trait HasTeams
      */
     public function ownsTeam($team)
     {
-        return $this->id === $team->user_id;
+        return (int) $this->id === (int) $team->user_id;
     }
 
     /**

--- a/src/Http/Controllers/Inertia/TeamMemberController.php
+++ b/src/Http/Controllers/Inertia/TeamMemberController.php
@@ -37,7 +37,7 @@ class TeamMemberController extends Controller
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  string  $teamId
-     * @param  string  $userId
+     * @param  int  $userId
      * @return \Illuminate\Http\RedirectResponse
      */
     public function update(Request $request, $teamId, $userId)
@@ -57,7 +57,7 @@ class TeamMemberController extends Controller
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  string  $teamId
-     * @param  string  $userId
+     * @param  int  $userId
      * @return \Illuminate\Http\RedirectResponse
      */
     public function destroy(Request $request, $teamId, $userId)

--- a/src/Http/Livewire/TeamMemberManager.php
+++ b/src/Http/Livewire/TeamMemberManager.php
@@ -56,7 +56,7 @@ class TeamMemberManager extends Component
     /**
      * The ID of the team member being removed.
      *
-     * @var string|null
+     * @var int|null
      */
     public $teamMemberIdBeingRemoved = null;
 
@@ -111,7 +111,7 @@ class TeamMemberManager extends Component
     /**
      * Allow the given user's role to be managed.
      *
-     * @param  string  $userId
+     * @param  int  $userId
      * @return void
      */
     public function manageRole($userId)
@@ -173,7 +173,7 @@ class TeamMemberManager extends Component
     /**
      * Confirm that the given team member should be removed.
      *
-     * @param  string  $userId
+     * @param  int  $userId
      * @return void
      */
     public function confirmTeamMemberRemoval($userId)

--- a/src/Jetstream.php
+++ b/src/Jetstream.php
@@ -160,9 +160,9 @@ class Jetstream
     /**
      * Find a user instance by the given ID.
      *
-     * @param  string  $id
+     * @param  int  $id
      */
-    public static function findUserByIdOrFail(string $id)
+    public static function findUserByIdOrFail($id)
     {
         return static::newUserModel()->where('id', $id)->firstOrFail();
     }

--- a/stubs/app/Models/User.php
+++ b/stubs/app/Models/User.php
@@ -5,7 +5,6 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
-use Illuminate\Support\Str;
 use Laravel\Fortify\TwoFactorAuthenticatable;
 use Laravel\Jetstream\HasProfilePhoto;
 use Laravel\Sanctum\HasApiTokens;
@@ -17,20 +16,6 @@ class User extends Authenticatable
     use HasProfilePhoto;
     use Notifiable;
     use TwoFactorAuthenticatable;
-
-    /**
-     * The "type" of the primary key ID.
-     *
-     * @var string
-     */
-    protected $keyType = 'string';
-
-    /**
-     * Indicates if the IDs are auto-incrementing.
-     *
-     * @var bool
-     */
-    public $incrementing = false;
 
     /**
      * The attributes that are mass assignable.
@@ -72,16 +57,4 @@ class User extends Authenticatable
     protected $appends = [
         'profile_photo_url',
     ];
-
-    /**
-     * Handle the model "booted" event.
-     *
-     * @return void
-     */
-    public static function booted()
-    {
-        static::creating(function ($model) {
-            $model->id = $model->id ?: (string) Str::orderedUuid();
-        });
-    }
 }

--- a/stubs/app/Models/UserWithTeams.php
+++ b/stubs/app/Models/UserWithTeams.php
@@ -5,7 +5,6 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
-use Illuminate\Support\Str;
 use Laravel\Fortify\TwoFactorAuthenticatable;
 use Laravel\Jetstream\HasProfilePhoto;
 use Laravel\Jetstream\HasTeams;
@@ -19,20 +18,6 @@ class User extends Authenticatable
     use HasTeams;
     use Notifiable;
     use TwoFactorAuthenticatable;
-
-    /**
-     * The "type" of the primary key ID.
-     *
-     * @var string
-     */
-    protected $keyType = 'string';
-
-    /**
-     * Indicates if the IDs are auto-incrementing.
-     *
-     * @var bool
-     */
-    public $incrementing = false;
 
     /**
      * The attributes that are mass assignable.
@@ -72,16 +57,4 @@ class User extends Authenticatable
     protected $appends = [
         'profile_photo_url',
     ];
-
-    /**
-     * Handle the model "booted" event.
-     *
-     * @return void
-     */
-    public static function booted()
-    {
-        static::creating(function ($model) {
-            $model->id = $model->id ?: (string) Str::orderedUuid();
-        });
-    }
 }

--- a/tests/Fixtures/User.php
+++ b/tests/Fixtures/User.php
@@ -12,35 +12,9 @@ class User extends Authenticatable
     use HasApiTokens, HasTeams;
 
     /**
-     * The "type" of the primary key ID.
-     *
-     * @var string
-     */
-    protected $keyType = 'string';
-
-    /**
-     * Indicates if the IDs are auto-incrementing.
-     *
-     * @var bool
-     */
-    public $incrementing = false;
-
-    /**
      * The attributes that aren't mass assignable.
      *
      * @var array
      */
     protected $guarded = [];
-
-    /**
-     * Handle the model "booted" event.
-     *
-     * @return void
-     */
-    public static function booted()
-    {
-        static::creating(function ($model) {
-            $model->id = $model->id ?: (string) Str::orderedUuid();
-        });
-    }
 }

--- a/tests/Fixtures/User.php
+++ b/tests/Fixtures/User.php
@@ -3,7 +3,6 @@
 namespace Laravel\Jetstream\Tests\Fixtures;
 
 use Illuminate\Foundation\Auth\User as Authenticatable;
-use Illuminate\Support\Str;
 use Laravel\Jetstream\HasTeams;
 use Laravel\Sanctum\HasApiTokens;
 


### PR DESCRIPTION
Use numeric IDs for users since using UUIDs for the authenticatable model would break many packages in the Laravel ecosystem.