### PR TITLE
make jetstream extendable for other stacks by the community

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -6,6 +6,7 @@ use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
+use InvalidArgumentException;
 use Symfony\Component\Process\Process;
 
 class InstallCommand extends Command
@@ -60,6 +61,15 @@ class InstallCommand extends Command
             '\Laravel\Jetstream\Http\Middleware\AuthenticateSession::class',
             app_path('Http/Kernel.php')
         );
+
+        // Install custom Stack
+        if (static::hasMacro($this->argument('stack'))) {
+            return static::{$this->argument('stack')}();
+        }
+
+        if (!in_array($this->argument('stack'), ['livewire', 'inertia'])) {
+            throw new InvalidArgumentException('Invalid stack.');
+        }
 
         // Install Stack...
         if ($this->argument('stack') === 'livewire') {

--- a/src/JetstreamServiceProvider.php
+++ b/src/JetstreamServiceProvider.php
@@ -162,6 +162,10 @@ class JetstreamServiceProvider extends ServiceProvider
      */
     protected function configureRoutes()
     {
+        if ($this->stackIsNotSupported()) {
+            return;
+        }
+
         Route::group([
             'namespace' => 'Laravel\Jetstream\Http\Controllers',
             'domain' => config('jetstream.domain', null),
@@ -197,5 +201,15 @@ class JetstreamServiceProvider extends ServiceProvider
 
         $kernel->appendMiddlewareToGroup('web', ShareInertiaData::class);
         $kernel->appendToMiddlewarePriority(ShareInertiaData::class);
+    }
+
+    /**
+     * Determines if the current stack is supported.
+     *
+     * @return bool
+     */
+    protected function stackIsNotSupported()
+    {
+        return !in_array(config('jetstream.stack'), ['livewire', 'inertia']);
     }
 }


### PR DESCRIPTION
This time without formating :)

This PR introduces the possibility for the community to create own presets based on Jetstream's existing functionality. For example if someone would rather use Vue without the Inertia stuff in the backend he could create a Vue preset by using

```
InstallCommand::macro('vue', function () {
  // do steps to setup vue preset with views etc.
});
```

Those little additions would help the community which is not yet so deep into Livewire and Inertia to come up with there own presets for Jetstream.