### PR TITLE
Add password confirmation to 2FA - livewire

### DIFF
--- a/src/Http/Livewire/TwoFactorAuthenticationForm.php
+++ b/src/Http/Livewire/TwoFactorAuthenticationForm.php
@@ -3,6 +3,8 @@
 namespace Laravel\Jetstream\Http\Livewire;
 
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Actions\DisableTwoFactorAuthentication;
 use Laravel\Fortify\Actions\EnableTwoFactorAuthentication;
 use Laravel\Fortify\Actions\GenerateNewRecoveryCodes;
@@ -10,6 +12,41 @@ use Livewire\Component;
 
 class TwoFactorAuthenticationForm extends Component
 {
+    /**
+     * Indicates if enable is being confirmed.
+     *
+     * @var bool
+     */
+    public $confirmingEnable = false;
+
+    /**
+     * Indicates if disable is being confirmed.
+     *
+     * @var bool
+     */
+    public $confirmingDisable = false;
+
+    /**
+     * Indicates if regenerate is being confirmed.
+     *
+     * @var bool
+     */
+    public $confirmingRegenerate = false;
+
+    /**
+     * The user's current password.
+     *
+     * @var string
+     */
+    public $password = '';
+
+    /**
+     * The user's current password.
+     *
+     * @var string
+     */
+    public $regenerate_password = '';
+
     /**
      * Indicates if two factor authentication QR code is being displayed.
      *
@@ -25,6 +62,55 @@ class TwoFactorAuthenticationForm extends Component
     public $showingRecoveryCodes = false;
 
     /**
+     * Confirm that the user would like to enable two factor authentication.
+     *
+     * @return void
+     */
+    public function confirmEnable()
+    {
+        $this->resetErrorBag();
+
+        $this->password = '';
+
+        $this->dispatchBrowserEvent('confirming-enable-two-factor-authentication');
+
+        $this->confirmingEnable = true;
+    }
+
+    /**
+     * Confirm that the user would like to disable two factor authentication.
+     *
+     * @return void
+     */
+    public function confirmDisable()
+    {
+        $this->resetErrorBag();
+
+        $this->password = '';
+
+        $this->dispatchBrowserEvent('confirming-disable-two-factor-authentication');
+
+        $this->confirmingDisable = true;
+    }
+
+
+    /**
+     * Confirm that the user would like to regenerate codes.
+     *
+     * @return void
+     */
+    public function confirmRegenerate()
+    {
+        $this->resetErrorBag();
+
+        $this->regenerate_password = '';
+
+        $this->dispatchBrowserEvent('confirming-regenerate-codes');
+
+        $this->confirmingRegenerate = true;
+    }
+
+    /**
      * Enable two factor authentication for the user.
      *
      * @param  \Laravel\Fortify\Actions\EnableTwoFactorAuthentication  $enable
@@ -32,10 +118,20 @@ class TwoFactorAuthenticationForm extends Component
      */
     public function enableTwoFactorAuthentication(EnableTwoFactorAuthentication $enable)
     {
+        $this->resetErrorBag();
+
+        if (! Hash::check($this->password, Auth::user()->password)) {
+            throw ValidationException::withMessages([
+                'password' => [__('This password does not match our records.')],
+            ]);
+        }
+
         $enable(Auth::user());
 
         $this->showingQrCode = true;
         $this->showingRecoveryCodes = true;
+
+        $this->confirmingEnable = false;
     }
 
     /**
@@ -46,9 +142,19 @@ class TwoFactorAuthenticationForm extends Component
      */
     public function regenerateRecoveryCodes(GenerateNewRecoveryCodes $generate)
     {
+        $this->resetErrorBag();
+
+        if (! Hash::check($this->regenerate_password, Auth::user()->password)) {
+            throw ValidationException::withMessages([
+                'password' => [__('This password does not match our records.')],
+            ]);
+        }
+
         $generate(Auth::user());
 
         $this->showingRecoveryCodes = true;
+
+        $this->confirmingRegenerate = false;
     }
 
     /**
@@ -59,7 +165,17 @@ class TwoFactorAuthenticationForm extends Component
      */
     public function disableTwoFactorAuthentication(DisableTwoFactorAuthentication $disable)
     {
+        $this->resetErrorBag();
+
+        if (! Hash::check($this->password, Auth::user()->password)) {
+            throw ValidationException::withMessages([
+                'password' => [__('This password does not match our records.')],
+            ]);
+        }
+
         $disable(Auth::user());
+
+        $this->confirmingDisable = false;
     }
 
     /**

--- a/src/Http/Livewire/TwoFactorAuthenticationForm.php
+++ b/src/Http/Livewire/TwoFactorAuthenticationForm.php
@@ -93,7 +93,6 @@ class TwoFactorAuthenticationForm extends Component
         $this->confirmingDisable = true;
     }
 
-
     /**
      * Confirm that the user would like to regenerate codes.
      *

--- a/stubs/livewire/resources/views/profile/two-factor-authentication-form.blade.php
+++ b/stubs/livewire/resources/views/profile/two-factor-authentication-form.blade.php
@@ -53,7 +53,7 @@
         <div class="mt-5">
             @if (! $this->enabled)
                 <x-jet-button type="button" wire:click="confirmEnable"  wire:loading.attr="disabled">
-                    Enabled Two Factor Authentication
+                    Enable Two Factor Authentication
                 </x-jet-button>
 
                 <!-- Enable Two Factor Authentication Confirmation Modal -->

--- a/stubs/livewire/resources/views/profile/two-factor-authentication-form.blade.php
+++ b/stubs/livewire/resources/views/profile/two-factor-authentication-form.blade.php
@@ -52,23 +52,113 @@
 
         <div class="mt-5">
             @if (! $this->enabled)
-                <x-jet-button type="button" wire:click="enableTwoFactorAuthentication" wire:loading.attr="disabled">
-                    Enable
+                <x-jet-button type="button" wire:click="confirmEnable"  wire:loading.attr="disabled">
+                    Enabled Two Factor Authentication
                 </x-jet-button>
+
+                <!-- Enable Two Factor Authentication Confirmation Modal -->
+                <x-jet-dialog-modal wire:model="confirmingEnable">
+                    <x-slot name="title">
+                        Enable Two Factor Authentication
+                    </x-slot>
+
+                    <x-slot name="content">
+                        Please enter your password to confirm you would like to enable two factor authentication.
+
+                        <div class="mt-4" x-data="{}" x-on:confirming-enable-two-factor-authentication.window="setTimeout(() => $refs.password.focus(), 250)">
+                            <x-jet-input type="password" class="mt-1 block w-3/4" placeholder="Password"
+                                         x-ref="password"
+                                         wire:model.defer="password"
+                                         wire:keydown.enter="enableTwoFactorAuthentication" />
+
+                            <x-jet-input-error for="password" class="mt-2" />
+                        </div>
+                    </x-slot>
+
+                    <x-slot name="footer">
+                        <x-jet-secondary-button wire:click="$toggle('confirmingEnable')" wire:loading.attr="disabled">
+                            Nevermind
+                        </x-jet-secondary-button>
+
+                        <x-jet-button class="ml-2" wire:click="enableTwoFactorAuthentication" wire:loading.attr="disabled">
+                            Enable Two Factor Authentication
+                        </x-jet-button>
+                    </x-slot>
+                </x-jet-dialog-modal>
             @else
                 @if ($showingRecoveryCodes)
-                    <x-jet-secondary-button class="mr-3" wire:click="regenerateRecoveryCodes">
+                    <x-jet-secondary-button class="mr-3" wire:click="confirmRegenerate">
                         Regenerate Recovery Codes
                     </x-jet-secondary-button>
+
+                    <!-- Regenerate Recovery Codes Confirmation Modal -->
+                    <x-jet-dialog-modal wire:model="confirmingRegenerate">
+                        <x-slot name="title">
+                            Regenerate Recovery Codes
+                        </x-slot>
+
+                        <x-slot name="content">
+                            Please enter your password to confirm you would like to regenerate recovery codes.
+
+                            <div class="mt-4" x-data="{}" x-on:confirming-regenerate-codes.window="setTimeout(() => $refs.password.focus(), 250)">
+                                <x-jet-input type="password" class="mt-1 block w-3/4" placeholder="Password"
+                                             x-ref="password"
+                                             wire:model.defer="regenerate_password"
+                                             wire:keydown.enter="regenerateRecoveryCodes" />
+
+                                <x-jet-input-error for="password" class="mt-2" />
+                            </div>
+                        </x-slot>
+
+                        <x-slot name="footer">
+                            <x-jet-secondary-button wire:click="$toggle('confirmingRegenerate')" wire:loading.attr="disabled">
+                                Nevermind
+                            </x-jet-secondary-button>
+
+                            <x-jet-button class="ml-2" wire:click="regenerateRecoveryCodes" wire:loading.attr="disabled">
+                                Regenerate Recovery Codes
+                            </x-jet-button>
+                        </x-slot>
+                    </x-jet-dialog-modal>
                 @else
                     <x-jet-secondary-button class="mr-3" wire:click="$toggle('showingRecoveryCodes')">
                         Show Recovery Codes
                     </x-jet-secondary-button>
                 @endif
 
-                <x-jet-danger-button wire:click="disableTwoFactorAuthentication" wire:loading.attr="disabled">
-                    Disable
+                <x-jet-danger-button  wire:click="confirmDisable" wire:loading.attr="disabled">
+                    Disable Two Factor Authentication
                 </x-jet-danger-button>
+
+                <!-- Disable Two Factor Authentication Confirmation Modal -->
+                <x-jet-dialog-modal wire:model="confirmingDisable">
+                    <x-slot name="title">
+                        Disable Two Factor Authentication
+                    </x-slot>
+
+                    <x-slot name="content">
+                        Please enter your password to confirm you would like to disable two factor authentication.
+
+                        <div class="mt-4" x-data="{}" x-on:confirming-disable-two-factor-authentication.window="setTimeout(() => $refs.password.focus(), 250)">
+                            <x-jet-input type="password" class="mt-1 block w-3/4" placeholder="Password"
+                                         x-ref="password"
+                                         wire:model.defer="password"
+                                         wire:keydown.enter="disableTwoFactorAuthentication" />
+
+                            <x-jet-input-error for="password" class="mt-2" />
+                        </div>
+                    </x-slot>
+
+                    <x-slot name="footer">
+                        <x-jet-secondary-button wire:click="$toggle('confirmingDisable')" wire:loading.attr="disabled">
+                            Nevermind
+                        </x-jet-secondary-button>
+
+                        <x-jet-danger-button class="ml-2" wire:click="disableTwoFactorAuthentication" wire:loading.attr="disabled">
+                            Disable Two Factor Authentication
+                        </x-jet-danger-button>
+                    </x-slot>
+                </x-jet-dialog-modal>
             @endif
         </div>
     </x-slot>


### PR DESCRIPTION
This PR adds a password confirmation dialog when enable/disable or generate a new codes for 2FA.
More info about how this works can be seen here https://d.pr/v/6C9rjI

Most companies require the user to confirm their identity before enable/disable the 2FA, and even require them to test the code after scanning the QR and before enabling 2FA.

We need to remember the user can login from multiple devices and can have the remember me checked, and if he forget to logout from a public computer any one can enable the 2FA and lock the main user out of his own account. Requiring the password makes such thing **a bit hard**.

Thanks.