### PR TITLE
Always show scroll bars

### DIFF
--- a/stubs/inertia/resources/views/app.blade.php
+++ b/stubs/inertia/resources/views/app.blade.php
@@ -17,7 +17,7 @@
         <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.26.0/moment.min.js"></script>
         <script src="{{ mix('/js/app.js') }}" defer></script>
     </head>
-    <body class="font-sans antialiased">
+    <body class="font-sans antialiased overflow-y-scroll">
         @inertia
     </body>
 </html>

--- a/stubs/livewire/resources/views/layouts/app.blade.php
+++ b/stubs/livewire/resources/views/layouts/app.blade.php
@@ -18,7 +18,7 @@
         <!-- Scripts -->
         <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.6.0/dist/alpine.js" defer></script>
     </head>
-    <body class="font-sans antialiased">
+    <body class="font-sans antialiased overflow-y-scroll">
         <div class="min-h-screen bg-gray-100">
             <nav x-data="{ open: false }" class="bg-white border-b border-gray-100">
                 <!-- Primary Navigation Menu -->


### PR DESCRIPTION
Currently, the vertical scroll bar is only shown when needed, so sometimes the page is "jumping":

![scroll](https://user-images.githubusercontent.com/98191/92176738-63076200-ee3f-11ea-9bd6-7b05ea04d263.gif)

After this PR, the scroll bars will always be visible.