### PR TITLE
Allow using Inertia without a session

### DIFF
--- a/src/Http/Middleware/ShareInertiaData.php
+++ b/src/Http/Middleware/ShareInertiaData.php
@@ -30,6 +30,10 @@ class ShareInertiaData
                 ];
             },
             'user' => function () use ($request) {
+                if (! $request->user()) {
+                    return;
+                }
+
                 if (Jetstream::hasTeamFeatures() && $request->user()) {
                     $request->user()->currentTeam;
                 }


### PR DESCRIPTION
This allows using Inertia for unauthenticated routes. I ran into this when moving the authentication scaffolding to Inertia, which I'll admit is outside the intended scope of the package, but still would be nice to have it working.

<details>
<summary>For anyone else running into this while this is open (or rejected), here's a hacky workaround</summary>

Add this function at the end of your `app/Http/Kernel.php`:

```php
public function updateWebGroup(\Closure $closure)
{
    $this->middlewareGroups['web'] = $closure($this->middlewareGroups['web']) ?? $this->middlewareGroups['web'];

    $this->syncMiddlewareToRouter();
}
```

And this to the boot method of your `JetstreamServiceProvider`:

```php
$this->app->make(Kernel::class)->updateWebGroup(function (array $web) {
    $web[array_search(\Laravel\Jetstream\Http\Middleware\ShareInertiaData::class, $web)] = \App\Http\Middleware\ShareInertiaData::class;

     return $web;
});
```

Now, copy the `ShareInertiaData` middleware to your local middleware folder and apply the changes of this PR.