### PR TITLE
Set timeout to INF

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -114,14 +114,14 @@ class InstallCommand extends Command
     {
         // Install Livewire...
         (new Process(['composer', 'require', 'livewire/livewire:^2.0', 'laravel/sanctum:^2.6'], base_path()))
-                ->setTimeout(null)
+                ->setTimeout(INF)
                 ->run(function ($type, $output) {
                     $this->output->write($output);
                 });
 
         // Sanctum...
         (new Process(['php', 'artisan', 'vendor:publish', '--provider=Laravel\Sanctum\SanctumServiceProvider', '--force'], base_path()))
-                ->setTimeout(null)
+                ->setTimeout(INF)
                 ->run(function ($type, $output) {
                     $this->output->write($output);
                 });
@@ -247,7 +247,7 @@ EOF;
     {
         // Install Inertia...
         (new Process(['composer', 'require', 'inertiajs/inertia-laravel', 'laravel/sanctum:^2.6'], base_path()))
-                ->setTimeout(null)
+                ->setTimeout(INF)
                 ->run(function ($type, $output) {
                     $this->output->write($output);
                 });
@@ -269,7 +269,7 @@ EOF;
 
         // Sanctum...
         (new Process(['php', 'artisan', 'vendor:publish', '--provider=Laravel\Sanctum\SanctumServiceProvider', '--force'], base_path()))
-                ->setTimeout(null)
+                ->setTimeout(INF)
                 ->run(function ($type, $output) {
                     $this->output->write($output);
                 });


### PR DESCRIPTION
Fixes #45 

Sometimes the installation of a stack takes very long time (because of low resource in my machine). That cause 
`Symfony\Component\Process\Exception\ProcessTimedOutException` 

So as to fix that I have added time limit to INF.
