### PR TITLE
Fix InstallCommand.php

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -78,7 +78,7 @@ class InstallCommand extends Command
     {
         if (! Str::contains($appConfig = file_get_contents(config_path('app.php')), 'App\\Providers\\FortifyServiceProvider::class')) {
             file_put_contents(config_path('app.php'), str_replace(
-                "App\\Providers\RouteServiceProvider::class,".PHP_EOL,
+                "App\\Providers\RouteServiceProvider::class,",
                 "App\\Providers\RouteServiceProvider::class,".PHP_EOL."        App\Providers\FortifyServiceProvider::class,".PHP_EOL,
                 $appConfig
             ));
@@ -433,7 +433,7 @@ EOF;
     {
         if (! Str::contains($appConfig = file_get_contents(config_path('app.php')), 'App\\Providers\\JetstreamServiceProvider::class')) {
             file_put_contents(config_path('app.php'), str_replace(
-                "App\\Providers\FortifyServiceProvider::class,".PHP_EOL,
+                "App\\Providers\FortifyServiceProvider::class,",
                 "App\\Providers\FortifyServiceProvider::class,".PHP_EOL."        App\Providers\JetstreamServiceProvider::class,".PHP_EOL,
                 $appConfig
             ));

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -434,7 +434,7 @@ EOF;
         if (! Str::contains($appConfig = file_get_contents(config_path('app.php')), 'App\\Providers\\JetstreamServiceProvider::class')) {
             file_put_contents(config_path('app.php'), str_replace(
                 "App\\Providers\FortifyServiceProvider::class,",
-                "App\\Providers\FortifyServiceProvider::class,".PHP_EOL."        App\Providers\JetstreamServiceProvider::class,".PHP_EOL,
+                "App\\Providers\FortifyServiceProvider::class,".PHP_EOL."        App\Providers\JetstreamServiceProvider::class,",
                 $appConfig
             ));
         }

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -79,7 +79,7 @@ class InstallCommand extends Command
         if (! Str::contains($appConfig = file_get_contents(config_path('app.php')), 'App\\Providers\\FortifyServiceProvider::class')) {
             file_put_contents(config_path('app.php'), str_replace(
                 "App\\Providers\RouteServiceProvider::class,",
-                "App\\Providers\RouteServiceProvider::class,".PHP_EOL."        App\Providers\FortifyServiceProvider::class,".PHP_EOL,
+                "App\\Providers\RouteServiceProvider::class,".PHP_EOL."        App\Providers\FortifyServiceProvider::class,",
                 $appConfig
             ));
         }


### PR DESCRIPTION
On windows, the Services Providers was not added to the app.php file.

![image](https://user-images.githubusercontent.com/7970196/92286471-0ff4e400-eeff-11ea-94d4-743b4ce3cbc1.png)

After some tests I realized that it would be enough to remove the PHP_EOL tag.


