### PR TITLE
Use application language on layouts

### DIFF
--- a/stubs/inertia/resources/views/app.blade.php
+++ b/stubs/inertia/resources/views/app.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/stubs/livewire/resources/views/layouts/app.blade.php
+++ b/stubs/livewire/resources/views/layouts/app.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/stubs/resources/views/layouts/guest.blade.php
+++ b/stubs/resources/views/layouts/guest.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
This PR sets the language attribute on the HTML tag of both stacks to follow the application's configured locale, like the welcome view does.

See #56 