### PR TITLE
Allow custom routes

### DIFF
--- a/src/JetstreamServiceProvider.php
+++ b/src/JetstreamServiceProvider.php
@@ -160,6 +160,12 @@ class JetstreamServiceProvider extends ServiceProvider
      */
     protected function configureRoutes()
     {
+        if ($path = config('jetstream.routes', null)) {
+            $this->loadRoutesFrom($path);
+
+            return;
+        }
+
         Route::group([
             'namespace' => 'Laravel\Jetstream\Http\Controllers',
             'domain' => config('jetstream.domain', null),


### PR DESCRIPTION
Matching a proposed PR in Fortity, This PR adds the ability to override Jetstream's routes file with an option in the configuration file.

Related issue/feature request: https://github.com/laravel/fortify/issues/9 and Fortify PR: https://github.com/laravel/fortify/pull/10

For my example use case, I put a route prefix before all authentication endpoints. This PR would allow Jetstream and Fortify the same flexibility.

When using the laravel/ui package, defining routes was an opt-in by calling the Auth::routes() on the app's routes file. In Jetstream and Fortify, they are booted with autoloading.

(I :heart: Laravel)