### PR TITLE
Typo: DeleteUserWithTeams was sometimes DeleteUser

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -415,7 +415,7 @@ EOF;
         copy(__DIR__.'/../../stubs/app/Actions/Jetstream/AddTeamMember.php', app_path('Actions/Jetstream/AddTeamMember.php'));
         copy(__DIR__.'/../../stubs/app/Actions/Jetstream/CreateTeam.php', app_path('Actions/Jetstream/CreateTeam.php'));
         copy(__DIR__.'/../../stubs/app/Actions/Jetstream/DeleteTeam.php', app_path('Actions/Jetstream/DeleteTeam.php'));
-        copy(__DIR__.'/../../stubs/app/Actions/Jetstream/DeleteUserWithTeams.php', app_path('Actions/Jetstream/DeleteUser.php'));
+        copy(__DIR__.'/../../stubs/app/Actions/Jetstream/DeleteUserWithTeams.php', app_path('Actions/Jetstream/DeleteUserWithTeams.php'));
         copy(__DIR__.'/../../stubs/app/Actions/Jetstream/UpdateTeamName.php', app_path('Actions/Jetstream/UpdateTeamName.php'));
 
         copy(__DIR__.'/../../stubs/app/Actions/Fortify/CreateNewUserWithTeams.php', app_path('Actions/Fortify/CreateNewUser.php'));

--- a/stubs/app/Actions/Jetstream/DeleteUserWithTeams.php
+++ b/stubs/app/Actions/Jetstream/DeleteUserWithTeams.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\DB;
 use Laravel\Jetstream\Contracts\DeletesTeams;
 use Laravel\Jetstream\Contracts\DeletesUsers;
 
-class DeleteUser implements DeletesUsers
+class DeleteUserWithTeams implements DeletesUsers
 {
     /**
      * The team deleter implementation.

--- a/tests/DeleteUserWithTeamsTest.php
+++ b/tests/DeleteUserWithTeamsTest.php
@@ -4,7 +4,7 @@ namespace Laravel\Jetstream\Tests;
 
 use App\Actions\Jetstream\CreateTeam;
 use App\Actions\Jetstream\DeleteTeam;
-use App\Actions\Jetstream\DeleteUser;
+use App\Actions\Jetstream\DeleteUserWithTeam;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Laravel\Jetstream\Jetstream;

--- a/tests/DeleteUserWithTeamsTest.php
+++ b/tests/DeleteUserWithTeamsTest.php
@@ -5,6 +5,7 @@ namespace Laravel\Jetstream\Tests;
 use App\Actions\Jetstream\CreateTeam;
 use App\Actions\Jetstream\DeleteTeam;
 use App\Actions\Jetstream\DeleteUserWithTeam;
+use App\Actions\Jetstream\DeleteUserWithTeams;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Laravel\Jetstream\Jetstream;
@@ -35,7 +36,7 @@ class DeleteUserWithTeamsTest extends OrchestraTestCase
 
         require $fixture;
 
-        $action = new DeleteUser(new DeleteTeam);
+        $action = new DeleteUserWithTeams(new DeleteTeam);
 
         $action->delete($team->owner);
 

--- a/tests/DeleteUserWithTeamsTest.php
+++ b/tests/DeleteUserWithTeamsTest.php
@@ -4,7 +4,6 @@ namespace Laravel\Jetstream\Tests;
 
 use App\Actions\Jetstream\CreateTeam;
 use App\Actions\Jetstream\DeleteTeam;
-use App\Actions\Jetstream\DeleteUserWithTeam;
 use App\Actions\Jetstream\DeleteUserWithTeams;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;

--- a/tests/DeleteUserWithTeamsTest.php
+++ b/tests/DeleteUserWithTeamsTest.php
@@ -31,7 +31,7 @@ class DeleteUserWithTeamsTest extends OrchestraTestCase
         $this->assertSame(2, DB::table('teams')->count());
         $this->assertSame(1, DB::table('team_user')->count());
 
-        copy(__DIR__.'/../stubs/app/Actions/Jetstream/DeleteUserWithTeams.php', $fixture = __DIR__.'/Fixtures/DeleteUser.php');
+        copy(__DIR__.'/../stubs/app/Actions/Jetstream/DeleteUserWithTeams.php', $fixture = __DIR__.'/Fixtures/DeleteUserWithTeams.php');
 
         require $fixture;
 


### PR DESCRIPTION
At first I thought this was some strategy to allow Developers to flexibly use `DeleteUser` Action but after digging thought maybe it was just a typo.
