### PR TITLE
Provide a way of customizing/disabling the default routes

### DIFF
--- a/src/Jetstream.php
+++ b/src/Jetstream.php
@@ -11,6 +11,13 @@ use Laravel\Jetstream\Contracts\UpdatesTeamNames;
 class Jetstream
 {
     /**
+     * Indicates if Jetstream routes will be registered.
+     *
+     * @var bool
+     */
+    public static $registersRoutes = true;
+
+    /**
      * The roles that are available to assign to users.
      *
      * @var array
@@ -298,5 +305,17 @@ class Jetstream
     public static function deleteUsersUsing(string $class)
     {
         return app()->singleton(DeletesUsers::class, $class);
+    }
+
+    /**
+     * Configure Jetstream to not register its routes.
+     *
+     * @return static
+     */
+    public static function ignoreRoutes()
+    {
+        static::$registersRoutes = false;
+
+        return new static;
     }
 }

--- a/src/JetstreamServiceProvider.php
+++ b/src/JetstreamServiceProvider.php
@@ -151,6 +151,10 @@ class JetstreamServiceProvider extends ServiceProvider
             __DIR__.'/../database/migrations/2020_05_21_100000_create_teams_table.php' => database_path('migrations/2020_05_21_100000_create_teams_table.php'),
             __DIR__.'/../database/migrations/2020_05_21_200000_create_team_user_table.php' => database_path('migrations/2020_05_21_200000_create_team_user_table.php'),
         ], 'jetstream-team-migrations');
+
+        $this->publishes([
+            __DIR__.'/../routes/'.config('jetstream.stack').'.php' => base_path('routes/jetstream'),
+        ], 'jetstream-routes');
     }
 
     /**
@@ -160,12 +164,14 @@ class JetstreamServiceProvider extends ServiceProvider
      */
     protected function configureRoutes()
     {
-        Route::group([
-            'namespace' => 'Laravel\Jetstream\Http\Controllers',
-            'domain' => config('jetstream.domain', null),
-        ], function () {
-            $this->loadRoutesFrom(__DIR__.'/../routes/'.config('jetstream.stack').'.php');
-        });
+        if (Jetstream::$registersRoutes) {
+            Route::group([
+                'namespace' => 'Laravel\Jetstream\Http\Controllers',
+                'domain' => config('jetstream.domain', null),
+            ], function () {
+                $this->loadRoutesFrom(__DIR__.'/../routes/'.config('jetstream.stack').'.php');
+            });
+        }
     }
 
     /**


### PR DESCRIPTION
This PR introduces a way of disabling registration of the default routes like other Laravel packages already allow (Cashier, for example). It also adds an option to publish the routes for the adapter you're currently using to your routes folder.

Resubmission of #54 