### PR TITLE
Typo: DeleteTeamForm component confirmation modal

### DIFF
--- a/stubs/inertia/resources/js/Pages/Teams/DeleteTeamForm.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/DeleteTeamForm.vue
@@ -10,7 +10,7 @@
 
         <template #content>
             <div class="max-w-xl text-sm text-gray-600">
-                Once a team is deleted, all of its resources and data will be permanently deleted. Before deleting this team, please download any data or information regrading this team that you wish to retain.
+                Once a team is deleted, all of its resources and data will be permanently deleted. Before deleting this team, please download any data or information regarding this team that you wish to retain.
             </div>
 
             <div class="mt-5">

--- a/stubs/livewire/resources/views/teams/delete-team-form.blade.php
+++ b/stubs/livewire/resources/views/teams/delete-team-form.blade.php
@@ -9,7 +9,7 @@
 
     <x-slot name="content">
         <div class="max-w-xl text-sm text-gray-600">
-            Once a team is deleted, all of its resources and data will be permanently deleted. Before deleting this team, please download any data or information regrading this team that you wish to retain.
+            Once a team is deleted, all of its resources and data will be permanently deleted. Before deleting this team, please download any data or information regarding this team that you wish to retain.
         </div>
 
         <div class="mt-5">


### PR DESCRIPTION
Fixes a spelling issue in the DeleteTeamForm component. 

Changes:

1. "Once a team is deleted, all of its resources and data will be permanently deleted. Before deleting this team, please download any data or information **regrading** this team that you wish to retain." 

to:

1. "Once a team is deleted, all of its resources and data will be permanently deleted. Before deleting this team, please download any data or information **regarding** this team that you wish to retain."