### PR TITLE
[livewire][teams]Update state property to include all team fields

### DIFF
--- a/src/Http/Livewire/UpdateTeamNameForm.php
+++ b/src/Http/Livewire/UpdateTeamNameForm.php
@@ -32,7 +32,7 @@ class UpdateTeamNameForm extends Component
     {
         $this->team = $team;
 
-        $this->state = ['name' => $team->name];
+        $this->state = $team->toArray();
     }
 
     /**


### PR DESCRIPTION
```src/Http/Livewire/UpdateTeamNameForm.php```

Mount ```$state``` property to include *all* existing fields of the ```Team``` Model instead of the ```name``` only 
in order to allow the implementation of additional, custom, fields for the ```Team``` Model. 

That way, **custom fields can be added** to the ```teams``` table, and be able to update them through ```app/Actions/Jetstream/UpdateTeamName.php``` and ```resources/views/teams/update-team-name-form.blade.php```.


<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
