### PR TITLE
Delete API Tokens on User deletion

### DIFF
--- a/stubs/app/Actions/Jetstream/DeleteUser.php
+++ b/stubs/app/Actions/Jetstream/DeleteUser.php
@@ -14,6 +14,8 @@ class DeleteUser implements DeletesUsers
      */
     public function delete($user)
     {
+        $user->tokens()->delete();
+
         $user->delete();
     }
 }

--- a/stubs/app/Actions/Jetstream/DeleteUserWithTeams.php
+++ b/stubs/app/Actions/Jetstream/DeleteUserWithTeams.php
@@ -37,6 +37,8 @@ class DeleteUser implements DeletesUsers
         DB::transaction(function () use ($user) {
             $this->deleteTeams($user);
 
+            $user->tokens()->delete();
+
             $user->delete();
         });
     }


### PR DESCRIPTION
On User account deletion, delete all related User API Tokens. [Documentation](https://laravel.com/docs/8.x/sanctum#revoking-tokens).