### PR TITLE
Fixes Error not found on Delete API Token 

### DIFF
--- a/src/Http/Livewire/ApiTokenManager.php
+++ b/src/Http/Livewire/ApiTokenManager.php
@@ -45,7 +45,7 @@ class ApiTokenManager extends Component
      *
      * @var \Laravel\Sanctum\PersonalAccessToken|null
      */
-    public $managingPermissionsFor;
+    protected $managingPermissionsFor;
 
     /**
      * The update API token form state.


### PR DESCRIPTION
- Jetstream Version: 0.6.4
- Laravel Version: 8.x-dev
- PHP Version 7.4 

## Description:

There is a weird behavior when trying to delete a token after first opening the manage token permissions modal. On deletion I get an error 404 not found. 

## Steps to reproduce: 

1) Go to API Tokens management. 
2) Create a token 
3) Click on permissions to open the modal and then click on Nevermind button 
4) Try to delete the token 

Here is a gif showcasing the issue: 
![capture](https://user-images.githubusercontent.com/12728267/92333577-dea72000-f086-11ea-9f60-03d96f09b008.gif)

Changing the visibility of the `managingPermissionsFor` property to protected fixes the issue. 
