### PR TITLE
Fix alignment of the welcome page.

### DIFF
--- a/resources/views/components/welcome.blade.php
+++ b/resources/views/components/welcome.blade.php
@@ -1,4 +1,4 @@
-<div class="p-6 sm:px-20 bg-white border-b border-gray-200">
+<div class="p-8 sm:px-20 bg-white border-b border-gray-200">
     <div>
         <x-jet-application-logo class="block h-12 w-auto" />
     </div>
@@ -16,7 +16,7 @@
 </div>
 
 <div class="bg-gray-200 bg-opacity-25 grid grid-cols-1 md:grid-cols-2">
-    <div class="p-6">
+    <div class="p-8">
         <div class="flex items-center">
             <svg fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" class="w-8 h-8 text-gray-400"><path d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"></path></svg>
             <div class="ml-4 text-lg text-gray-600 leading-7 font-semibold"><a href="https://laravel.com/docs">Documentation</a></div>
@@ -39,7 +39,7 @@
         </div>
     </div>
 
-    <div class="p-6 border-t border-gray-200 md:border-t-0 md:border-l">
+    <div class="p-8 border-t border-gray-200 md:border-t-0 md:border-l">
         <div class="flex items-center">
             <svg fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" class="w-8 h-8 text-gray-400"><path d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z"></path><path d="M15 13a3 3 0 11-6 0 3 3 0 016 0z"></path></svg>
             <div class="ml-4 text-lg text-gray-600 leading-7 font-semibold"><a href="https://laracasts.com">Laracasts</a></div>
@@ -62,7 +62,7 @@
         </div>
     </div>
 
-    <div class="p-6 border-t border-gray-200">
+    <div class="p-8 border-t border-gray-200">
         <div class="flex items-center">
             <svg fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" class="w-8 h-8 text-gray-400"><path d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"></path></svg>
             <div class="ml-4 text-lg text-gray-600 leading-7 font-semibold"><a href="https://tailwindcss.com/">Tailwind</a></div>
@@ -75,7 +75,7 @@
         </div>
     </div>
 
-    <div class="p-6 border-t border-gray-200 md:border-l">
+    <div class="p-8 border-t border-gray-200 md:border-l">
         <div class="flex items-center">
             <svg fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" class="w-8 h-8 text-gray-400"><path d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"></path></svg>
             <div class="ml-4 text-lg text-gray-600 leading-7 font-semibold">Authentication</div>


### PR DESCRIPTION
This PR addresses an issue where the left hand edge of the welcome page boxes don't align with the content above it. Before this PR, the welcome page looks like this:

![image](https://user-images.githubusercontent.com/199807/92395404-31321c00-f11b-11ea-9811-0d8bd7344518.png)

And afterwards, it looks like this:

![image](https://user-images.githubusercontent.com/199807/92395383-2bd4d180-f11b-11ea-8b11-32a98cc25c67.png)

Everything has a little bit more breathing room and the edges now align perfectly :smile:

**NOTE:** I'm not sure if I'm supposed to compile the assets for this as the `p-8` class is stripped (I assume by PurgeCSS) but I can't see any way of generating them easily for this PR. If there's another step I need to take, please let me know so that I can do it 😄 