### PR TITLE
Fix "remember me" checkbox

### DIFF
--- a/stubs/resources/views/auth/login.blade.php
+++ b/stubs/resources/views/auth/login.blade.php
@@ -27,7 +27,7 @@
 
             <div class="block mt-4">
                 <label class="flex items-center">
-                    <input type="checkbox" class="form-checkbox">
+                    <input type="checkbox" class="form-checkbox" name="remember">
                     <span class="ml-2 text-sm text-gray-600">{{ __('Remember me') }}</span>
                 </label>
             </div>


### PR DESCRIPTION
The "remember me" checkbox does not specify an attribute of `name="remember"`, so the cookie isn't actually being set.