### PR TITLE
Teams HasTeamPermissions check if API user or not

### DIFF
--- a/src/HasTeams.php
+++ b/src/HasTeams.php
@@ -154,7 +154,8 @@ trait HasTeams
         }
 
         if (in_array(HasApiTokens::class, class_uses_recursive($this)) &&
-            ! $this->tokenCan($permission)) {
+            ! $this->tokenCan($permission) &&
+            $this->currentAccessToken() !== null) {
             return false;
         }
 


### PR DESCRIPTION
Resolves Bug #62 by only comparing API Permissions and Team permissions only if the user has a Sanctum Access Token (authed via API), otherwise will only check if the user is granted the team permissions. 