### PR TITLE
Fix API vs Web TeamsHasPermissions, add Tests

### DIFF
--- a/src/HasTeams.php
+++ b/src/HasTeams.php
@@ -154,7 +154,8 @@ trait HasTeams
         }
 
         if (in_array(HasApiTokens::class, class_uses_recursive($this)) &&
-            ! $this->tokenCan($permission)) {
+            ! $this->tokenCan($permission) &&
+            $this->currentAccessToken() !== null) {
             return false;
         }
 

--- a/tests/TeamBehaviorTest.php
+++ b/tests/TeamBehaviorTest.php
@@ -7,6 +7,7 @@ use Laravel\Jetstream\Jetstream;
 use Laravel\Jetstream\Team;
 use Laravel\Jetstream\Tests\Fixtures\User;
 use Laravel\Sanctum\TransientToken;
+use Laravel\Sanctum\Sanctum;
 
 class TeamBehaviorTest extends OrchestraTestCase
 {
@@ -54,6 +55,15 @@ class TeamBehaviorTest extends OrchestraTestCase
         $otherUser->teams()->attach($team, ['role' => 'editor']);
         $otherUser = $otherUser->fresh();
 
+        $this->assertTrue($otherUser->belongsToTeam($team));
+        $this->assertFalse($otherUser->ownsTeam($team));
+
+        $this->assertTrue($otherUser->hasTeamPermission($team, 'foo'));
+        $this->assertFalse($otherUser->hasTeamPermission($team, 'bar'));
+
+        $this->assertTrue($team->userHasPermission($otherUser, 'foo'));
+        $this->assertFalse($team->userHasPermission($otherUser, 'bar'));
+
         $otherUser->withAccessToken(new TransientToken);
 
         $this->assertTrue($otherUser->belongsToTeam($team));
@@ -88,9 +98,25 @@ class TeamBehaviorTest extends OrchestraTestCase
             'password' => 'secret',
         ]);
 
+        $authToken = new Sanctum;
+        $adam = $authToken->actingAs($adam, ['bar'], []);
+
         $team->users()->attach($adam, ['role' => 'admin']);
 
         $this->assertFalse($adam->hasTeamPermission($team, 'foo'));
+        
+        $john = User::forceCreate([
+            'name' => 'John Doe',
+            'email' => 'john@doe.com',
+            'password' => 'secret',
+        ]);
+
+        $authToken = new Sanctum;
+        $john = $authToken->actingAs($john, ['foo'], []);
+
+        $team->users()->attach($john, ['role' => 'admin']);
+
+        $this->assertTrue($john->hasTeamPermission($team, 'foo'));
     }
 
     protected function migrate()

--- a/tests/TeamBehaviorTest.php
+++ b/tests/TeamBehaviorTest.php
@@ -6,8 +6,8 @@ use App\Actions\Jetstream\CreateTeam;
 use Laravel\Jetstream\Jetstream;
 use Laravel\Jetstream\Team;
 use Laravel\Jetstream\Tests\Fixtures\User;
-use Laravel\Sanctum\TransientToken;
 use Laravel\Sanctum\Sanctum;
+use Laravel\Sanctum\TransientToken;
 
 class TeamBehaviorTest extends OrchestraTestCase
 {

--- a/tests/TeamBehaviorTest.php
+++ b/tests/TeamBehaviorTest.php
@@ -104,7 +104,7 @@ class TeamBehaviorTest extends OrchestraTestCase
         $team->users()->attach($adam, ['role' => 'admin']);
 
         $this->assertFalse($adam->hasTeamPermission($team, 'foo'));
-        
+
         $john = User::forceCreate([
             'name' => 'John Doe',
             'email' => 'john@doe.com',


### PR DESCRIPTION
Resolves #62 by checking whether authenticated user is utilising a Sanctum access token prior to comparing token and team permissions.

Enhanced tests to include scenario for web-based user and authenticated user. Updated token test to utilise Sanctum mock to compare explicit API permission matching to team permissions.