### PR TITLE
add support multilang to livewire

### DIFF
--- a/stubs/livewire/resources/views/api/api-token-manager.blade.php
+++ b/stubs/livewire/resources/views/api/api-token-manager.blade.php
@@ -2,11 +2,11 @@
     <!-- Generate API Token -->
     <x-jet-form-section submit="createApiToken">
         <x-slot name="title">
-            Create API Token
+            {{ __('Create API Token') }}
         </x-slot>
 
         <x-slot name="description">
-            API tokens allow third-party services to authenticate with our application on your behalf.
+            {{ __('API tokens allow third-party services to authenticate with our application on your behalf.') }}
         </x-slot>
 
         <x-slot name="form">
@@ -36,11 +36,11 @@
 
         <x-slot name="actions">
             <x-jet-action-message class="mr-3" on="created">
-                Created.
+                {{ __('Created.') }}
             </x-jet-action-message>
 
             <x-jet-button>
-                Create
+                {{ __('Create') }}
             </x-jet-button>
         </x-slot>
     </x-jet-form-section>
@@ -52,11 +52,11 @@
         <div class="mt-10 sm:mt-0">
             <x-jet-action-section>
                 <x-slot name="title">
-                    Manage API Tokens
+                    {{ __('Manage API Tokens') }}
                 </x-slot>
 
                 <x-slot name="description">
-                    You may delete any of your existing tokens if they are no longer needed.
+                    {{ __('You may delete any of your existing tokens if they are no longer needed.') }}
                 </x-slot>
 
                 <!-- API Token List -->
@@ -77,12 +77,12 @@
 
                                     @if (Laravel\Jetstream\Jetstream::hasPermissions())
                                         <button class="cursor-pointer ml-6 text-sm text-gray-400 underline focus:outline-none" wire:click="manageApiTokenPermissions({{ $token->id }})">
-                                            Permissions
+                                            {{ __('Permissions') }}
                                         </button>
                                     @endif
 
                                     <button class="cursor-pointer ml-6 text-sm text-red-500 focus:outline-none" wire:click="confirmApiTokenDeletion({{ $token->id }})">
-                                        Delete
+                                        {{ __('Delete') }}
                                     </button>
                                 </div>
                             </div>
@@ -96,12 +96,12 @@
     <!-- Token Value Modal -->
     <x-jet-dialog-modal wire:model="displayingToken">
         <x-slot name="title">
-            API Token
+            {{ __('API Token') }}
         </x-slot>
 
         <x-slot name="content">
             <div>
-                Please copy your new API token. For your security, it won't be shown again.
+                {{ __('Please copy your new API token. For your security, it won\'t be shown again.') }}
             </div>
 
             <div class="mt-4 bg-gray-100 px-4 py-2 rounded font-mono text-sm text-gray-500">
@@ -111,7 +111,7 @@
 
         <x-slot name="footer">
             <x-jet-secondary-button wire:click="$set('displayingToken', false)" wire:loading.attr="disabled">
-                Close
+                {{ __('Close') }}
             </x-jet-secondary-button>
         </x-slot>
     </x-jet-dialog-modal>
@@ -119,7 +119,7 @@
     <!-- API Token Permissions Modal -->
     <x-jet-dialog-modal wire:model="managingApiTokenPermissions">
         <x-slot name="title">
-            API Token Permissions
+            {{ __('API Token Permissions') }}
         </x-slot>
 
         <x-slot name="content">
@@ -135,11 +135,11 @@
 
         <x-slot name="footer">
             <x-jet-secondary-button wire:click="$set('managingApiTokenPermissions', false)" wire:loading.attr="disabled">
-                Nevermind
+                {{ __('Nevermind') }}
             </x-jet-secondary-button>
 
             <x-jet-button class="ml-2" wire:click="updateApiToken" wire:loading.attr="disabled">
-                Save
+                {{ __('Save') }}
             </x-jet-button>
         </x-slot>
     </x-jet-dialog-modal>
@@ -147,20 +147,20 @@
     <!-- Delete Token Confirmation Modal -->
     <x-jet-confirmation-modal wire:model="confirmingApiTokenDeletion">
         <x-slot name="title">
-            Delete API Token
+            {{ __('Delete API Token') }}
         </x-slot>
 
         <x-slot name="content">
-            Are you sure you would like to delete this API token?
+            {{ __('Are you sure you would like to delete this API token?') }}
         </x-slot>
 
         <x-slot name="footer">
             <x-jet-secondary-button wire:click="$toggle('confirmingApiTokenDeletion')" wire:loading.attr="disabled">
-                Nevermind
+                {{ __('Nevermind') }}
             </x-jet-secondary-button>
 
             <x-jet-danger-button class="ml-2" wire:click="deleteApiToken" wire:loading.attr="disabled">
-                Delete
+                {{ __('Delete') }}
             </x-jet-danger-button>
         </x-slot>
     </x-jet-confirmation-modal>

--- a/stubs/livewire/resources/views/api/index.blade.php
+++ b/stubs/livewire/resources/views/api/index.blade.php
@@ -1,7 +1,7 @@
 <x-app-layout>
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            API Tokens
+            {{ __('API Tokens') }}
         </h2>
     </x-slot>
 

--- a/stubs/livewire/resources/views/dashboard.blade.php
+++ b/stubs/livewire/resources/views/dashboard.blade.php
@@ -1,7 +1,7 @@
 <x-app-layout>
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            Dashboard
+            {{ __('Dashboard') }}
         </h2>
     </x-slot>
 

--- a/stubs/livewire/resources/views/layouts/app.blade.php
+++ b/stubs/livewire/resources/views/layouts/app.blade.php
@@ -35,7 +35,7 @@
                             <!-- Navigation Links -->
                             <div class="hidden space-x-8 sm:-my-px sm:ml-10 sm:flex">
                                 <x-jet-nav-link href="/dashboard" :active="request()->routeIs('dashboard')">
-                                    Dashboard
+                                    {{ __('Dashboard') }}
                                 </x-jet-nav-link>
                             </div>
                         </div>
@@ -52,16 +52,16 @@
                                 <x-slot name="content">
                                     <!-- Account Management -->
                                     <div class="block px-4 py-2 text-xs text-gray-400">
-                                        Manage Account
+                                        {{ __('Manage Account') }}
                                     </div>
 
                                     <x-jet-dropdown-link href="/user/profile">
-                                        Profile
+                                        {{ __('Profile') }}
                                     </x-jet-dropdown-link>
 
                                     @if (Laravel\Jetstream\Jetstream::hasApiFeatures())
                                         <x-jet-dropdown-link href="/user/api-tokens">
-                                            API Tokens
+                                            {{ __('API Tokens') }}
                                         </x-jet-dropdown-link>
                                     @endif
 
@@ -70,17 +70,17 @@
                                     <!-- Team Management -->
                                     @if (Laravel\Jetstream\Jetstream::hasTeamFeatures())
                                         <div class="block px-4 py-2 text-xs text-gray-400">
-                                            Manage Team
+                                            {{ __('Manage Team') }}
                                         </div>
 
                                         <!-- Team Settings -->
                                         <x-jet-dropdown-link href="/teams/{{ Auth::user()->currentTeam->id }}">
-                                            Team Settings
+                                            {{ __('Team Settings') }}
                                         </x-jet-dropdown-link>
 
                                         @can('create', Laravel\Jetstream\Jetstream::newTeamModel())
                                             <x-jet-dropdown-link href="/teams/create">
-                                                Create New Team
+                                                {{ __('Create New Team') }}
                                             </x-jet-dropdown-link>
                                         @endcan
 
@@ -88,7 +88,7 @@
 
                                         <!-- Team Switcher -->
                                         <div class="block px-4 py-2 text-xs text-gray-400">
-                                            Switch Teams
+                                            {{ __('Switch Teams') }}
                                         </div>
 
                                         @foreach (Auth::user()->allTeams() as $team)
@@ -105,7 +105,7 @@
                                         <x-jet-dropdown-link href="{{ route('logout') }}"
                                                             onclick="event.preventDefault();
                                                                      this.closest('form').submit();">
-                                            Logout
+                                            {{ __('Logout') }}
                                         </x-jet-dropdown-link>
                                     </form>
                                 </x-slot>
@@ -128,7 +128,7 @@
                 <div :class="{'block': open, 'hidden': ! open}" class="hidden sm:hidden">
                     <div class="pt-2 pb-3 space-y-1">
                         <x-jet-responsive-nav-link href="/dashboard" :active="request()->routeIs('dashboard')">
-                            Dashboard
+                            {{ __('Dashboard') }}
                         </x-jet-responsive-nav-link>
                     </div>
 
@@ -148,12 +148,12 @@
                         <div class="mt-3 space-y-1">
                             <!-- Account Management -->
                             <x-jet-responsive-nav-link href="/user/profile" :active="request()->routeIs('profile.show')">
-                                Profile
+                                {{ __('Profile') }}
                             </x-jet-responsive-nav-link>
 
                             @if (Laravel\Jetstream\Jetstream::hasApiFeatures())
                                 <x-jet-responsive-nav-link href="/user/api-tokens" :active="request()->routeIs('api-tokens.index')">
-                                    API Tokens
+                                    {{ __('API Tokens') }}
                                 </x-jet-responsive-nav-link>
                             @endif
 
@@ -164,7 +164,7 @@
                                 <x-jet-responsive-nav-link href="{{ route('logout') }}"
                                                 onclick="event.preventDefault();
                                                          this.closest('form').submit();">
-                                    Logout
+                                    {{ __('Logout') }}
                                 </x-jet-responsive-nav-link>
                             </form>
 
@@ -173,23 +173,23 @@
                                 <div class="border-t border-gray-200"></div>
 
                                 <div class="block px-4 py-2 text-xs text-gray-400">
-                                    Manage Team
+                                    {{ __('Manage Team') }}
                                 </div>
 
                                 <!-- Team Settings -->
                                 <x-jet-responsive-nav-link href="/teams/{{ Auth::user()->currentTeam->id }}" :active="request()->routeIs('teams.show')">
-                                    Team Settings
+                                    {{ __('Team Settings') }}
                                 </x-jet-responsive-nav-link>
 
                                 <x-jet-responsive-nav-link href="/teams/create" :active="request()->routeIs('teams.create')">
-                                    Create New Team
+                                    {{ __('Create New Team') }}
                                 </x-jet-responsive-nav-link>
 
                                 <div class="border-t border-gray-200"></div>
 
                                 <!-- Team Switcher -->
                                 <div class="block px-4 py-2 text-xs text-gray-400">
-                                    Switch Teams
+                                    {{ __('Switch Teams') }}
                                 </div>
 
                                 @foreach (Auth::user()->allTeams() as $team)

--- a/stubs/livewire/resources/views/profile/delete-user-form.blade.php
+++ b/stubs/livewire/resources/views/profile/delete-user-form.blade.php
@@ -1,31 +1,31 @@
 <x-jet-action-section>
     <x-slot name="title">
-        Delete Account
+        {{ __('Delete Account') }}
     </x-slot>
 
     <x-slot name="description">
-        Permanently delete your account.
+        {{ __('Permanently delete your account.') }}
     </x-slot>
 
     <x-slot name="content">
         <div class="max-w-xl text-sm text-gray-600">
-            Once your account is deleted, all of its resources and data will be permanently deleted. Before deleting your account, please download any data or information that you wish to retain.
+            {{ __('Once your account is deleted, all of its resources and data will be permanently deleted. Before deleting your account, please download any data or information that you wish to retain.') }}
         </div>
 
         <div class="mt-5">
             <x-jet-danger-button wire:click="confirmUserDeletion" wire:loading.attr="disabled">
-                Delete Account
+                {{ __('Delete Account') }}
             </x-jet-danger-button>
         </div>
 
         <!-- Delete User Confirmation Modal -->
         <x-jet-dialog-modal wire:model="confirmingUserDeletion">
             <x-slot name="title">
-                Delete Account
+                {{ __('Delete Account') }}
             </x-slot>
 
             <x-slot name="content">
-                Are you sure you want to delete your account? Once your account is deleted, all of its resources and data will be permanently deleted. Please enter your password to confirm you would like to permanently delete your account.
+                {{ __('Are you sure you want to delete your account? Once your account is deleted, all of its resources and data will be permanently deleted. Please enter your password to confirm you would like to permanently delete your account.') }}
 
                 <div class="mt-4" x-data="{}" x-on:confirming-delete-user.window="setTimeout(() => $refs.password.focus(), 250)">
                     <x-jet-input type="password" class="mt-1 block w-3/4" placeholder="Password"
@@ -39,11 +39,11 @@
 
             <x-slot name="footer">
                 <x-jet-secondary-button wire:click="$toggle('confirmingUserDeletion')" wire:loading.attr="disabled">
-                    Nevermind
+                    {{ __('Nevermind') }}
                 </x-jet-secondary-button>
 
                 <x-jet-danger-button class="ml-2" wire:click="deleteUser" wire:loading.attr="disabled">
-                    Delete Account
+                    {{ __('Delete Account') }}
                 </x-jet-danger-button>
             </x-slot>
         </x-jet-dialog-modal>

--- a/stubs/livewire/resources/views/profile/logout-other-browser-sessions-form.blade.php
+++ b/stubs/livewire/resources/views/profile/logout-other-browser-sessions-form.blade.php
@@ -1,15 +1,15 @@
 <x-jet-action-section>
     <x-slot name="title">
-        Browser Sessions
+        {{ __('Browser Sessions') }}
     </x-slot>
 
     <x-slot name="description">
-        Manage and logout your active sessions on other browsers and devices.
+        {{ __('Manage and logout your active sessions on other browsers and devices.') }}
     </x-slot>
 
     <x-slot name="content">
         <div class="max-w-xl text-sm text-gray-600">
-            If necessary, you may logout of all of your other browser sessions across all of your devices. If you feel your account has been compromised, you should also update your password.
+            {{ __('If necessary, you may logout of all of your other browser sessions across all of your devices. If you feel your account has been compromised, you should also update your password.') }}
         </div>
 
         @if (count($this->sessions) > 0)
@@ -39,9 +39,9 @@
                                     {{ $session->ip_address }},
 
                                     @if ($session->is_current_device)
-                                        <span class="text-green-500 font-semibold">This device</span>
+                                        <span class="text-green-500 font-semibold">{{ __('This device') }}</span>
                                     @else
-                                        Last active {{ $session->last_active }}
+                                        {{ __('Last active') }} {{ $session->last_active }}
                                     @endif
                                 </div>
                             </div>
@@ -53,22 +53,22 @@
 
         <div class="flex items-center mt-5">
             <x-jet-button wire:click="confirmLogout" wire:loading.attr="disabled">
-                Logout Other Browser Sessions
+                {{ __('Logout Other Browser Sessions') }}
             </x-jet-button>
 
             <x-jet-action-message class="ml-3" on="loggedOut">
-                Done.
+                {{ __('Done.') }}
             </x-jet-action-message>
         </div>
 
         <!-- Logout Other Devices Confirmation Modal -->
         <x-jet-dialog-modal wire:model="confirmingLogout">
             <x-slot name="title">
-                Logout Other Browser Sessions
+                {{ __('Logout Other Browser Sessions') }}
             </x-slot>
 
             <x-slot name="content">
-                Please enter your password to confirm you would like to logout of your other browser sessions across all of your devices.
+                {{ __('Please enter your password to confirm you would like to logout of your other browser sessions across all of your devices.') }}
 
                 <div class="mt-4" x-data="{}" x-on:confirming-logout-other-browser-sessions.window="setTimeout(() => $refs.password.focus(), 250)">
                     <x-jet-input type="password" class="mt-1 block w-3/4" placeholder="Password"
@@ -82,11 +82,11 @@
 
             <x-slot name="footer">
                 <x-jet-secondary-button wire:click="$toggle('confirmingLogout')" wire:loading.attr="disabled">
-                    Nevermind
+                    {{ __('Nevermind') }}
                 </x-jet-secondary-button>
 
                 <x-jet-button class="ml-2" wire:click="logoutOtherBrowserSessions" wire:loading.attr="disabled">
-                    Logout Other Browser Sessions
+                    {{ __('Logout Other Browser Sessions') }}
                 </x-jet-button>
             </x-slot>
         </x-jet-dialog-modal>

--- a/stubs/livewire/resources/views/profile/show.blade.php
+++ b/stubs/livewire/resources/views/profile/show.blade.php
@@ -1,7 +1,7 @@
 <x-app-layout>
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            Profile
+            {{ __('Profile') }}
         </h2>
     </x-slot>
 

--- a/stubs/livewire/resources/views/profile/two-factor-authentication-form.blade.php
+++ b/stubs/livewire/resources/views/profile/two-factor-authentication-form.blade.php
@@ -1,24 +1,24 @@
 <x-jet-action-section>
     <x-slot name="title">
-        Two Factor Authentication
+        {{ __('Two Factor Authentication') }}
     </x-slot>
 
     <x-slot name="description">
-        Add additional security to your account using two factor authentication.
+        {{ __('Add additional security to your account using two factor authentication.') }}
     </x-slot>
 
     <x-slot name="content">
         <h3 class="text-lg font-medium text-gray-900">
             @if ($this->enabled)
-                You have enabled two factor authentication.
+                {{ __('You have enabled two factor authentication.') }}
             @else
-                You have not enabled two factor authentication.
+                {{ __('You have not enabled two factor authentication.') }}
             @endif
         </h3>
 
         <div class="mt-3 max-w-xl text-sm text-gray-600">
             <p>
-                When two factor authentication is enabled, you will be prompted for a secure, random token during authentication. You may retrieve this token from your phone's Google Authenticator application.
+                {{ __('When two factor authentication is enabled, you will be prompted for a secure, random token during authentication. You may retrieve this token from your phone\'s Google Authenticator application.') }}
             </p>
         </div>
 
@@ -26,7 +26,7 @@
             @if ($showingQrCode)
                 <div class="mt-4 max-w-xl text-sm text-gray-600">
                     <p class="font-semibold">
-                        Two factor authentication is now enabled. Scan the following QR code using your phone's authenticator application.
+                        {{ __('Two factor authentication is now enabled. Scan the following QR code using your phone\'s authenticator application.') }}
                     </p>
                 </div>
 
@@ -38,7 +38,7 @@
             @if ($showingRecoveryCodes)
                 <div class="mt-4 max-w-xl text-sm text-gray-600">
                     <p class="font-semibold">
-                        Store these recovery codes in a secure password manager. They can be used to recover access to your account if your two factor authentication device is lost.
+                        {{ __('Store these recovery codes in a secure password manager. They can be used to recover access to your account if your two factor authentication device is lost.') }}
                     </p>
                 </div>
 
@@ -53,21 +53,21 @@
         <div class="mt-5">
             @if (! $this->enabled)
                 <x-jet-button type="button" wire:click="enableTwoFactorAuthentication" wire:loading.attr="disabled">
-                    Enable
+                    {{ __('Enable') }}
                 </x-jet-button>
             @else
                 @if ($showingRecoveryCodes)
                     <x-jet-secondary-button class="mr-3" wire:click="regenerateRecoveryCodes">
-                        Regenerate Recovery Codes
+                        {{ __('Regenerate Recovery Codes') }}
                     </x-jet-secondary-button>
                 @else
                     <x-jet-secondary-button class="mr-3" wire:click="$toggle('showingRecoveryCodes')">
-                        Show Recovery Codes
+                        {{ __('Show Recovery Codes') }}
                     </x-jet-secondary-button>
                 @endif
 
                 <x-jet-danger-button wire:click="disableTwoFactorAuthentication" wire:loading.attr="disabled">
-                    Disable
+                    {{ __('Disable') }}
                 </x-jet-danger-button>
             @endif
         </div>

--- a/stubs/livewire/resources/views/profile/update-password-form.blade.php
+++ b/stubs/livewire/resources/views/profile/update-password-form.blade.php
@@ -1,10 +1,10 @@
 <x-jet-form-section submit="updatePassword">
     <x-slot name="title">
-        Update Password
+        {{ __('Update Password') }}
     </x-slot>
 
     <x-slot name="description">
-        Ensure your account is using a long, random password to stay secure.
+        {{ __('Ensure your account is using a long, random password to stay secure.') }}
     </x-slot>
 
     <x-slot name="form">
@@ -29,11 +29,11 @@
 
     <x-slot name="actions">
         <x-jet-action-message class="mr-3" on="saved">
-            Saved.
+            {{ __('Saved.') }}
         </x-jet-action-message>
 
         <x-jet-button>
-            Save
+            {{ __('Save') }}
         </x-jet-button>
     </x-slot>
 </x-jet-form-section>

--- a/stubs/livewire/resources/views/profile/update-profile-information-form.blade.php
+++ b/stubs/livewire/resources/views/profile/update-profile-information-form.blade.php
@@ -1,10 +1,10 @@
 <x-jet-form-section submit="updateProfileInformation">
     <x-slot name="title">
-        Profile Information
+        {{ __('Profile Information') }}
     </x-slot>
 
     <x-slot name="description">
-        Update your account's profile information and email address.
+        {{ __('Update your account\'s profile information and email address.') }}
     </x-slot>
 
     <x-slot name="form">
@@ -39,7 +39,7 @@
                 </div>
 
                 <x-jet-secondary-button class="mt-2" type="button" x-on:click.prevent="$refs.photo.click()">
-                    Select A New Photo
+                    {{ __('Select A New Photo') }}
                 </x-jet-secondary-button>
 
                 <x-jet-input-error for="photo" class="mt-2" />
@@ -63,11 +63,11 @@
 
     <x-slot name="actions">
         <x-jet-action-message class="mr-3" on="saved">
-            Saved.
+            {{ __('Saved.') }}
         </x-jet-action-message>
 
         <x-jet-button>
-            Save
+            {{ __('Save') }}
         </x-jet-button>
     </x-slot>
 </x-jet-form-section>

--- a/stubs/livewire/resources/views/teams/create-team-form.blade.php
+++ b/stubs/livewire/resources/views/teams/create-team-form.blade.php
@@ -1,10 +1,10 @@
 <x-jet-form-section submit="createTeam">
     <x-slot name="title">
-        Team Details
+        {{ __('Team Details') }}
     </x-slot>
 
     <x-slot name="description">
-        Create a new team to collaborate with others on projects.
+        {{ __('Create a new team to collaborate with others on projects.') }}
     </x-slot>
 
     <x-slot name="form">
@@ -30,7 +30,7 @@
 
     <x-slot name="actions">
         <x-jet-button>
-            Create
+            {{ __('Create') }}
         </x-jet-button>
     </x-slot>
 </x-jet-form-section>

--- a/stubs/livewire/resources/views/teams/create.blade.php
+++ b/stubs/livewire/resources/views/teams/create.blade.php
@@ -1,7 +1,7 @@
 <x-app-layout>
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            Create Team
+            {{ __('Create Team') }}
         </h2>
     </x-slot>
 

--- a/stubs/livewire/resources/views/teams/delete-team-form.blade.php
+++ b/stubs/livewire/resources/views/teams/delete-team-form.blade.php
@@ -1,40 +1,40 @@
 <x-jet-action-section>
     <x-slot name="title">
-        Delete Team
+        {{ __('Delete Team') }}
     </x-slot>
 
     <x-slot name="description">
-        Permanently delete this team.
+        {{ __('Permanently delete this team.') }}
     </x-slot>
 
     <x-slot name="content">
         <div class="max-w-xl text-sm text-gray-600">
-            Once a team is deleted, all of its resources and data will be permanently deleted. Before deleting this team, please download any data or information regarding this team that you wish to retain.
+            {{ __('Once a team is deleted, all of its resources and data will be permanently deleted. Before deleting this team, please download any data or information regarding this team that you wish to retain.') }}
         </div>
 
         <div class="mt-5">
             <x-jet-danger-button wire:click="$toggle('confirmingTeamDeletion')" wire:loading.attr="disabled">
-                Delete Team
+                {{ __('Delete Team') }}
             </x-jet-danger-button>
         </div>
 
         <!-- Delete Team Confirmation Modal -->
         <x-jet-confirmation-modal wire:model="confirmingTeamDeletion">
             <x-slot name="title">
-                Delete Team
+                {{ __('Delete Team') }}
             </x-slot>
 
             <x-slot name="content">
-                Are you sure you want to delete this team? Once a team is deleted, all of its resources and data will be permanently deleted.
+                {{ __('Are you sure you want to delete this team? Once a team is deleted, all of its resources and data will be permanently deleted.') }}
             </x-slot>
 
             <x-slot name="footer">
                 <x-jet-secondary-button wire:click="$toggle('confirmingTeamDeletion')" wire:loading.attr="disabled">
-                    Nevermind
+                    {{ __('Nevermind') }}
                 </x-jet-secondary-button>
 
                 <x-jet-danger-button class="ml-2" wire:click="deleteTeam" wire:loading.attr="disabled">
-                    Delete Team
+                    {{ __('Delete Team') }}
                 </x-jet-danger-button>
             </x-slot>
         </x-jet-confirmation-modal>

--- a/stubs/livewire/resources/views/teams/show.blade.php
+++ b/stubs/livewire/resources/views/teams/show.blade.php
@@ -1,7 +1,7 @@
 <x-app-layout>
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            Team Settings
+            {{ __('Team Settings') }}
         </h2>
     </x-slot>
 

--- a/stubs/livewire/resources/views/teams/team-member-manager.blade.php
+++ b/stubs/livewire/resources/views/teams/team-member-manager.blade.php
@@ -6,17 +6,17 @@
         <div class="mt-10 sm:mt-0">
             <x-jet-form-section submit="addTeamMember">
                 <x-slot name="title">
-                    Add Team Member
+                    {{ __('Add Team Member') }}
                 </x-slot>
 
                 <x-slot name="description">
-                    Add a new team member to your team, allowing them to collaborate with you.
+                    {{ __('Add a new team member to your team, allowing them to collaborate with you.') }}
                 </x-slot>
 
                 <x-slot name="form">
                     <div class="col-span-6">
                         <div class="max-w-xl text-sm text-gray-600">
-                            Please provide the email address of the person you would like to add to this team. The email address must be associated with an existing account.
+                            {{ __('Please provide the email address of the person you would like to add to this team. The email address must be associated with an existing account.' }}
                         </div>
                     </div>
 
@@ -63,11 +63,11 @@
 
                 <x-slot name="actions">
                     <x-jet-action-message class="mr-3" on="saved">
-                        Added.
+                        {{ __('Added.') }}
                     </x-jet-action-message>
 
                     <x-jet-button>
-                        Add
+                        {{ __('Add') }}
                     </x-jet-button>
                 </x-slot>
             </x-jet-form-section>
@@ -81,11 +81,11 @@
         <div class="mt-10 sm:mt-0">
             <x-jet-action-section>
                 <x-slot name="title">
-                    Team Members
+                    {{ __('Team Members') }}
                 </x-slot>
 
                 <x-slot name="description">
-                    All of the people that are part of this team.
+                    {{ __('All of the people that are part of this team.') }}
                 </x-slot>
 
                 <!-- Team Member List -->
@@ -113,13 +113,13 @@
                                     <!-- Leave Team -->
                                     @if ($this->user->id === $user->id)
                                         <button class="cursor-pointer ml-6 text-sm text-red-500 focus:outline-none" wire:click="$toggle('confirmingLeavingTeam')">
-                                            Leave
+                                            {{ __('Leave') }}
                                         </button>
 
                                     <!-- Remove Team Member -->
                                     @elseif (Gate::check('removeTeamMember', $team))
                                         <button class="cursor-pointer ml-6 text-sm text-red-500 focus:outline-none" wire:click="confirmTeamMemberRemoval('{{ $user->id }}')">
-                                            Remove
+                                            {{ __('Remove') }}
                                         </button>
                                     @endif
                                 </div>
@@ -134,7 +134,7 @@
     <!-- Role Management Modal -->
     <x-jet-dialog-modal wire:model="currentlyManagingRole">
         <x-slot name="title">
-            Manage Role
+            {{ __('Manage Role') }}
         </x-slot>
 
         <x-slot name="content">
@@ -166,11 +166,11 @@
 
         <x-slot name="footer">
             <x-jet-secondary-button wire:click="stopManagingRole" wire:loading.attr="disabled">
-                Nevermind
+                {{ __('Nevermind') }}
             </x-jet-secondary-button>
 
             <x-jet-button class="ml-2" wire:click="updateRole" wire:loading.attr="disabled">
-                Save
+                {{ __('Save') }}
             </x-jet-button>
         </x-slot>
     </x-jet-dialog-modal>
@@ -178,20 +178,20 @@
     <!-- Leave Team Confirmation Modal -->
     <x-jet-confirmation-modal wire:model="confirmingLeavingTeam">
         <x-slot name="title">
-            Leave Team
+            {{ __('Leave Team') }}
         </x-slot>
 
         <x-slot name="content">
-            Are you sure you would like to leave this team?
+            {{ __('Are you sure you would like to leave this team?') }}
         </x-slot>
 
         <x-slot name="footer">
             <x-jet-secondary-button wire:click="$toggle('confirmingLeavingTeam')" wire:loading.attr="disabled">
-                Nevermind
+                {{ __('Nevermind') }}
             </x-jet-secondary-button>
 
             <x-jet-danger-button class="ml-2" wire:click="leaveTeam" wire:loading.attr="disabled">
-                Leave
+                {{ __('Leave') }}
             </x-jet-danger-button>
         </x-slot>
     </x-jet-confirmation-modal>
@@ -199,20 +199,20 @@
     <!-- Remove Team Member Confirmation Modal -->
     <x-jet-confirmation-modal wire:model="confirmingTeamMemberRemoval">
         <x-slot name="title">
-            Remove Team Member
+            {{ __('Remove Team Member') }}
         </x-slot>
 
         <x-slot name="content">
-            Are you sure you would like to remove this person from the team?
+            {{ __('Are you sure you would like to remove this person from the team?') }}
         </x-slot>
 
         <x-slot name="footer">
             <x-jet-secondary-button wire:click="$toggle('confirmingTeamMemberRemoval')" wire:loading.attr="disabled">
-                Nevermind
+                {{ __('Nevermind') }}
             </x-jet-secondary-button>
 
             <x-jet-danger-button class="ml-2" wire:click="removeTeamMember" wire:loading.attr="disabled">
-                Remove
+                {{ __('Remove') }}
             </x-jet-danger-button>
         </x-slot>
     </x-jet-confirmation-modal>

--- a/stubs/livewire/resources/views/teams/update-team-name-form.blade.php
+++ b/stubs/livewire/resources/views/teams/update-team-name-form.blade.php
@@ -1,10 +1,10 @@
 <x-jet-form-section submit="updateTeamName">
     <x-slot name="title">
-        Team Name
+        {{ __('Team Name') }}
     </x-slot>
 
     <x-slot name="description">
-        The team's name and owner information.
+        {{ __('The team\'s name and owner information.') }}
     </x-slot>
 
     <x-slot name="form">
@@ -39,11 +39,11 @@
     @if (Gate::check('update', $team))
         <x-slot name="actions">
             <x-jet-action-message class="mr-3" on="saved">
-                Saved.
+                {{ __('Saved.') }}
             </x-jet-action-message>
 
             <x-jet-button>
-                Save
+                {{ __('Save') }}
             </x-jet-button>
         </x-slot>
     @endif


### PR DESCRIPTION
The pull request is to add to the livewire configuration the option that labels have multi-language capacity, in order to facilitate internationalization with applications that are developed in other countries.

Example
**Before**
Permanently delete your account.

**After**
{{ __('Permanently delete your account.') }}