### PR TITLE
Add delete photo button

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Jetstream::role('editor', 'Editor', [
 <a name="team-authorization"></a>
 ### Authorization
 
-A user's team permissions may be determine using the `hasTeamPermission` method available via the `Laravel\Jetstream\HasTeams` trait:
+A user's team permissions may be determined using the `hasTeamPermission` method available via the `Laravel\Jetstream\HasTeams` trait:
 
 ```php
 if ($request->user()->hasTeamPermission($team, 'read')) {

--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,14 @@
         "ext-json": "*",
         "illuminate/support": "^8.0",
         "jenssegers/agent": "^2.6",
-        "laravel/fortify": "^0.0.1"
+        "laravel/fortify": "^1.0"
     },
     "require-dev": {
         "inertiajs/inertia-laravel": "^0.2.4",
         "laravel/sanctum": "^2.6",
         "mockery/mockery": "^1.0",
         "orchestra/testbench": "^6.0",
-        "phpunit/phpunit": "^8.0"
+        "phpunit/phpunit": "^9.3"
     },
     "autoload": {
         "psr-4": {

--- a/routes/inertia.php
+++ b/routes/inertia.php
@@ -21,6 +21,9 @@ Route::group(['middleware' => config('jetstream.middleware', ['web'])], function
 
         Route::delete('/user', [CurrentUserController::class, 'destroy'])
                     ->name('current-user.destroy');
+        
+        Route::delete('/user/profile-photo', [CurrentUserController::class, 'deleteProfilePhoto'])
+                    ->name('current-user-photo.destroy');
 
         // API...
         if (Jetstream::hasApiFeatures()) {

--- a/src/HasProfilePhoto.php
+++ b/src/HasProfilePhoto.php
@@ -27,6 +27,20 @@ trait HasProfilePhoto
             }
         });
     }
+    
+    /**
+     * Delete the user's profile photo.
+     *
+     * @return void
+     */
+    public function deleteProfilePhoto()
+    {
+        Storage::disk($this->profilePhotoDisk())->delete($this->profile_photo_path);
+
+        $this->forceFill([
+            'profile_photo_path' => null,
+        ])->save();
+    }
 
     /**
      * Get the URL to the user's profile photo.

--- a/src/Http/Controllers/Inertia/CurrentUserController.php
+++ b/src/Http/Controllers/Inertia/CurrentUserController.php
@@ -21,7 +21,7 @@ class CurrentUserController extends Controller
     {
         $request->user()->deleteProfilePhoto();
 
-        return response('', 200)->header('X-Inertia-Location', url('/user/profile'));
+        return back()->with('status', 'profile-photo-deleted');
     }
     
     /**

--- a/src/Http/Controllers/Inertia/CurrentUserController.php
+++ b/src/Http/Controllers/Inertia/CurrentUserController.php
@@ -12,6 +12,19 @@ use Laravel\Jetstream\Contracts\DeletesUsers;
 class CurrentUserController extends Controller
 {
     /**
+     * Delete the current user profile photo.
+     *
+     * @param Request $request
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function deleteProfilePhoto(Request $request)
+    {
+        $request->user()->deleteProfilePhoto();
+
+        return response('', 200)->header('X-Inertia-Location', url('/user/profile'));
+    }
+    
+    /**
      * Delete the current user.
      *
      * @param  \Illuminate\Http\Request  $request

--- a/src/Http/Livewire/UpdateProfileInformationForm.php
+++ b/src/Http/Livewire/UpdateProfileInformationForm.php
@@ -58,6 +58,20 @@ class UpdateProfileInformationForm extends Component
 
         $this->emit('saved');
     }
+    
+    /**
+     * Delete user's profile photo.
+     *
+     * @param \Laravel\Fortify\Contracts\UpdatesUserProfileInformation $updater
+     *
+     * @return void
+     */
+    public function deleteProfilePhoto(UpdatesUserProfileInformation $updater)
+    {
+        Auth::user()->deleteProfilePhoto();
+
+        return redirect()->route('profile.show');
+    }
 
     /**
      * Get the current user of the application.

--- a/src/JetstreamServiceProvider.php
+++ b/src/JetstreamServiceProvider.php
@@ -153,7 +153,7 @@ class JetstreamServiceProvider extends ServiceProvider
         ], 'jetstream-team-migrations');
 
         $this->publishes([
-            __DIR__.'/../routes/'.config('jetstream.stack').'.php' => base_path('routes/jetstream'),
+            __DIR__.'/../routes/'.config('jetstream.stack').'.php' => base_path('routes/jetstream.php'),
         ], 'jetstream-routes');
     }
 

--- a/src/JetstreamServiceProvider.php
+++ b/src/JetstreamServiceProvider.php
@@ -153,7 +153,7 @@ class JetstreamServiceProvider extends ServiceProvider
         ], 'jetstream-team-migrations');
 
         $this->publishes([
-            __DIR__.'/../routes/'.config('jetstream.stack').'.php' => base_path('routes/jetstream.php'),
+            __DIR__.'/../routes/'.config('jetstream.stack').'.php' => base_path('routes/jetstream'),
         ], 'jetstream-routes');
     }
 

--- a/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
@@ -108,12 +108,10 @@
 
         methods: {
             deleteProfilePhoto() {
-                var form = this.$inertia.form({
-                    '_method': 'DELETE',
-                });
-
-                form.post('/user/profile-photo', {
-                    preserveScroll: true
+                this.$inertia.delete('/user/profile-photo', {
+                    preserveScroll: true,
+                }).then(() => {
+                    this.photoPreview = null
                 });
             },
             

--- a/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
@@ -33,6 +33,10 @@
                 <jet-secondary-button class="mt-2" type="button" @click.native.prevent="selectNewPhoto">
                     Select A New Photo
                 </jet-secondary-button>
+                
+                <jet-button type="button" v-if="$page.user.profile_photo_path">
+                    Delete Photo
+                </jet-button>
 
                 <jet-input-error :message="form.error('photo')" class="mt-2" />
             </div>

--- a/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
@@ -34,7 +34,7 @@
                     Select A New Photo
                 </jet-secondary-button>
                 
-                <jet-button type="button" v-if="$page.user.profile_photo_path">
+                <jet-button type="button" @click.native.prevent="deleteProfilePhoto" v-if="$page.user.profile_photo_path">
                     Delete Photo
                 </jet-button>
 
@@ -107,6 +107,16 @@
         },
 
         methods: {
+            deleteProfilePhoto() {
+                var form = this.$inertia.form({
+                    '_method': 'DELETE',
+                });
+
+                form.post('/user/profile-photo', {
+                    preserveScroll: true
+                });
+            },
+            
             updateProfileInformation() {
                 if (this.$refs.photo) {
                     this.form.photo = this.$refs.photo.files[0]

--- a/stubs/livewire/resources/views/profile/update-profile-information-form.blade.php
+++ b/stubs/livewire/resources/views/profile/update-profile-information-form.blade.php
@@ -41,6 +41,12 @@
                 <x-jet-secondary-button class="mt-2" type="button" x-on:click.prevent="$refs.photo.click()">
                     Select A New Photo
                 </x-jet-secondary-button>
+                
+                @if($this->user->profile_photo_path)
+                    <x-jet-button type="button" wire:click="deleteProfilePhoto">
+                        Delete Photo
+                    </x-jet-button>
+                @endif
 
                 <x-jet-input-error for="photo" class="mt-2" />
             </div>


### PR DESCRIPTION
Add a button next to "Select a new Photo" that will have the function of delete the current photo and return to the Jetstream default profile photo.

This can be good if an user want to remove your photo temporarily or if the person want to use the default jetstream photo.

A more interesting case would be if the site had been modified the jetstream to use Gravatar and the user want to use he/she Gravatar profile photo.