### PR TITLE
Add alt attribute/value to image tag

### DIFF
--- a/stubs/inertia/resources/js/Layouts/AppLayout.vue
+++ b/stubs/inertia/resources/js/Layouts/AppLayout.vue
@@ -26,7 +26,7 @@
                             <jet-dropdown align="right" width="48">
                                 <template #trigger>
                                     <button class="flex text-sm border-2 border-transparent rounded-full focus:outline-none focus:border-gray-300 transition duration-150 ease-in-out">
-                                        <img class="h-8 w-8 rounded-full" :src="$page.user.profile_photo_url" alt="" />
+                                        <img class="h-8 w-8 rounded-full" :src="$page.user.profile_photo_url" :alt="$page.user.name" />
                                     </button>
                                 </template>
 
@@ -117,7 +117,7 @@
                 <div class="pt-4 pb-1 border-t border-gray-200">
                     <div class="flex items-center px-4">
                         <div class="flex-shrink-0">
-                            <img class="h-10 w-10 rounded-full" :src="$page.user.profile_photo_url" alt="" />
+                            <img class="h-10 w-10 rounded-full" :src="$page.user.profile_photo_url" :alt="$page.user.name" />
                         </div>
 
                         <div class="ml-3">

--- a/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
@@ -20,7 +20,7 @@
 
                 <!-- Current Profile Photo -->
                 <div class="mt-2" v-show="! photoPreview">
-                    <img :src="$page.user.profile_photo_url" class="rounded-full h-20 w-20">
+                    <img :src="$page.user.profile_photo_url" alt="Current Profile Photo" class="rounded-full h-20 w-20">
                 </div>
 
                 <!-- New Profile Photo Preview -->

--- a/stubs/inertia/resources/js/Pages/Teams/CreateTeamForm.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/CreateTeamForm.vue
@@ -13,7 +13,7 @@
                 <jet-label value="Team Owner" />
 
                 <div class="flex items-center mt-2">
-                    <img class="w-12 h-12 rounded-full" :src="$page.user.profile_photo_url">
+                    <img class="w-12 h-12 rounded-full" :src="$page.user.profile_photo_url" :alt="$page.user.name">
 
                     <div class="ml-4 leading-tight">
                         <div>{{ $page.user.name }}</div>

--- a/stubs/inertia/resources/js/Pages/Teams/TeamMemberManager.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/TeamMemberManager.vue
@@ -87,7 +87,7 @@
                     <div class="space-y-6">
                         <div class="flex items-center justify-between" v-for="user in team.users">
                             <div class="flex items-center">
-                                <img class="w-8 h-8 rounded-full" :src="user.profile_photo_url">
+                                <img class="w-8 h-8 rounded-full" :src="user.profile_photo_url" :alt="user.name">
                                 <div class="ml-4">{{ user.name }}</div>
                             </div>
 

--- a/stubs/inertia/resources/js/Pages/Teams/UpdateTeamNameForm.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/UpdateTeamNameForm.vue
@@ -14,7 +14,7 @@
                 <jet-label value="Team Owner" />
 
                 <div class="flex items-center mt-2">
-                    <img class="w-12 h-12 rounded-full" :src="team.owner.profile_photo_url">
+                    <img class="w-12 h-12 rounded-full" :src="team.owner.profile_photo_url" :alt="team.owner.name">
 
                     <div class="ml-4 leading-tight">
                         <div>{{ team.owner.name }}</div>

--- a/stubs/livewire/resources/views/layouts/app.blade.php
+++ b/stubs/livewire/resources/views/layouts/app.blade.php
@@ -45,7 +45,7 @@
                             <x-jet-dropdown align="right" width="48">
                                 <x-slot name="trigger">
                                     <button class="flex text-sm border-2 border-transparent rounded-full focus:outline-none focus:border-gray-300 transition duration-150 ease-in-out">
-                                        <img class="h-8 w-8 rounded-full" src="{{ Auth::user()->profile_photo_url }}" alt="" />
+                                        <img class="h-8 w-8 rounded-full" src="{{ Auth::user()->profile_photo_url }}" alt="{{ Auth::user()->name }}" />
                                     </button>
                                 </x-slot>
 
@@ -136,7 +136,7 @@
                     <div class="pt-4 pb-1 border-t border-gray-200">
                         <div class="flex items-center px-4">
                             <div class="flex-shrink-0">
-                                <img class="h-10 w-10 rounded-full" src="{{ Auth::user()->profile_photo_url }}" alt="" />
+                                <img class="h-10 w-10 rounded-full" src="{{ Auth::user()->profile_photo_url }}" alt="{{ Auth::user()->name }}" />
                             </div>
 
                             <div class="ml-3">

--- a/stubs/livewire/resources/views/profile/update-profile-information-form.blade.php
+++ b/stubs/livewire/resources/views/profile/update-profile-information-form.blade.php
@@ -28,7 +28,7 @@
 
                 <!-- Current Profile Photo -->
                 <div class="mt-2" x-show="! photoPreview">
-                    <img src="{{ $this->user->profile_photo_url }}" class="rounded-full h-20 w-20">
+                    <img src="{{ $this->user->profile_photo_url }}" alt="{{ $this->user->name }}" class="rounded-full h-20 w-20">
                 </div>
 
                 <!-- New Profile Photo Preview -->

--- a/stubs/livewire/resources/views/teams/create-team-form.blade.php
+++ b/stubs/livewire/resources/views/teams/create-team-form.blade.php
@@ -12,7 +12,7 @@
             <x-jet-label value="Team Owner" />
 
             <div class="flex items-center mt-2">
-                <img class="w-12 h-12 rounded-full" src="{{ $this->user->profile_photo_url }}">
+                <img class="w-12 h-12 rounded-full" src="{{ $this->user->profile_photo_url }}" alt="{{ $this->user->name }}">
 
                 <div class="ml-4 leading-tight">
                     <div>{{ $this->user->name }}</div>

--- a/stubs/livewire/resources/views/teams/team-member-manager.blade.php
+++ b/stubs/livewire/resources/views/teams/team-member-manager.blade.php
@@ -94,7 +94,7 @@
                         @foreach ($team->users->sortBy('name') as $user)
                             <div class="flex items-center justify-between">
                                 <div class="flex items-center">
-                                    <img class="w-8 h-8 rounded-full" src="{{ $user->profile_photo_url }}">
+                                    <img class="w-8 h-8 rounded-full" src="{{ $user->profile_photo_url }}" alt="{{ $user->name }}">
                                     <div class="ml-4">{{ $user->name }}</div>
                                 </div>
 

--- a/stubs/livewire/resources/views/teams/update-team-name-form.blade.php
+++ b/stubs/livewire/resources/views/teams/update-team-name-form.blade.php
@@ -13,7 +13,7 @@
             <x-jet-label value="Team Owner" />
 
             <div class="flex items-center mt-2">
-                <img class="w-12 h-12 rounded-full" src="{{ $team->owner->profile_photo_url }}">
+                <img class="w-12 h-12 rounded-full" src="{{ $team->owner->profile_photo_url }}" alt="{{ $team->owner->name }}">
 
                 <div class="ml-4 leading-tight">
                     <div>{{ $team->owner->name }}</div>


### PR DESCRIPTION
## What
Added the user's name to every image alt attribute.

## Why
You cannot navigate to profile through the UI anymore if the image becomes broken, it simply disappears. As well as alt tags should be set.

## Questions
Its currently just the users name property, should we add `USERNAME's Profile Picture` to make it more descriptive for a11y? Or since the image is actually used to navigate to the profile maybe even `Open Dropdown`?



![image](https://user-images.githubusercontent.com/5164617/92571416-66597e00-f283-11ea-9996-4dcf64f0f638.png)
![image](https://user-images.githubusercontent.com/5164617/92571447-71aca980-f283-11ea-941c-ebd65e0e0cf1.png)
