### PR TITLE
Create missing personalTeam, in cases where Teams feature was enabled later on.

### DIFF
--- a/src/HasTeams.php
+++ b/src/HasTeams.php
@@ -69,6 +69,13 @@ trait HasTeams
      */
     public function personalTeam()
     {
+        if ($this->ownedTeams->isEmpty()) {
+            return $this->ownedTeams()->create([
+                'name' => explode(' ', $this->name, 2)[0]."'s Team",
+                'personal_team' => true,
+            ]);
+        }
+
         return $this->ownedTeams->where('personal_team', true)->first();
     }
 


### PR DESCRIPTION
Hey there,

This error appears if Teams functionality isn't enabled from the get go, but is enabled at a later stage.

When trying to view the dashboard, I get the following error.
`Trying to get property 'id' of non-object (View: /resources/views/layouts/app.blade.php)`

Which appears to be the result of the User not having the default/personalTeam created for them, the following line then appears to trigger this error.
`Auth::user()->currentTeam->id`

I'm sure that there are a ton of different ways around this, this PR aims to resolve it by forcing a default Team to be created (if they don't already have one), anytime personalTeam is called. (currentTeam also calls personalTeam if the User does not have a team)

```
    /**
     * Get the user's "personal" team.
     *
     * @return \App\Team
     */
    public function personalTeam()
    {
        if ($this->ownedTeams->isEmpty()) {
            return $this->ownedTeams()->create([
                'name' => explode(' ', $this->name, 2)[0]."'s Team",
                'personal_team' => true,
            ]);
        }

        return $this->ownedTeams->where('personal_team', true)->first();
    }

```
