### PR TITLE
[1.x] Add delete profile photo button

### DIFF
--- a/routes/inertia.php
+++ b/routes/inertia.php
@@ -22,6 +22,9 @@ Route::group(['middleware' => config('jetstream.middleware', ['web'])], function
         Route::delete('/user', [CurrentUserController::class, 'destroy'])
                     ->name('current-user.destroy');
 
+        Route::delete('/user/profile-photo', [CurrentUserController::class, 'deleteProfilePhoto'])
+                    ->name('current-user-photo.destroy');
+
         // API...
         if (Jetstream::hasApiFeatures()) {
             Route::get('/user/api-tokens', [ApiTokenController::class, 'index'])->name('api-tokens.index');

--- a/src/HasProfilePhoto.php
+++ b/src/HasProfilePhoto.php
@@ -29,6 +29,20 @@ trait HasProfilePhoto
     }
 
     /**
+     * Delete the user's profile photo.
+     *
+     * @return void
+     */
+    public function deleteProfilePhoto()
+    {
+        Storage::disk($this->profilePhotoDisk())->delete($this->profile_photo_path);
+
+        $this->forceFill([
+            'profile_photo_path' => null,
+        ])->save();
+    }
+
+    /**
      * Get the URL to the user's profile photo.
      *
      * @return string

--- a/src/Http/Controllers/Inertia/CurrentUserController.php
+++ b/src/Http/Controllers/Inertia/CurrentUserController.php
@@ -12,6 +12,19 @@ use Laravel\Jetstream\Contracts\DeletesUsers;
 class CurrentUserController extends Controller
 {
     /**
+     * Delete the current user profile photo.
+     *
+     * @param Request $request
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function deleteProfilePhoto(Request $request)
+    {
+        $request->user()->deleteProfilePhoto();
+
+        return back()->with('status', 'profile-photo-deleted');
+    }
+    
+    /**
      * Delete the current user.
      *
      * @param  \Illuminate\Http\Request  $request

--- a/src/Http/Livewire/UpdateProfileInformationForm.php
+++ b/src/Http/Livewire/UpdateProfileInformationForm.php
@@ -60,6 +60,20 @@ class UpdateProfileInformationForm extends Component
     }
 
     /**
+     * Delete user's profile photo.
+     *
+     * @param \Laravel\Fortify\Contracts\UpdatesUserProfileInformation $updater
+     *
+     * @return void
+     */
+    public function deleteProfilePhoto(UpdatesUserProfileInformation $updater)
+    {
+        Auth::user()->deleteProfilePhoto();
+
+        return redirect()->route('profile.show');
+    }
+
+    /**
      * Get the current user of the application.
      *
      * @return mixed

--- a/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
@@ -34,6 +34,10 @@
                     Select A New Photo
                 </jet-secondary-button>
 
+                <jet-button type="button" @click.native.prevent="deleteProfilePhoto" v-if="$page.user.profile_photo_path">
+                    Delete Photo
+                </jet-button>
+
                 <jet-input-error :message="form.error('photo')" class="mt-2" />
             </div>
 
@@ -103,6 +107,14 @@
         },
 
         methods: {
+            deleteProfilePhoto() {
+                this.$inertia.delete('/user/profile-photo', {
+                    preserveScroll: true,
+                }).then(() => {
+                    this.photoPreview = null
+                });
+            },
+            
             updateProfileInformation() {
                 if (this.$refs.photo) {
                     this.form.photo = this.$refs.photo.files[0]

--- a/stubs/livewire/resources/views/profile/update-profile-information-form.blade.php
+++ b/stubs/livewire/resources/views/profile/update-profile-information-form.blade.php
@@ -42,6 +42,12 @@
                     Select A New Photo
                 </x-jet-secondary-button>
 
+                @if($this->user->profile_photo_path)
+                    <x-jet-button type="button" wire:click="deleteProfilePhoto">
+                        Delete Photo
+                    </x-jet-button>
+                @endif
+
                 <x-jet-input-error for="photo" class="mt-2" />
             </div>
         @endif


### PR DESCRIPTION
Add a button next to "Select a new Photo" that will have the function of delete the current photo and return to the Jetstream default profile photo.

This can be good if an user want to remove your photo temporarily or if the person want to use the default jetstream photo.

A more interesting case would be if the site had been modified the jetstream to use Gravatar and the user want to use he/she Gravatar profile photo.