### PR TITLE
Make team menu entry "truncate" (text-overflow)

### DIFF
--- a/resources/views/components/switchable-team.blade.php
+++ b/resources/views/components/switchable-team.blade.php
@@ -13,7 +13,7 @@
                 <svg class="mr-2 h-5 w-5 text-green-400" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" stroke="currentColor" viewBox="0 0 24 24"><path d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
             @endif
 
-            <div>{{ $team->name }}</div>
+            <div class="truncate">{{ $team->name }}</div>
         </div>
     </x-dynamic-component>
 </form>


### PR DESCRIPTION
If you make use of an to long team name the text "overflows" the box.

eg:

![Bildschirmfoto 2020-09-09 um 17 15 53](https://user-images.githubusercontent.com/3373530/92619176-77c17b00-f2c1-11ea-86cb-7f143ec57d79.png)

This PR would fix that by adding "truncate" class to the menu entry:

![Bildschirmfoto 2020-09-09 um 17 26 08](https://user-images.githubusercontent.com/3373530/92619285-99226700-f2c1-11ea-9868-22211ee7fd6e.png)
