### PR TITLE
Use static properties for Team and Membership too

### DIFF
--- a/src/Jetstream.php
+++ b/src/Jetstream.php
@@ -46,6 +46,20 @@ class Jetstream
     public static $userModel = 'App\\Models\\User';
 
     /**
+     * The team model that should be used by Jetstream.
+     *
+     * @var string
+     */
+    public static $teamModel = 'App\\Models\\Team';
+
+    /**
+     * The membership model that should be used by Jetstream.
+     *
+     * @var string
+     */
+    public static $membershipModel = 'App\\Models\\Membership';
+
+    /**
      * Determine if Jetstream has registered roles.
      *
      * @return bool
@@ -227,7 +241,7 @@ class Jetstream
      */
     public static function teamModel()
     {
-        return 'App\\Models\\Team';
+        return static::$teamModel;
     }
 
     /**
@@ -249,7 +263,7 @@ class Jetstream
      */
     public static function membershipModel()
     {
-        return 'App\\Models\\Membership';
+        return static::$membershipModel;
     }
 
     /**


### PR DESCRIPTION
Keeping some parody with the way the User model is managed by the Jetstream service, the Team and Membership models are now treated the same way.

This was inspired by #118 since that made me realize editing models location wouldn't be done in a consistent manner. So if all you wanted to do was point models to a different location you'd be overriding properties and methods. So by exposing all as static properties, now you only would add properties to your extension of Jetstream.

---

# What extending Jetstream to adjust models looks like:

## Before:
```
<?php


namespace App;

use App\SomeOther\Folder\User;

class MyJetstream extends \Laravel\Jetstream\Jetstream
{
    public static $userModel = User::class;

    /**
     * Get the name of the team model used by the application.
     *
     * @return string
     */
    public static function teamModel()
    {
        return 'App\\SomeOther\\Folder\\Team';
    }

    /**
     * Get the name of the team model used by the application.
     *
     * @return string
     */
    public static function membershipModel()
    {
        return 'App\\SomeOther\\Folder\\Membership';
    }
}
```

## After
```
<?php


namespace App;

use App\SomeOther\Folder\User;
use App\SomeOther\Folder\Team;
use App\SomeOther\Folder\Membership;

class MyJetstream extends \Laravel\Jetstream\Jetstream
{
    public static $userModel = User::class;
    public static $teamModel = Team::class;
    public static $membershipModel = Membership::class;
}
```