### PR TITLE
Add useTeamModel and useMembershipModel to compliment useUserModel

### DIFF
--- a/src/Jetstream.php
+++ b/src/Jetstream.php
@@ -257,6 +257,19 @@ class Jetstream
     }
 
     /**
+     * Specify the team model that should be used by Jetstream.
+     *
+     * @param  string  $model
+     * @return static
+     */
+    public static function useTeamModel(string $model)
+    {
+        static::$teamModel = $model;
+
+        return new static;
+    }
+
+    /**
      * Get the name of the team model used by the application.
      *
      * @return string
@@ -264,6 +277,19 @@ class Jetstream
     public static function membershipModel()
     {
         return static::$membershipModel;
+    }
+
+    /**
+     * Specify the membership model that should be used by Jetstream.
+     *
+     * @param  string  $model
+     * @return static
+     */
+    public static function useMembershipModel(string $model)
+    {
+        static::$membershipModel = $model;
+
+        return new static;
     }
 
     /**


### PR DESCRIPTION
Per title this is a follow up to #119 to add the equivalent use*Model methods to configure without extending the Jetstream class.