### PR TITLE
[1.x] Inertia: Use check instead of authorize for canCreateTeams

### DIFF
--- a/src/Http/Middleware/ShareInertiaData.php
+++ b/src/Http/Middleware/ShareInertiaData.php
@@ -25,7 +25,7 @@ class ShareInertiaData
                 return [
                     'canCreateTeams' => $request->user() &&
                                         Jetstream::hasTeamFeatures() &&
-                                        Gate::forUser($request->user())->authorize('create', Jetstream::newTeamModel()),
+                                        Gate::forUser($request->user())->check('create', Jetstream::newTeamModel()),
                     'canManageTwoFactorAuthentication' => Features::canManageTwoFactorAuthentication(),
                     'flash' => $request->session()->get('flash', []),
                     'hasApiFeatures' => Jetstream::hasApiFeatures(),


### PR DESCRIPTION
The authorize call in ShareInertiaData causes an AuthorizationException, this means the data is not shared with Inertia. Changing authorize to check returns the boolean value and will populate canCreateTeams correctly when TeamPolicy->create returns false.

This closes #113 
