### PR TITLE
Get correct Http kernel filename & User model filename

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -499,7 +499,7 @@ EOF;
     }
 
     /**
-     * Get Http kernel file name
+     * Get Http kernel file name.
      *
      * @return  false|string
      * @throws \ReflectionException

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -58,7 +58,7 @@ class InstallCommand extends Command
         $this->replaceInFile(
             '// \Illuminate\Session\Middleware\AuthenticateSession::class',
             '\Laravel\Jetstream\Http\Middleware\AuthenticateSession::class',
-            app_path('Http/Kernel.php')
+            $this->getHttpKernelFileName()
         );
 
         // Install Stack...
@@ -496,5 +496,16 @@ EOF;
     protected function replaceInFile($search, $replace, $path)
     {
         file_put_contents($path, str_replace($search, $replace, file_get_contents($path)));
+    }
+
+    /**
+     * Get Http kernel file name
+     *
+     * @return  false|string
+     * @throws \ReflectionException
+     */
+    protected function getHttpKernelFileName()
+    {
+        return (new \ReflectionClass(resolve(\Illuminate\Contracts\Http\Kernel::class)))->getFileName();
     }
 }

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -162,7 +162,7 @@ class InstallCommand extends Command
         $this->installJetstreamServiceProvider();
 
         // Models...
-        copy(__DIR__.'/../../stubs/app/Models/User.php', app_path('Models/User.php'));
+        copy(__DIR__.'/../../stubs/app/Models/User.php', $this->getUserModel());
 
         // Actions...
         copy(__DIR__.'/../../stubs/app/Actions/Fortify/CreateNewUser.php', app_path('Actions/Fortify/CreateNewUser.php'));
@@ -501,11 +501,22 @@ EOF;
     /**
      * Get Http kernel file name.
      *
-     * @return  false|string
+     * @return  string
      * @throws \ReflectionException
      */
     protected function getHttpKernelFileName()
     {
         return (new \ReflectionClass(resolve(\Illuminate\Contracts\Http\Kernel::class)))->getFileName();
+    }
+
+    /**
+     * Get User model file name.
+     *
+     * @return  string
+     * @throws \ReflectionException
+     */
+    protected function getUserModelFileName()
+    {
+        return (new \ReflectionClass(config('auth.providers.users.model')))->getFileName();
     }
 }

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -162,7 +162,7 @@ class InstallCommand extends Command
         $this->installJetstreamServiceProvider();
 
         // Models...
-        copy(__DIR__.'/../../stubs/app/Models/User.php', $this->getUserModel());
+        copy(__DIR__.'/../../stubs/app/Models/User.php', $this->getUserModelFileName());
 
         // Actions...
         copy(__DIR__.'/../../stubs/app/Actions/Fortify/CreateNewUser.php', app_path('Actions/Fortify/CreateNewUser.php'));


### PR DESCRIPTION
The Http Kernel could be in a different location than the default one, so the following line is incorrect:

```php
app_path('Http/Kernel.php')
```

In one of our projects, the Http kernel is located in the `src/App/HttpKernel.php`:
```php
$app->singleton(
    Illuminate\Contracts\Http\Kernel::class,
    App\HttpKernel::class
);
```

So, installing jetstream in such projects won't be possible due to the location path.

The same applies to the `User` model, which might be in different folder than the `App/Models`.
