### PR TITLE
Consistently use array-syntax for validation rules

### DIFF
--- a/src/Http/Controllers/Inertia/ApiTokenController.php
+++ b/src/Http/Controllers/Inertia/ApiTokenController.php
@@ -35,7 +35,7 @@ class ApiTokenController extends Controller
         Validator::make([
             'name' => $request->name,
         ], [
-            'name' => 'required|string|max:255',
+            'name' => ['required', 'string', 'max:255'],
         ])->validateWithBag('createApiToken');
 
         $token = $request->user()->createToken(

--- a/src/Http/Livewire/ApiTokenManager.php
+++ b/src/Http/Livewire/ApiTokenManager.php
@@ -92,7 +92,7 @@ class ApiTokenManager extends Component
         Validator::make([
             'name' => $this->createApiTokenForm['name'],
         ], [
-            'name' => 'required|string|max:255',
+            'name' => ['required', 'string', 'max:255'],
         ])->validateWithBag('createApiToken');
 
         $this->displayTokenValue($this->user->createToken(

--- a/stubs/app/Actions/Jetstream/AddTeamMember.php
+++ b/stubs/app/Actions/Jetstream/AddTeamMember.php
@@ -62,7 +62,7 @@ class AddTeamMember implements AddsTeamMembers
     protected function rules()
     {
         return array_filter([
-            'email' => 'required|email|exists:users',
+            'email' => ['required', 'email', 'exists:users'],
             'role' => Jetstream::hasRoles()
                             ? ['required', 'string', new Role]
                             : null,

--- a/stubs/app/Actions/Jetstream/CreateTeam.php
+++ b/stubs/app/Actions/Jetstream/CreateTeam.php
@@ -21,7 +21,7 @@ class CreateTeam implements CreatesTeams
         Gate::forUser($user)->authorize('create', Jetstream::newTeamModel());
 
         Validator::make($input, [
-            'name' => 'required|string|max:255',
+            'name' => ['required', 'string', 'max:255'],
         ])->validateWithBag('createTeam');
 
         return $user->ownedTeams()->create([

--- a/stubs/app/Actions/Jetstream/UpdateTeamName.php
+++ b/stubs/app/Actions/Jetstream/UpdateTeamName.php
@@ -21,7 +21,7 @@ class UpdateTeamName implements UpdatesTeamNames
         Gate::forUser($user)->authorize('update', $team);
 
         Validator::make($input, [
-            'name' => 'required|string|max:255',
+            'name' => ['required', 'string', 'max:255'],
         ])->validateWithBag('updateTeamName');
 
         $team->forceFill([


### PR DESCRIPTION
Jetstream broadly uses the array-syntax for validation rules, which makes them a little easier to work with than their pipe-delimited cousins.

I've updated the places in both the main package and stubs to consistently use the array-syntax.