### PR TITLE
[1.x] Fix API token deletion bug

### DIFF
--- a/src/Http/Livewire/ApiTokenManager.php
+++ b/src/Http/Livewire/ApiTokenManager.php
@@ -175,6 +175,8 @@ class ApiTokenManager extends Component
         $this->user->load('tokens');
 
         $this->confirmingApiTokenDeletion = false;
+
+        $this->managingPermissionsFor = null;
     }
 
     /**


### PR DESCRIPTION
Fixes #152 

## Cause of the problem:
* When a user views the permissions modal for an API Token, a property on the component called `$managingPermissionsFor` is set to the corresponding API Token model
* If a user clicks "delete" and the model is no longer in the Database, that property hasn't been "unset", so when livewire goes to look it up by ID, it can't find it and a 404 error is thrown.

## The Fix:
* Immediately after deleting an API Token model, unset the `$managingPermissionsFor` property