### PR TITLE
Fix CreateNewUserWithTeams class name

### DIFF
--- a/stubs/app/Actions/Fortify/CreateNewUserWithTeams.php
+++ b/stubs/app/Actions/Fortify/CreateNewUserWithTeams.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Facades\Validator;
 use Laravel\Fortify\Contracts\CreatesNewUsers;
 use Laravel\Fortify\Rules\Password;
 
-class CreateNewUser implements CreatesNewUsers
+class CreateNewUserWithTeams implements CreatesNewUsers
 {
     /**
      * Create a newly registered user.


### PR DESCRIPTION
The name of the class should match the filename but this one was wrong possibly from copy-pasting the actual CreateNewUser class. 