### PR TITLE
Fix profile picture distortion for team owners

### DIFF
--- a/stubs/inertia/resources/js/Pages/Teams/CreateTeamForm.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/CreateTeamForm.vue
@@ -13,7 +13,7 @@
                 <jet-label value="Team Owner" />
 
                 <div class="flex items-center mt-2">
-                    <img class="w-12 h-12 rounded-full" :src="$page.user.profile_photo_url" :alt="$page.user.name">
+                    <img class="w-12 h-12 rounded-full object-cover" :src="$page.user.profile_photo_url" :alt="$page.user.name">
 
                     <div class="ml-4 leading-tight">
                         <div>{{ $page.user.name }}</div>

--- a/stubs/inertia/resources/js/Pages/Teams/UpdateTeamNameForm.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/UpdateTeamNameForm.vue
@@ -14,7 +14,7 @@
                 <jet-label value="Team Owner" />
 
                 <div class="flex items-center mt-2">
-                    <img class="w-12 h-12 rounded-full" :src="team.owner.profile_photo_url" :alt="team.owner.name">
+                    <img class="w-12 h-12 rounded-full object-cover" :src="team.owner.profile_photo_url" :alt="team.owner.name">
 
                     <div class="ml-4 leading-tight">
                         <div>{{ team.owner.name }}</div>

--- a/stubs/livewire/resources/views/teams/create-team-form.blade.php
+++ b/stubs/livewire/resources/views/teams/create-team-form.blade.php
@@ -12,7 +12,7 @@
             <x-jet-label value="Team Owner" />
 
             <div class="flex items-center mt-2">
-                <img class="w-12 h-12 rounded-full" src="{{ $this->user->profile_photo_url }}" alt="{{ $this->user->name }}">
+                <img class="w-12 h-12 rounded-full object-cover" src="{{ $this->user->profile_photo_url }}" alt="{{ $this->user->name }}">
 
                 <div class="ml-4 leading-tight">
                     <div>{{ $this->user->name }}</div>

--- a/stubs/livewire/resources/views/teams/update-team-name-form.blade.php
+++ b/stubs/livewire/resources/views/teams/update-team-name-form.blade.php
@@ -13,7 +13,7 @@
             <x-jet-label value="Team Owner" />
 
             <div class="flex items-center mt-2">
-                <img class="w-12 h-12 rounded-full" src="{{ $team->owner->profile_photo_url }}" alt="{{ $team->owner->name }}">
+                <img class="w-12 h-12 rounded-full object-cover" src="{{ $team->owner->profile_photo_url }}" alt="{{ $team->owner->name }}">
 
                 <div class="ml-4 leading-tight">
                     <div>{{ $team->owner->name }}</div>


### PR DESCRIPTION
I realised profile pictures of team owners are missing  `object-cover` class so it looks distorted if the picture uploaded is not a square. 