### PR TITLE
Update Fortify Actions CreateNewUser.php and CreateNewUserWithTeams.php stubs to use PasswordValidationRules Trait

### DIFF
--- a/stubs/app/Actions/Fortify/CreateNewUser.php
+++ b/stubs/app/Actions/Fortify/CreateNewUser.php
@@ -6,10 +6,11 @@ use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 use Laravel\Fortify\Contracts\CreatesNewUsers;
-use Laravel\Fortify\Rules\Password;
 
 class CreateNewUser implements CreatesNewUsers
 {
+    use PasswordValidationRules;
+
     /**
      * Validate and create a newly registered user.
      *
@@ -21,7 +22,7 @@ class CreateNewUser implements CreatesNewUsers
         Validator::make($input, [
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
-            'password' => ['required', 'string', new Password, 'confirmed'],
+            'password' => $this->passwordRules(),
         ])->validate();
 
         return User::create([

--- a/stubs/app/Actions/Fortify/CreateNewUserWithTeams.php
+++ b/stubs/app/Actions/Fortify/CreateNewUserWithTeams.php
@@ -8,10 +8,11 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 use Laravel\Fortify\Contracts\CreatesNewUsers;
-use Laravel\Fortify\Rules\Password;
 
 class CreateNewUser implements CreatesNewUsers
 {
+    use PasswordValidationRules;
+
     /**
      * Create a newly registered user.
      *
@@ -23,7 +24,7 @@ class CreateNewUser implements CreatesNewUsers
         Validator::make($input, [
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
-            'password' => ['required', 'string', new Password, 'confirmed'],
+            'password' => $this->passwordRules(),
         ])->validate();
 
         return DB::transaction(function () use ($input) {


### PR DESCRIPTION
This PR address issue: https://github.com/laravel/jetstream/issues/167

Currently the Fortify Action Stubs aren't in sync with this repo so this is an attempt to update them so when users install jetstream they are fully to to date with Fortify's stub.