### PR TITLE
Fix HasTeams trait to be able to use queries with('currentTeam')

### DIFF
--- a/src/HasTeams.php
+++ b/src/HasTeams.php
@@ -23,7 +23,7 @@ trait HasTeams
      */
     public function currentTeam()
     {
-        if (is_null($this->current_team_id)) {
+        if (is_null($this->current_team_id) && $this->id) {
             $this->forceFill([
                 'current_team_id' => $this->personalTeam()->id,
             ])->save();


### PR DESCRIPTION
When adding with('currentTeam') to an eloquent builder an error happens:

<img width="1735" alt="CleanShot 2020-09-13 at 01 59 39@2x" src="https://user-images.githubusercontent.com/23129218/93013339-e07c5200-f564-11ea-828e-306350598df7.png">

The issue is because the `currentTeam` method is checking if the user has `current_team_id` in order to set the default current_team_id based on the personal team. However, since the builder isn't a user itself, it always tries to perform this action.

Adding the check to see if the id is there, we will make sure that is a single user and not a query.

<img width="1117" alt="CleanShot 2020-09-13 at 02 05 24@2x" src="https://user-images.githubusercontent.com/23129218/93013430-a2336280-f565-11ea-852b-705bfc9591c2.png">

