### PR TITLE
[1.x] Fix 'laravel new project-name --jet'

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -5,6 +5,7 @@ namespace Laravel\Jetstream\Console;
 use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Symfony\Component\Process\Process;
 
@@ -101,8 +102,11 @@ class InstallCommand extends Command
         }
 
         $this->replaceInFile("'SESSION_DRIVER', 'file'", "'SESSION_DRIVER', 'database'", config_path('session.php'));
-        $this->replaceInFile('SESSION_DRIVER=file', 'SESSION_DRIVER=database', base_path('.env'));
         $this->replaceInFile('SESSION_DRIVER=file', 'SESSION_DRIVER=database', base_path('.env.example'));
+
+        if ($this->isDatabaseConnectionConfigured()) {
+            $this->replaceInFile('SESSION_DRIVER=file', 'SESSION_DRIVER=database', base_path('.env'));
+        }
     }
 
     /**
@@ -497,5 +501,21 @@ EOF;
     protected function replaceInFile($search, $replace, $path)
     {
         file_put_contents($path, str_replace($search, $replace, file_get_contents($path)));
+    }
+
+    /**
+     * Check if a database connection is currently configured.
+     *
+     * @return bool
+     */
+    protected function isDatabaseConnectionConfigured()
+    {
+        try {
+            DB::connection()->getPdo();
+        } catch (Exception $e) {
+            return false;
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
If you create an app using

```
laravel new project-name --jet
cd project-name
valet link
```

And try to open the page right away, this is what you will see:

```
Illuminate\Database\QueryException
SQLSTATE[HY000] [2002] Connection refused (SQL: select * from `sessions` where `id` = fZXzv4NDHB0ZxfUwdQV5Z4FmAuIdjEMyOy7zKwop limit 1)
```


Because you probably don't have a database configured. This PR fix this by only configuring the your `.env` if you actually have a database connection configured. So new users will still see the new Laravel app page.