### PR TITLE
[1.x] Add MustVerifyEmail Interface to User Model

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,6 +1,6 @@
 php:
   preset: laravel
   disabled:
-    - unused_use
+    - no_unused_imports
 js: true
 css: true

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,4 +1,6 @@
 php:
   preset: laravel
+  disabled:
+    - unused_use
 js: true
 css: true

--- a/stubs/app/Models/User.php
+++ b/stubs/app/Models/User.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;


### PR DESCRIPTION
The stub for the User model is missing the `Illuminate\Contracts\Auth\MustVerifyEmail` interface which is in the default [Laravel project](https://github.com/laravel/laravel/blob/master/app/Models/User.php#L5) and mentioned in the [Jetstream docs](https://jetstream.laravel.com/1.x/features/authentication.html#email-verification) as already being present.