### PR TITLE
[2.x] Remove the registersRoutes variable.

### DIFF
--- a/src/Jetstream.php
+++ b/src/Jetstream.php
@@ -11,13 +11,6 @@ use Laravel\Jetstream\Contracts\UpdatesTeamNames;
 class Jetstream
 {
     /**
-     * Indicates if Jetstream routes will be registered.
-     *
-     * @var bool
-     */
-    public static $registersRoutes = true;
-
-    /**
      * The roles that are available to assign to users.
      *
      * @var array
@@ -314,7 +307,7 @@ class Jetstream
      */
     public static function ignoreRoutes()
     {
-        static::$registersRoutes = false;
+        config(['jetstream.routes' => false]);
 
         return new static;
     }

--- a/src/JetstreamServiceProvider.php
+++ b/src/JetstreamServiceProvider.php
@@ -164,14 +164,16 @@ class JetstreamServiceProvider extends ServiceProvider
      */
     protected function configureRoutes()
     {
-        if (Jetstream::$registersRoutes) {
-            Route::group([
-                'namespace' => 'Laravel\Jetstream\Http\Controllers',
-                'domain' => config('jetstream.domain', null),
-            ], function () {
-                $this->loadRoutesFrom(__DIR__.'/../routes/'.config('jetstream.stack').'.php');
-            });
+        if ($this->app->routesAreCached() || config('jetstream.routes') === false) {
+            return;
         }
+
+        Route::group([
+            'namespace' => 'Laravel\Jetstream\Http\Controllers',
+            'domain' => config('jetstream.domain', null),
+        ], function () {
+            $this->loadRoutesFrom(__DIR__.'/../routes/'.config('jetstream.stack').'.php');
+        });
     }
 
     /**


### PR DESCRIPTION
After comments from https://github.com/laravel/sanctum/pull/194. 
I have created this PR to move the way the routes get pulled in to follow the current sanctum flow.