### PR TITLE
Don't include update password form if feature disabled (livewire)

### DIFF
--- a/stubs/livewire/resources/views/profile/show.blade.php
+++ b/stubs/livewire/resources/views/profile/show.blade.php
@@ -9,11 +9,13 @@
         <div class="max-w-7xl mx-auto py-10 sm:px-6 lg:px-8">
             @livewire('profile.update-profile-information-form')
 
-            <x-jet-section-border />
-
-            <div class="mt-10 sm:mt-0">
-                @livewire('profile.update-password-form')
-            </div>
+            @if (Laravel\Fortify\Features::enabled(Laravel\Fortify\Features::updatePasswords()))
+                <x-jet-section-border />
+            
+                <div class="mt-10 sm:mt-0">
+                    @livewire('profile.update-password-form')
+                </div>
+            @endif
 
             @if (Laravel\Fortify\Features::canManageTwoFactorAuthentication())
                 <x-jet-section-border />


### PR DESCRIPTION
If the updatePasswords feature is disabled (because the project is implementing password-less login) then the password form should be excluded from the profile view

