### PR TITLE
Preserve the current URL when changing teams in InertiaJS

### DIFF
--- a/stubs/livewire/resources/views/profile/show.blade.php
+++ b/stubs/livewire/resources/views/profile/show.blade.php
@@ -9,11 +9,13 @@
         <div class="max-w-7xl mx-auto py-10 sm:px-6 lg:px-8">
             @livewire('profile.update-profile-information-form')
 
-            <x-jet-section-border />
-
-            <div class="mt-10 sm:mt-0">
-                @livewire('profile.update-password-form')
-            </div>
+            @if (Laravel\Fortify\Features::enabled(Laravel\Fortify\Features::updatePasswords()))
+                <x-jet-section-border />
+            
+                <div class="mt-10 sm:mt-0">
+                    @livewire('profile.update-password-form')
+                </div>
+            @endif
 
             @if (Laravel\Fortify\Features::canManageTwoFactorAuthentication())
                 <x-jet-section-border />


### PR DESCRIPTION
This change preserves the current URL of the browser when switching teams so that you don't always return to the Dashboard.vue, but rather the page on which you were on when the team was switched.