### PR TITLE
[8.x] Fix jet-application-mark height class

### DIFF
--- a/stubs/inertia/resources/js/Layouts/AppLayout.vue
+++ b/stubs/inertia/resources/js/Layouts/AppLayout.vue
@@ -8,7 +8,7 @@
                         <!-- Logo -->
                         <div class="flex-shrink-0 flex items-center">
                             <a href="/dashboard">
-                                <jet-application-mark class="block h-9 w-auto" />
+                                <jet-application-mark class="block h-8 w-auto" />
                             </a>
                         </div>
 


### PR DESCRIPTION
The "h-9" class is not included in TailwindCSS by default. As such, the "jet-application-mark" size is not constrained and it covers the entire page. Proposing the "h-9" class be changed to "h-8" to resolve this issue.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
