### PR TITLE
Fix button margins on small screens

### DIFF
--- a/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
@@ -30,11 +30,11 @@
                     </span>
                 </div>
 
-                <jet-secondary-button class="mt-2" type="button" @click.native.prevent="selectNewPhoto">
+                <jet-secondary-button class="mt-2 mr-2" type="button" @click.native.prevent="selectNewPhoto">
                     Select A New Photo
                 </jet-secondary-button>
 
-                <jet-secondary-button type="button" class="ml-2" @click.native.prevent="deletePhoto" v-if="$page.user.profile_photo_path">
+                <jet-secondary-button type="button" class="mt-2" @click.native.prevent="deletePhoto" v-if="$page.user.profile_photo_path">
                     Remove Photo
                 </jet-secondary-button>
 

--- a/stubs/livewire/resources/views/profile/update-profile-information-form.blade.php
+++ b/stubs/livewire/resources/views/profile/update-profile-information-form.blade.php
@@ -38,12 +38,12 @@
                     </span>
                 </div>
 
-                <x-jet-secondary-button class="mt-2" type="button" x-on:click.prevent="$refs.photo.click()">
+                <x-jet-secondary-button class="mt-2 mr-2" type="button" x-on:click.prevent="$refs.photo.click()">
                     {{ __('Select A New Photo') }}
                 </x-jet-secondary-button>
 
                 @if ($this->user->profile_photo_path)
-                    <x-jet-secondary-button type="button" class="ml-2" wire:click="deleteProfilePhoto">
+                    <x-jet-secondary-button type="button" class="mt-2" wire:click="deleteProfilePhoto">
                         {{ __('Remove Photo') }}
                     </x-jet-secondary-button>
                 @endif


### PR DESCRIPTION
Just a button fix of the remove photo button position on small screens. This update does not change anything visually for desktop screens. 

How is being displayed now:
![image](https://user-images.githubusercontent.com/35383529/93247374-982b8280-f764-11ea-86f9-35b818840622.png)


How it will be shown:
![image](https://user-images.githubusercontent.com/35383529/93247331-89dd6680-f764-11ea-99d6-57d2fecc59c9.png)

