### PR TITLE
[1.x] Update modal z-index

### DIFF
--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -27,7 +27,7 @@ switch ($maxWidth ?? '2xl') {
         x-show="show"
         x-on:close.stop="show = false"
         x-on:keydown.escape.window="show = false"
-        class="fixed top-0 inset-x-0 px-4 pt-6 sm:px-0 sm:flex sm:items-top sm:justify-center"
+        class="fixed top-0 inset-x-0 px-4 pt-6 z-50 sm:px-0 sm:flex sm:items-top sm:justify-center"
         style="display: none;">
     <div x-show="show" class="fixed inset-0 transform transition-all" x-on:click="show = false" x-transition:enter="ease-out duration-300"
                     x-transition:enter-start="opacity-0"


### PR DESCRIPTION
This change ensures that the modal dialog is always on the front.