### PR TITLE
[1.x] Allow full access to ui-avatars api

### DIFF
--- a/config/jetstream.php
+++ b/config/jetstream.php
@@ -34,4 +34,9 @@ return [
         // Features::teams(),
     ],
 
+    
+    'default-profile-photo' => [
+        'color'      => 'f2ff2f',
+        'background' => 'aaaaaa',
+    ],
 ];

--- a/src/HasProfilePhoto.php
+++ b/src/HasProfilePhoto.php
@@ -47,7 +47,13 @@ trait HasProfilePhoto
      */
     protected function defaultProfilePhotoUrl()
     {
-        return 'https://ui-avatars.com/api/?name='.urlencode($this->name).'&color=7F9CF5&background=EBF4FF';
+        $params = config('jetstream.default-profile-photo');
+
+        // Make sure it is backwards compatible for users that already published jetstream config.
+        $params['color'] = config('jetstream.default-profile-photo.color', '7F9CF5');
+        $params['background'] = config('jetstream.default-profile-photo.background', 'EBF4FF');
+
+        return 'https://ui-avatars.com/api/?name=' . urlencode($this->name) . '&' . http_build_query($params);
     }
 
     /**

--- a/src/HasProfilePhoto.php
+++ b/src/HasProfilePhoto.php
@@ -47,7 +47,7 @@ trait HasProfilePhoto
      */
     protected function defaultProfilePhotoUrl()
     {
-        $params = config('jetstream.default-profile-photo');
+        $params = config('jetstream.default-profile-photo', []);
 
         // Make sure it is backwards compatible for users that already published jetstream config.
         $params['color'] = config('jetstream.default-profile-photo.color', '7F9CF5');


### PR DESCRIPTION
This PR exposes the manipulation of the default profile photo through the config.

After merging, we will be able to change the default text color and background color for the default profile photo but most importantly we will be able to specify any [ui-avatar](https://ui-avatars.com/) parameter we want.