### PR TITLE
Show password validation errors on reset password page

### DIFF
--- a/resources/views/components/validation-errors-bag.blade.php
+++ b/resources/views/components/validation-errors-bag.blade.php
@@ -1,0 +1,13 @@
+@props(['bag'])
+
+@if ($errors->hasBag($bag))
+    <div {{ $attributes }}>
+        <div class="font-medium text-red-600">{{ __('Please, fix the following errors') }}</div>
+
+        <ul class="mt-3 list-disc list-inside text-sm text-red-600">
+            @foreach ($errors->$bag->all() as $error)
+                <li>{{ $error }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif

--- a/src/JetstreamServiceProvider.php
+++ b/src/JetstreamServiceProvider.php
@@ -112,6 +112,7 @@ class JetstreamServiceProvider extends ServiceProvider
             $this->registerComponent('section-title');
             $this->registerComponent('switchable-team');
             $this->registerComponent('validation-errors');
+            $this->registerComponent('validation-errors-bag');
             $this->registerComponent('welcome');
         });
     }

--- a/stubs/resources/views/auth/reset-password.blade.php
+++ b/stubs/resources/views/auth/reset-password.blade.php
@@ -5,7 +5,9 @@
         </x-slot>
 
         <x-jet-validation-errors class="mb-4" />
-
+        
+        <x-jet-validation-errors-bag class="mb-4" :bag="'updatePassword'" />
+        
         <form method="POST" action="{{ route('password.update') }}">
             @csrf
 


### PR DESCRIPTION
Jetstream uses Fortify's `ResetUserPassword` class to reset the user password that returns an error-bag called `updatePassword`. 

Therefore, no validation errors on the reset-password page.

There are other ways that could fix this using the existing components; However, it seemed more appropriate to make a component to return all the errors within an error-bag.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
