### PR TITLE
Correct ID value for email field

### DIFF
--- a/stubs/inertia/resources/js/Pages/Teams/TeamMemberManager.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/TeamMemberManager.vue
@@ -23,7 +23,7 @@
                     <!-- Member Email -->
                     <div class="col-span-6 sm:col-span-4">
                         <jet-label for="email" value="Email" />
-                        <jet-input id="name" type="text" class="mt-1 block w-full" v-model="addTeamMemberForm.email" />
+                        <jet-input id="email" type="text" class="mt-1 block w-full" v-model="addTeamMemberForm.email" />
                         <jet-input-error :message="addTeamMemberForm.error('email')" class="mt-2" />
                     </div>
 


### PR DESCRIPTION
Corrects the ID value for the email field which was incorrect causing the email label not to be linked to the field and a console warning that two elements on the page had the ID "name".