### PR TITLE
[1.x] Use explicit table names from custom pivot models

### DIFF
--- a/src/HasTeams.php
+++ b/src/HasTeams.php
@@ -55,10 +55,9 @@ trait HasTeams
      */
     public function teams()
     {
-        return $this->belongsToMany(Jetstream::teamModel())
+        return $this->belongsToMany(Jetstream::teamModel(), Jetstream::membershipModel())
                         ->withPivot('role')
                         ->withTimestamps()
-                        ->using(Jetstream::membershipModel())
                         ->as('membership');
     }
 

--- a/src/Membership.php
+++ b/src/Membership.php
@@ -6,5 +6,10 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
 
 abstract class Membership extends Pivot
 {
-    //
+    /**
+     * The table associated with the pivot model.
+     *
+     * @var string
+     */
+    protected $table = 'team_user';
 }

--- a/src/Team.php
+++ b/src/Team.php
@@ -29,10 +29,9 @@ abstract class Team extends Model
      */
     public function users()
     {
-        return $this->belongsToMany(Jetstream::userModel())
+        return $this->belongsToMany(Jetstream::userModel(), Jetstream::membershipModel())
                         ->withPivot('role')
                         ->withTimestamps()
-                        ->using(Jetstream::membershipModel())
                         ->as('membership');
     }
 


### PR DESCRIPTION
If you register a **custom pivot model** for the teams-users relationship through `Jetstream::useMembershipModel()` and your model has a **custom table name** (other than the usual derived `team_user` table name), you must also override the whole membership-related relationship declarations, both `User::teams()` from [`HasTeams`](https://github.com/laravel/jetstream/blob/3ac0a23814c643b1e4de8168423e5be784081261/src/HasTeams.php#L56) and `Team::users()` from [`Team`](https://github.com/laravel/jetstream/blob/3ac0a23814c643b1e4de8168423e5be784081261/src/Team.php#L30) in your app. 

The problem is not very apparent after just customising the pivot model, as you just get an SQL error saying table `team_user` doesn't exist, thrown from the Jetstream dashboard view.

## Background

This happens because the `using()` method on `BelongsToMany` relationships only sets the pivot model to use, and leaves the derived table name, ignoring any custom table name declared in the pivot model.

To actually customise the table name, it must be passed as the second parameter for `belongsToMany()` in the relationship declarations. A `Pivot` model classname is also accepted, and that sets both the pivot model for the relationship **and also the table name from that model**.

*Note:* There is no plan for the Laravel framework to make `using()` also pull out the table name from the pivot model:
https://github.com/laravel/framework/issues/26864#issuecomment-447586436

## Solution

This PR replaces the call to `using()` with that second `$table` parameter on `belongsToMany()` so that any customisation of the team membership pivot model and its table can be done *within* just that model, not having to also update specific parts of `Team` and `User` models, that require some source diving to find out.

## Consequences

To make this work, Jetstream's included default `Membership` pivot model needs to be explicit about its table name. As the default table name `team_user` is already hard-coded in the migration, I don't think explicitly declaring it in the model should have any negative consequences. But I may be wrong, this may have to be reconsidered if there are use-cases where it would complicate things, *please let me know*!

In any apps where the membership pivot model or table has already been customised in some way, the methods and properties changed in this PR will already have been overriden. So updating Jetstream in an existing app with these changes should be non-breaking both for customised, and uncustomised apps.

## Testing

I haven't added any new tests as the changes are standard documented Laravel features, and the existing tests pass.

Maybe it'd be good to add tests to Jetstream for different intended customisations, like swapping out all models for customised ones? But I guess that's a higher level thing to do outside this PR, involving all kinds of fixtures and multiple sets of migrations... 🙀