### PR TITLE
[1.x] Fix purging of CSS classes on production builds

### DIFF
--- a/stubs/inertia/tailwind.config.js
+++ b/stubs/inertia/tailwind.config.js
@@ -1,7 +1,12 @@
 const defaultTheme = require('tailwindcss/defaultTheme');
 
 module.exports = {
-    purge: ['./storage/framework/views/*.php', './resources/views/**/*.blade.php', './resources/js/**/*.vue'],
+    purge: [
+        './vendor/laravel/jetstream/**/*.blade.php',
+        './storage/framework/views/*.php',
+        './resources/views/**/*.blade.php',
+        './resources/js/**/*.vue',
+    ],
 
     theme: {
         extend: {

--- a/stubs/livewire/tailwind.config.js
+++ b/stubs/livewire/tailwind.config.js
@@ -1,7 +1,11 @@
 const defaultTheme = require('tailwindcss/defaultTheme');
 
 module.exports = {
-    purge: ['./storage/framework/views/*.php', './resources/views/**/*.blade.php'],
+    purge: [
+        './vendor/laravel/jetstream/**/*.blade.php',
+        './storage/framework/views/*.php',
+        './resources/views/**/*.blade.php',
+    ],
 
     theme: {
         extend: {


### PR DESCRIPTION
### Problem:
If you do not publish the Jetstream views, those CSS classes will be purged from Tailwind on production builds, resulting in broken layouts.

**Example:**
![Screenshot from 2020-09-21 18-19-32](https://user-images.githubusercontent.com/19389981/93794010-da0e6a00-fc37-11ea-956d-55c86e3f59b0.png)

### Solution:
This PR fixes this issue **and** allows the Jetstream views to remain unpublished by simply including Jetstream in the list of folder PostCSS needs to search for classes.

**Result:**
![Screenshot from 2020-09-21 18-24-22](https://user-images.githubusercontent.com/19389981/93794235-1f329c00-fc38-11ea-916f-7d788cf3fcc7.png)

### Why:
Keeping, non-customized, views unpublished is what I prefer because it keeps my repository clean and I only publish files I actually need to modify.

---

Really fixes: https://github.com/laravel/jetstream/issues/170