### PR TITLE
[1.x] Use Inertia's `[only]` lazy evaluation

### DIFF
--- a/stubs/inertia/resources/js/Pages/Teams/UpdateTeamNameForm.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/UpdateTeamNameForm.vue
@@ -82,8 +82,9 @@
 
         methods: {
             updateTeamName() {
-                this.form.put('/teams/' + this.team.id, {
-                    preserveScroll: true
+                this.form.put(`/teams/'${this.team.id}`, {
+                    preserveScroll: true,
+                    only: ['team']
                 });
             },
         },


### PR DESCRIPTION
This PR updates the `put` request for updating the `team` name to take advantage of the lazy evaluation that Inertia offers outlined here https://inertiajs.com/responses#lazy-evaluation

This change will allow Inertia reduce the number of quieres needed to render the view.