### PR TITLE
[1.x] Added hasTeamRole check on the HasTeams trait.

### DIFF
--- a/src/HasTeams.php
+++ b/src/HasTeams.php
@@ -116,6 +116,34 @@ trait HasTeams
             'id', $this->id
         )->first()->membership->role);
     }
+   
+    /**
+     * Determine if the user has the given role on the given team.
+     *
+     * @param mixed $team
+     * @param string $role
+     * @return bool
+     */
+    public function hasTeamRole($team, string $role)
+    {
+        if ($this->ownsTeam($team)) {
+            return true;
+        }
+
+        if (! $this->belongsToTeam($team)) {
+            return false;
+        }
+
+        $roleObject = Jetstream::findRole($team->users->where(
+            'id', $this->id
+        )->first()->membership->role);
+
+        if (! $roleObject) {
+            return false;
+        }
+
+        return $roleObject->key === $role;
+    }
 
     /**
      * Get the user's permissions for the given team.

--- a/src/HasTeams.php
+++ b/src/HasTeams.php
@@ -120,8 +120,8 @@ trait HasTeams
     /**
      * Determine if the user has the given role on the given team.
      *
-     * @param mixed $team
-     * @param string $role
+     * @param  mixed  $team
+     * @param  string  $role
      * @return bool
      */
     public function hasTeamRole($team, string $role)

--- a/src/HasTeams.php
+++ b/src/HasTeams.php
@@ -116,7 +116,7 @@ trait HasTeams
             'id', $this->id
         )->first()->membership->role);
     }
-   
+
     /**
      * Determine if the user has the given role on the given team.
      *

--- a/tests/AddTeamMemberTest.php
+++ b/tests/AddTeamMemberTest.php
@@ -44,6 +44,8 @@ class AddTeamMemberTest extends OrchestraTestCase
         $team = $team->fresh();
 
         $this->assertCount(1, $team->users);
+        
+        $this->assertTrue($otherUser->hasTeamRole($team, 'admin'));
 
         $team->users->first()->withAccessToken(new TransientToken);
 

--- a/tests/AddTeamMemberTest.php
+++ b/tests/AddTeamMemberTest.php
@@ -44,7 +44,7 @@ class AddTeamMemberTest extends OrchestraTestCase
         $team = $team->fresh();
 
         $this->assertCount(1, $team->users);
-        
+
         $this->assertTrue($otherUser->hasTeamRole($team, 'admin'));
 
         $team->users->first()->withAccessToken(new TransientToken);


### PR DESCRIPTION
I have added this check because we do have a `hasTeamPermission` function but I missed a function to check if the team has a specific role.
When I checked the trait I saw the following function `teamRole` which returns the role object.
So when I saw that I wanted to add a function that returns true or false based on the fact if the role actually exists.

I would love to read your opinion on this pull request.