### PR TITLE
Allow for permissions and roles to be fetched from database models

### DIFF
--- a/database/migrations/2020_09_23_220000_create_permissions_table.php
+++ b/database/migrations/2020_09_23_220000_create_permissions_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatePermissionsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('permissions', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('permissions');
+    }
+}

--- a/database/migrations/2020_09_23_230000_create_team_roles_table.php
+++ b/database/migrations/2020_09_23_230000_create_team_roles_table.php
@@ -15,7 +15,7 @@ class CreateTeamRolesTable extends Migration
     {
         Schema::create('team_roles', function (Blueprint $table) {
             $table->id();
-            $table->foreignId( 'team_id');
+            $table->foreignId('team_id');
             $table->string('key');
             $table->string('label');
             $table->text('description')->nullable();

--- a/database/migrations/2020_09_23_230000_create_team_roles_table.php
+++ b/database/migrations/2020_09_23_230000_create_team_roles_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTeamRolesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('team_roles', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId( 'team_id');
+            $table->string('key');
+            $table->string('label');
+            $table->text('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('team_roles');
+    }
+}

--- a/database/migrations/2020_09_24_000000_create_team_role_permissions_table.php
+++ b/database/migrations/2020_09_24_000000_create_team_role_permissions_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTeamRolePermissionsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('team_role_permissions', function (Blueprint $table) {
+            $table->foreignId('team_role_id');
+            $table->foreignId('permission_id');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('team_role_permissions');
+    }
+}

--- a/src/Jetstream.php
+++ b/src/Jetstream.php
@@ -431,12 +431,12 @@ class Jetstream
     {
         static::$teamRoleModel = $model;
 
-        if (!static::newTeamRoleModel()->permissions instanceof Collection) {
+        if (! static::newTeamRoleModel()->permissions instanceof Collection) {
             throw new \Exception('TeamRole model supplied must have a permissions relationship.');
         }
 
 //        @TODO - Check for existence of name field here
-//        if (!static::newTeamRoleModel()->offsetExists('name')) {
+//        if (! static::newTeamRoleModel()->offsetExists('name')) {
 //            throw new \Exception('TeamRole model supplied must have a name field');
 //        }
 

--- a/src/Jetstream.php
+++ b/src/Jetstream.php
@@ -382,7 +382,7 @@ class Jetstream
      * @param  string  $model
      * @return static
      */
-    public static function usePermissionModel(string $model)
+    public static function usePermissionModel(string $model = null)
     {
         static::$permissionModel = $model;
 
@@ -427,18 +427,20 @@ class Jetstream
      * @param  string  $model
      * @return static
      */
-    public static function useTeamRoleModel(string $model)
+    public static function useTeamRoleModel(string $model = null)
     {
         static::$teamRoleModel = $model;
 
-        if (! static::newTeamRoleModel()->permissions instanceof Collection) {
-            throw new \Exception('TeamRole model supplied must have a permissions relationship.');
-        }
+        if ($model) {
+            if (! static::newTeamRoleModel()->permissions instanceof Collection) {
+                throw new \Exception('TeamRole model supplied must have a permissions relationship.');
+            }
 
-//        @TODO - Check for existence of name field here
-//        if (! static::newTeamRoleModel()->offsetExists('name')) {
-//            throw new \Exception('TeamRole model supplied must have a name field');
-//        }
+//            @TODO - Check for existence of name field here
+//            if (! static::newTeamRoleModel()->offsetExists('name')) {
+//                throw new \Exception('TeamRole model supplied must have a name field');
+//            }
+        }
 
         return new static;
     }

--- a/src/Jetstream.php
+++ b/src/Jetstream.php
@@ -97,7 +97,7 @@ class Jetstream
     public static function hasRoles()
     {
         if (static::hasTeamRolesModel()) {
-            return static::newUserModel()->count() > 0;
+            return static::newTeamRoleModel()->count() > 0;
         }
 
         return count(static::$roles) > 0;
@@ -157,7 +157,7 @@ class Jetstream
     public static function hasPermissions()
     {
         if (static::hasPermissionsModel()) {
-            return static::newUserModel()->count() > 0;
+            return static::newPermissionModel()->all()->count() > 0;
         }
 
         return count(static::$permissions) > 0;

--- a/stubs/app/Models/Permission.php
+++ b/stubs/app/Models/Permission.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Permission extends Model
+{
+    use HasFactory;
+}

--- a/stubs/app/Models/TeamRole.php
+++ b/stubs/app/Models/TeamRole.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class TeamRole extends Model
+{
+    use HasFactory;
+
+    public function permissions()
+    {
+        return $this->belongsToMany(Permission::class);
+    }
+}

--- a/tests/Fixtures/Permission.php
+++ b/tests/Fixtures/Permission.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Laravel\Jetstream\Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Permission extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var array
+     */
+    protected $guarded = [];
+}

--- a/tests/Fixtures/TeamRole.php
+++ b/tests/Fixtures/TeamRole.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Laravel\Jetstream\Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class TeamRole extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var array
+     */
+    protected $guarded = [];
+
+    public function permissions()
+    {
+        return $this->belongsToMany(Permission::class, 'team_role_permissions');
+    }
+}

--- a/tests/JetstreamTest.php
+++ b/tests/JetstreamTest.php
@@ -79,6 +79,7 @@ class JetstreamTest extends OrchestraTestCase
 
         Jetstream::usePermissionModel(Permission::class);
 
+        $this->assertTrue(Jetstream::hasPermissions());
         $this->assertInstanceOf(Permission::class, Jetstream::newPermissionModel());
     }
 
@@ -92,7 +93,10 @@ class JetstreamTest extends OrchestraTestCase
 
         Jetstream::useTeamRoleModel(TeamRole::class);
 
+        $this->assertTrue(Jetstream::hasRoles());
         $this->assertInstanceOf(TeamRole::class, Jetstream::newTeamRoleModel());
+        $this->assertInstanceOf(TeamRole::class, Jetstream::findRole('editor'));
+        $this->assertInstanceOf(TeamRole::class, Jetstream::findRole('admin'));
     }
 
     protected function migrate()

--- a/tests/JetstreamTest.php
+++ b/tests/JetstreamTest.php
@@ -8,6 +8,43 @@ use Laravel\Jetstream\Tests\Fixtures\TeamRole;
 
 class JetstreamTest extends OrchestraTestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->migrate();
+
+        $createPermission = Permission::create(['name' => 'create']);
+        $deletePermission = Permission::create(['name' => 'delete']);
+        $readPermission = Permission::create(['name' => 'read']);
+        $updatePermission = Permission::create(['name' => 'update']);
+
+        TeamRole::create([
+            'team_id' => 1,
+            'key' => 'admin',
+            'label' => 'Admin',
+            'description' => 'Admin Description',
+        ])->permissions()->saveMany([$readPermission, $createPermission]);
+
+        TeamRole::create([
+            'team_id' => 1,
+            'key' => 'editor',
+            'label' => 'Editor',
+            'description' => 'Editor Description',
+        ])->permissions()->saveMany([$deletePermission, $readPermission, $updatePermission]);
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        TeamRole::all()->each->delete();
+        Permission::all()->each->delete();
+
+        Jetstream::usePermissionModel(null);
+        Jetstream::useTeamRoleModel(null);
+    }
+
     public function test_roles_can_be_registered()
     {
         Jetstream::$permissions = [];
@@ -36,13 +73,6 @@ class JetstreamTest extends OrchestraTestCase
 
     public function test_permissions_model_can_be_provided_and_return_permissions()
     {
-        $this->migrate();
-
-        Permission::create(['name' => 'create']);
-        Permission::create(['name' => 'delete']);
-        Permission::create(['name' => 'read']);
-        Permission::create(['name' => 'update']);
-
         Jetstream::$permissions = [];
 
         $this->assertFalse(Jetstream::hasPermissions());
@@ -55,25 +85,6 @@ class JetstreamTest extends OrchestraTestCase
     public function test_roles_model_can_be_provided_and_return_permissions()
     {
         $this->migrate();
-
-        $createPermission = Permission::create(['name' => 'create']);
-        $deletePermission = Permission::create(['name' => 'delete']);
-        $readPermission = Permission::create(['name' => 'read']);
-        $updatePermission = Permission::create(['name' => 'update']);
-
-        TeamRole::create([
-            'team_id' => 1,
-            'key' => 'admin',
-            'label' => 'Admin',
-            'description' => 'Admin Description',
-        ])->permissions()->saveMany([$readPermission, $createPermission]);
-
-        TeamRole::create([
-            'team_id' => 1,
-            'key' => 'editor',
-            'label' => 'Editor',
-            'description' => 'Editor Description',
-        ])->permissions()->saveMany([$deletePermission, $readPermission, $updatePermission]);
 
         Jetstream::$roles = [];
 


### PR DESCRIPTION
As proposed in Issue #258 I think it would be useful to have the ability to optionally pull permissions and roles from database tables instead.

I've had a quick go at how that might look. This would obviously need more work before it could be approved. Not everyone would want this functionality and it clutters up the Jetsteam.php class somewhat so would be interested in your thoughts on how we could optionally include this functionality. Possibly add it behind a `--database-roles-and-permissions' flag similar to the way you can optionally include teams.

Happy to continue working on this but didn't want to get too far into it before you've had a chance to look over issue 258 and decide if this is something you're interested in.