### PR TITLE
[1.x] Allow teams uri customization

### DIFF
--- a/routes/inertia.php
+++ b/routes/inertia.php
@@ -36,15 +36,15 @@ Route::group(['middleware' => config('jetstream.middleware', ['web'])], function
 
         // Teams...
         if (Jetstream::hasTeamFeatures()) {
-            Route::get('/teams/create', [TeamController::class, 'create'])->name('teams.create');
-            Route::post('/teams', [TeamController::class, 'store'])->name('teams.store');
-            Route::get('/teams/{team}', [TeamController::class, 'show'])->name('teams.show');
-            Route::put('/teams/{team}', [TeamController::class, 'update'])->name('teams.update');
-            Route::delete('/teams/{team}', [TeamController::class, 'destroy'])->name('teams.destroy');
+            Route::get('/'.Jetstream::teamsPrefix().'/create', [TeamController::class, 'create'])->name('teams.create');
+            Route::post('/'.Jetstream::teamsPrefix(), [TeamController::class, 'store'])->name('teams.store');
+            Route::get('/'.Jetstream::teamsPrefix().'/{team}', [TeamController::class, 'show'])->name('teams.show');
+            Route::put('/'.Jetstream::teamsPrefix().'/{team}', [TeamController::class, 'update'])->name('teams.update');
+            Route::delete('/'.Jetstream::teamsPrefix().'/{team}', [TeamController::class, 'destroy'])->name('teams.destroy');
             Route::put('/current-team', [CurrentTeamController::class, 'update'])->name('current-team.update');
-            Route::post('/teams/{team}/members', [TeamMemberController::class, 'store'])->name('team-members.store');
-            Route::put('/teams/{team}/members/{user}', [TeamMemberController::class, 'update'])->name('team-members.update');
-            Route::delete('/teams/{team}/members/{user}', [TeamMemberController::class, 'destroy'])->name('team-members.destroy');
+            Route::post('/'.Jetstream::teamsPrefix().'/{team}/members', [TeamMemberController::class, 'store'])->name('team-members.store');
+            Route::put('/'.Jetstream::teamsPrefix().'/{team}/members/{user}', [TeamMemberController::class, 'update'])->name('team-members.update');
+            Route::delete('/'.Jetstream::teamsPrefix().'/{team}/members/{user}', [TeamMemberController::class, 'destroy'])->name('team-members.destroy');
         }
     });
 });

--- a/routes/livewire.php
+++ b/routes/livewire.php
@@ -20,8 +20,8 @@ Route::group(['middleware' => config('jetstream.middleware', ['web'])], function
 
         // Teams...
         if (Jetstream::hasTeamFeatures()) {
-            Route::get('/teams/create', [TeamController::class, 'create'])->name('teams.create');
-            Route::get('/teams/{team}', [TeamController::class, 'show'])->name('teams.show');
+            Route::get('/'.Jetstream::teamsPrefix().'/create', [TeamController::class, 'create'])->name('teams.create');
+            Route::get('/'.Jetstream::teamsPrefix().'/{team}', [TeamController::class, 'show'])->name('teams.show');
             Route::put('/current-team', [CurrentTeamController::class, 'update'])->name('current-team.update');
         }
     });

--- a/src/Jetstream.php
+++ b/src/Jetstream.php
@@ -53,6 +53,13 @@ class Jetstream
     public static $teamModel = 'App\\Models\\Team';
 
     /**
+     * The prefix used in the URI to describe teams.
+     *
+     * @var string
+     */
+    public static $teamsPrefix = 'teams';
+
+    /**
      * The membership model that should be used by Jetstream.
      *
      * @var string
@@ -341,6 +348,27 @@ class Jetstream
     public static function deleteTeamsUsing(string $class)
     {
         return app()->singleton(DeletesTeams::class, $class);
+    }
+
+    /**
+     * Get the string used to describe teams.
+     *
+     * @return string
+     */
+    public static function teamsPrefix()
+    {
+        return static::$teamsPrefix;
+    }
+
+    /**
+     * Set the string used to describe teams.
+     *
+     * @param  string  $string
+     * @return void
+     */
+    public static function prefixTeamsAs($string)
+    {
+        static::$teamsPrefix = $string;
     }
 
     /**

--- a/tests/TeamMemberControllerTest.php
+++ b/tests/TeamMemberControllerTest.php
@@ -37,7 +37,7 @@ class TeamMemberControllerTest extends OrchestraTestCase
 
         $team->users()->attach($adam, ['role' => 'admin']);
 
-        $response = $this->actingAs($team->owner)->put('/teams/'.$team->id.'/members/'.$adam->id, [
+        $response = $this->actingAs($team->owner)->put('/'.Jetstream::teamsPrefix().'/'.$team->id.'/members/'.$adam->id, [
             'role' => 'editor',
         ]);
 
@@ -65,7 +65,7 @@ class TeamMemberControllerTest extends OrchestraTestCase
 
         $team->users()->attach($adam, ['role' => 'admin']);
 
-        $response = $this->actingAs($adam)->put('/teams/'.$team->id.'/members/'.$adam->id, [
+        $response = $this->actingAs($adam)->put('/'.Jetstream::teamsPrefix().'/'.$team->id.'/members/'.$adam->id, [
             'role' => 'admin',
         ]);
 


### PR DESCRIPTION
This pull request contains a single commit that allows customization of the `/teams/` URI.

This was a feature in Laravel Spark that was useful for route localization or simply to present the Teams feature differently in the URL. In my case, it makes more sense for each user to have a personal workspace and shared workspaces, rather than a personal team and shared teams. In many view files this can already be done by just changing the word Team to Workspace, this extends that effort to URIs as well.

The default terminology remains `teams`, users that want to change that should do so exactly like they would in Laravel Spark. In the JeststreamServiceProvider, you can now add:

```
Jetstream::prefixTeamsAs('bands');
```

I hope this is helpful, thanks!