### PR TITLE
Use getAuthIdentifier instead of getKey for compatibility with other Laravel auth providers

### DIFF
--- a/src/Http/Controllers/Inertia/OtherBrowserSessionsController.php
+++ b/src/Http/Controllers/Inertia/OtherBrowserSessionsController.php
@@ -46,7 +46,7 @@ class OtherBrowserSessionsController extends Controller
         }
 
         DB::table(config('session.table', 'sessions'))
-            ->where('user_id', $request->user()->getKey())
+            ->where('user_id', $request->user()->getAuthIdentifier())
             ->where('id', '!=', $request->session()->getId())
             ->delete();
     }

--- a/src/Http/Controllers/Inertia/UserProfileController.php
+++ b/src/Http/Controllers/Inertia/UserProfileController.php
@@ -37,8 +37,8 @@ class UserProfileController extends Controller
         }
 
         return collect(
-            DB::table('sessions')
-                    ->where('user_id', $request->user()->getKey())
+            DB::table(config('session.table', 'sessions'))
+                    ->where('user_id', $request->user()->getAuthIdentifier())
                     ->orderBy('last_activity', 'desc')
                     ->get()
         )->map(function ($session) use ($request) {

--- a/src/Http/Livewire/LogoutOtherBrowserSessionsForm.php
+++ b/src/Http/Livewire/LogoutOtherBrowserSessionsForm.php
@@ -78,7 +78,7 @@ class LogoutOtherBrowserSessionsForm extends Component
         }
 
         DB::table(config('session.table', 'sessions'))
-            ->where('user_id', Auth::user()->getKey())
+            ->where('user_id', Auth::user()->getAuthIdentifier())
             ->where('id', '!=', request()->session()->getId())
             ->delete();
     }
@@ -95,8 +95,8 @@ class LogoutOtherBrowserSessionsForm extends Component
         }
 
         return collect(
-            DB::table('sessions')
-                    ->where('user_id', Auth::user()->getKey())
+            DB::table(config('session.table', 'sessions'))
+                    ->where('user_id', Auth::user()->getAuthIdentifier())
                     ->orderBy('last_activity', 'desc')
                     ->get()
         )->map(function ($session) {


### PR DESCRIPTION
**Purpose**:

This PR provides further support for other authentication providers in Jetstream.

**Reason**:

Since the `getKey()` method is not apart of the `Authenticatable` contract, anyone attempting to use the Inertia stack in Jetstream with another authentication provider cannot do so if the authenticatable user does not implement the `getKey()` method.

**Details**:

It would be great to use the `getAuthIdentifier()` method instead of `getKey()` since the former is implemented in the Authenticatable contract when using other authentication providers in Jetstream.

**Breaking Changes**:

There are no breaking changes in this PR. The `getAuthIdentifier()` method uses the `id` database column by default on the included `App\Models\User` model. Anyone who has adjusted or modified their primary user key will also be compatible with this change, due to the `Illuminate\Auth\Authenticatable` trait retrieving the key name dynamically from the model's `$primaryKey` property.

If there are any questions or concerns please let me know! 👍 ❤️ 