### PR TITLE
[1.x] Ensure text remains visible during webfont load

### DIFF
--- a/stubs/resources/views/layouts/guest.blade.php
+++ b/stubs/resources/views/layouts/guest.blade.php
@@ -8,7 +8,7 @@
         <title>{{ config('app.name', 'Laravel') }}</title>
 
         <!-- Fonts -->
-        <link href="https://fonts.googleapis.com/css?family=Nunito:400,600,700" rel="stylesheet">
+        <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap">
 
         <!-- Styles -->
         <link rel="stylesheet" href="{{ asset('css/app.css') }}">


### PR DESCRIPTION
Ensure text remains visible during webfont load via the `display` parameter.

It is already there in the `app` layout. This PR adds the same to the `guest` layout.