### PR TITLE
[1.x] Add reveal-password component

### DIFF
--- a/resources/views/components/revealable-password.blade.php
+++ b/resources/views/components/revealable-password.blade.php
@@ -1,0 +1,17 @@
+@props([
+    'class',
+    'disabled' => false,
+])
+
+<div class="{{ "relative flex items-center $class" }}" x-data="{ showPassword: false }">
+    <input {!! $attributes !!} {{ $disabled ? 'disabled' : '' }} class="form-input block w-full rounded-md shadow-sm pr-12" x-bind:type="showPassword ? 'text' : 'password'" />
+    <button type="button" x-on:click="showPassword = !showPassword" class="w-8 h-8 p-1 absolute right-2 text-gray-500 rounded-full focus:outline-none focus:text-gray-600 focus:shadow-outline ">
+        <svg x-show="showPassword" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+        </svg>
+        <svg x-show="!showPassword" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+        </svg>
+    </button>
+</div>

--- a/src/JetstreamServiceProvider.php
+++ b/src/JetstreamServiceProvider.php
@@ -107,6 +107,7 @@ class JetstreamServiceProvider extends ServiceProvider
             $this->registerComponent('nav-link');
             $this->registerComponent('responsive-nav-link');
             $this->registerComponent('responsive-switchable-team');
+            $this->registerComponent('revealable-password');
             $this->registerComponent('secondary-button');
             $this->registerComponent('section-border');
             $this->registerComponent('section-title');

--- a/stubs/inertia/resources/js/Jetstream/ConfirmsPassword.vue
+++ b/stubs/inertia/resources/js/Jetstream/ConfirmsPassword.vue
@@ -13,7 +13,7 @@
                 {{ content }}
 
                 <div class="mt-4">
-                    <jet-input type="password" class="mt-1 block w-3/4" placeholder="Password"
+                    <jet-revealable-password class="mt-1 block w-3/4" placeholder="Password"
                                 ref="password"
                                 v-model="form.password"
                                 @keyup.enter.native="confirmPassword" />
@@ -38,7 +38,7 @@
 <script>
     import JetButton from './Button'
     import JetDialogModal from './DialogModal'
-    import JetInput from './Input'
+    import JetRevealablePassword from './RevealablePassword'
     import JetInputError from './InputError'
     import JetSecondaryButton from './SecondaryButton'
 
@@ -58,7 +58,7 @@
         components: {
             JetButton,
             JetDialogModal,
-            JetInput,
+            JetRevealablePassword,
             JetInputError,
             JetSecondaryButton,
         },

--- a/stubs/inertia/resources/js/Jetstream/RevealablePassword.vue
+++ b/stubs/inertia/resources/js/Jetstream/RevealablePassword.vue
@@ -1,0 +1,37 @@
+<template>
+    <div class="relative flex items-center">
+        <input v-bind="$attrs" class="form-input block w-full rounded-md shadow-sm pr-12" :value="value" @input="$emit('input', $event.target.value)" ref="input" :type="type">
+        <button type="button" @click="showPassword = !showPassword" class="w-8 h-8 p-1 absolute right-2 text-gray-500 rounded-full focus:outline-none focus:text-gray-600 focus:shadow-outline ">
+            <svg v-if="showPassword" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+            </svg>
+            <svg v-else xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+            </svg>
+        </button>
+    </div>
+</template>
+
+<script>
+    export default {
+        props: ['value'],
+
+        methods: {
+            focus() {
+                this.$refs.input.focus()
+            }
+        },
+        data() {
+            return {
+                showPassword: false,
+            }
+        },
+        computed: {
+            type() {
+                return this.showPassword ? 'text' : 'password';
+            }
+        }
+    }
+</script>
+

--- a/stubs/inertia/resources/js/Pages/Profile/DeleteUserForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/DeleteUserForm.vue
@@ -29,7 +29,7 @@
                     Are you sure you want to delete your account? Once your account is deleted, all of its resources and data will be permanently deleted. Please enter your password to confirm you would like to permanently delete your account.
 
                     <div class="mt-4">
-                        <jet-input type="password" class="mt-1 block w-3/4" placeholder="Password"
+                        <jet-revealable-password class="mt-1 block w-3/4" placeholder="Password"
                                     ref="password"
                                     v-model="form.password"
                                     @keyup.enter.native="deleteUser" />
@@ -57,7 +57,7 @@
     import JetButton from './../../Jetstream/Button'
     import JetDialogModal from './../../Jetstream/DialogModal'
     import JetDangerButton from './../../Jetstream/DangerButton'
-    import JetInput from './../../Jetstream/Input'
+    import JetRevealablePassword from './../../Jetstream/RevealablePassword'
     import JetInputError from './../../Jetstream/InputError'
     import JetSecondaryButton from './../../Jetstream/SecondaryButton'
 
@@ -67,7 +67,7 @@
             JetButton,
             JetDangerButton,
             JetDialogModal,
-            JetInput,
+            JetRevealablePassword,
             JetInputError,
             JetSecondaryButton,
         },

--- a/stubs/inertia/resources/js/Pages/Profile/LogoutOtherBrowserSessionsForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/LogoutOtherBrowserSessionsForm.vue
@@ -63,7 +63,7 @@
                     Please enter your password to confirm you would like to logout of your other browser sessions across all of your devices.
 
                     <div class="mt-4">
-                        <jet-input type="password" class="mt-1 block w-3/4" placeholder="Password"
+                        <jet-revealable-password class="mt-1 block w-3/4" placeholder="Password"
                                     ref="password"
                                     v-model="form.password"
                                     @keyup.enter.native="logoutOtherBrowserSessions" />
@@ -91,7 +91,7 @@
     import JetActionSection from './../../Jetstream/ActionSection'
     import JetButton from './../../Jetstream/Button'
     import JetDialogModal from './../../Jetstream/DialogModal'
-    import JetInput from './../../Jetstream/Input'
+    import JetRevealablePassword from "./../../Jetstream/RevealablePassword";
     import JetInputError from './../../Jetstream/InputError'
     import JetSecondaryButton from './../../Jetstream/SecondaryButton'
 
@@ -103,7 +103,7 @@
             JetActionSection,
             JetButton,
             JetDialogModal,
-            JetInput,
+            JetRevealablePassword,
             JetInputError,
             JetSecondaryButton,
         },

--- a/stubs/inertia/resources/js/Pages/Profile/UpdatePasswordForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/UpdatePasswordForm.vue
@@ -11,7 +11,7 @@
         <template #form>
             <div class="col-span-6 sm:col-span-4">
                 <jet-label for="current_password" value="Current Password" />
-                <jet-input id="current_password" type="password" class="mt-1 block w-full" v-model="form.current_password" ref="current_password" autocomplete="current-password" />
+                <jet-revealable-password id="current_password" class="mt-1 block w-full" v-model="form.current_password" ref="current_password" autocomplete="current-password" />
                 <jet-input-error :message="form.error('current_password')" class="mt-2" />
             </div>
 
@@ -47,6 +47,7 @@
     import JetInput from './../../Jetstream/Input'
     import JetInputError from './../../Jetstream/InputError'
     import JetLabel from './../../Jetstream/Label'
+    import JetRevealablePassword from "./../../Jetstream/RevealablePassword";
 
     export default {
         components: {
@@ -56,6 +57,7 @@
             JetInput,
             JetInputError,
             JetLabel,
+            JetRevealablePassword,
         },
 
         data() {

--- a/stubs/resources/views/auth/login.blade.php
+++ b/stubs/resources/views/auth/login.blade.php
@@ -22,7 +22,7 @@
 
             <div class="mt-4">
                 <x-jet-label for="password" value="{{ __('Password') }}" />
-                <x-jet-input id="password" class="block mt-1 w-full" type="password" name="password" required autocomplete="current-password" />
+                <x-jet-revealable-password id="password" class="block mt-1 w-full" name="password" required autocomplete="current-password" />
             </div>
 
             <div class="block mt-4">


### PR DESCRIPTION
This is a follow up on #292 it will ad a new blade component `<x-jet-revealable-password>`, and a new vue component as well.

I have replaced most usage of the old password inputs except for password and password confirmation dialogs. 
Otherwise you could simply copy&paste the password from one field to the other.