### PR TITLE
[1.x] Add dependancy-less modal focus trapping

### DIFF
--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -27,11 +27,11 @@ switch ($maxWidth ?? '2xl') {
     x-data="{
         show: @entangle($attributes->wire('model')),
         focusables() {
-            // All focusable element types.
+            // All focusable element types...
             let selector = 'a, button, input, textarea, select, details, [tabindex]:not([tabindex=\'-1\'])'
 
             return [...$el.querySelectorAll(selector)]
-                // All non-disabled elements.
+                // All non-disabled elements...
                 .filter(el => ! el.hasAttribute('disabled'))
         },
         firstFocusable() { return this.focusables()[0] },

--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -23,12 +23,33 @@ switch ($maxWidth ?? '2xl') {
 }
 @endphp
 
-<div id="{{ $id }}" x-data="{ show: @entangle($attributes->wire('model')) }"
-        x-show="show"
-        x-on:close.stop="show = false"
-        x-on:keydown.escape.window="show = false"
-        class="fixed top-0 inset-x-0 px-4 pt-6 z-50 sm:px-0 sm:flex sm:items-top sm:justify-center"
-        style="display: none;">
+<div
+    x-data="{
+        show: @entangle($attributes->wire('model')),
+        focusables() {
+            // All focusable element types.
+            let selector = 'a, button, input, textarea, select, details, [tabindex]:not([tabindex=\'-1\'])'
+
+            return [...$el.querySelectorAll(selector)]
+                // All non-disabled elements.
+                .filter(el => ! el.hasAttribute('disabled'))
+        },
+        firstFocusable() { return this.focusables()[0] },
+        lastFocusable() { return this.focusables().slice(-1)[0] },
+        nextFocusable() { return this.focusables()[this.nextFocusableIndex()] || this.firstFocusable() },
+        prevFocusable() { return this.focusables()[this.prevFocusableIndex()] || this.lastFocusable() },
+        nextFocusableIndex() { return (this.focusables().indexOf(document.activeElement) + 1) % (this.focusables().length + 1) },
+        prevFocusableIndex() { return Math.max(0, this.focusables().indexOf(document.activeElement)) -1 },
+    }"
+    x-on:close.stop="show = false"
+    x-on:keydown.escape.window="show = false"
+    x-on:keydown.tab.prevent="$event.shiftKey || nextFocusable().focus()"
+    x-on:keydown.shift.tab.prevent="prevFocusable().focus()"
+    x-show="show"
+    id="{{ $id }}"
+    class="fixed top-0 inset-x-0 px-4 pt-6 z-50 sm:px-0 sm:flex sm:items-top sm:justify-center"
+    style="display: none;"
+>
     <div x-show="show" class="fixed inset-0 transform transition-all" x-on:click="show = false" x-transition:enter="ease-out duration-300"
                     x-transition:enter-start="opacity-0"
                     x-transition:enter-end="opacity-100"


### PR DESCRIPTION
This PR adds "focus-trapping" to the modals in Jetstream.

This means that pressing "Tab" and "Shift+Tab" will only cycle through focusing elements inside the modal.

Here's a gif:
![focus_trap](https://user-images.githubusercontent.com/3670578/94830522-a66ed500-03d9-11eb-8504-0854590d6894.gif)
