### PR TITLE
[1.x] Extract switch team logic into HasTeams trait

### DIFF
--- a/src/HasTeams.php
+++ b/src/HasTeams.php
@@ -24,12 +24,28 @@ trait HasTeams
     public function currentTeam()
     {
         if (is_null($this->current_team_id) && $this->id) {
-            $this->forceFill([
-                'current_team_id' => $this->personalTeam()->id,
-            ])->save();
+            $this->switchTeam($this->personalTeam());
         }
 
         return $this->belongsTo(Jetstream::teamModel(), 'current_team_id');
+    }
+
+    /**
+     * Switch the user's context to the given team.
+     *
+     * @return bool
+     */
+    public function switchTeam($team)
+    {
+        if (! $this->belongsToTeam($team)) {
+            return false;
+        }
+
+        $this->forceFill([
+            'current_team_id' => $team->id,
+        ])->save();
+
+        return true;
     }
 
     /**

--- a/src/Http/Controllers/CurrentTeamController.php
+++ b/src/Http/Controllers/CurrentTeamController.php
@@ -18,13 +18,9 @@ class CurrentTeamController extends Controller
     {
         $team = Jetstream::newTeamModel()->findOrFail($request->team_id);
 
-        if (! $request->user()->belongsToTeam($team)) {
+        if (! $request->user()->switchTeam($team)) {
             abort(403);
         }
-
-        $request->user()->forceFill([
-            'current_team_id' => $team->id,
-        ])->save();
 
         return redirect(config('fortify.home'), 303);
     }


### PR DESCRIPTION
This PR extract the logic for team switching into the `HasTeams` trait, which allows to switch the current team from code. 

__Example:__ Use the `switchTeam` method to change the current team during a test.

```php
/** @test */
public function xyz()
{
    $user = User::factory()->create();

    // ...

    $user->switchTeam($otherTeam);

    // ...
}
```