### PR TITLE
Use named routes on Inertia with Ziggy

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -247,7 +247,7 @@ EOF;
     protected function installInertiaStack()
     {
         // Install Inertia...
-        (new Process(['composer', 'require', 'inertiajs/inertia-laravel', 'laravel/sanctum:^2.6'], base_path()))
+        (new Process(['composer', 'require', 'inertiajs/inertia-laravel', 'laravel/sanctum:^2.6', 'tightenco/ziggy'], base_path()))
                 ->setTimeout(null)
                 ->run(function ($type, $output) {
                     $this->output->write($output);

--- a/stubs/inertia/resources/js/Jetstream/ConfirmsPassword.vue
+++ b/stubs/inertia/resources/js/Jetstream/ConfirmsPassword.vue
@@ -80,7 +80,7 @@
             startConfirmingPassword() {
                 this.form.error = '';
 
-                axios.get('/user/confirmed-password-status').then(response => {
+                axios.get(route('password.confirmation')).then(response => {
                     if (response.data.confirmed) {
                         this.$emit('confirmed');
                     } else {
@@ -97,7 +97,7 @@
             confirmPassword() {
                 this.form.processing = true;
 
-                axios.post('/user/confirm-password', {
+                axios.post(route('password.confirm'), {
                     password: this.form.password,
                 }).then(response => {
                     this.confirmingPassword = false;

--- a/stubs/inertia/resources/js/Layouts/AppLayout.vue
+++ b/stubs/inertia/resources/js/Layouts/AppLayout.vue
@@ -7,14 +7,14 @@
                     <div class="flex">
                         <!-- Logo -->
                         <div class="flex-shrink-0 flex items-center">
-                            <a href="/dashboard">
+                            <inertia-link :href="route('dashboard')">
                                 <jet-application-mark class="block h-9 w-auto" />
-                            </a>
+                            </inertia-link>
                         </div>
 
                         <!-- Navigation Links -->
                         <div class="hidden space-x-8 sm:-my-px sm:ml-10 sm:flex">
-                            <jet-nav-link href="/dashboard" :active="$page.currentRouteName == 'dashboard'">
+                            <jet-nav-link :href="route('dashboard')" :active="$page.currentRouteName == 'dashboard'">
                                 Dashboard
                             </jet-nav-link>
                         </div>
@@ -46,11 +46,11 @@
                                         Manage Account
                                     </div>
 
-                                    <jet-dropdown-link href="/user/profile">
+                                    <jet-dropdown-link :href="route('profile.show')">
                                         Profile
                                     </jet-dropdown-link>
 
-                                    <jet-dropdown-link href="/user/api-tokens" v-if="$page.jetstream.hasApiFeatures">
+                                    <jet-dropdown-link :href="route('api-tokens.index')" v-if="$page.jetstream.hasApiFeatures">
                                         API Tokens
                                     </jet-dropdown-link>
 
@@ -63,11 +63,11 @@
                                         </div>
 
                                         <!-- Team Settings -->
-                                        <jet-dropdown-link :href="'/teams/' + $page.user.current_team.id">
+                                        <jet-dropdown-link :href="route('teams.show', $page.user.current_team)">
                                             Team Settings
                                         </jet-dropdown-link>
 
-                                        <jet-dropdown-link href="/teams/create" v-if="$page.jetstream.canCreateTeams">
+                                        <jet-dropdown-link :href="route('teams.create')" v-if="$page.jetstream.canCreateTeams">
                                             Create New Team
                                         </jet-dropdown-link>
 
@@ -118,7 +118,7 @@
             <!-- Responsive Navigation Menu -->
             <div :class="{'block': showingNavigationDropdown, 'hidden': ! showingNavigationDropdown}" class="sm:hidden">
                 <div class="pt-2 pb-3 space-y-1">
-                    <jet-responsive-nav-link href="/dashboard" :active="$page.currentRouteName == 'dashboard'">
+                    <jet-responsive-nav-link :href="route('dashboard')" :active="$page.currentRouteName == 'dashboard'">
                         Dashboard
                     </jet-responsive-nav-link>
                 </div>
@@ -137,11 +137,11 @@
                     </div>
 
                     <div class="mt-3 space-y-1">
-                        <jet-responsive-nav-link href="/user/profile" :active="$page.currentRouteName == 'profile.show'">
+                        <jet-responsive-nav-link :href="route('profile.show')" :active="$page.currentRouteName == 'profile.show'">
                             Profile
                         </jet-responsive-nav-link>
 
-                        <jet-responsive-nav-link href="/user/api-tokens" :active="$page.currentRouteName == 'api-tokens.index'" v-if="$page.jetstream.hasApiFeatures">
+                        <jet-responsive-nav-link :href="route('api-tokens.index')" :active="$page.currentRouteName == 'api-tokens.index'" v-if="$page.jetstream.hasApiFeatures">
                             API Tokens
                         </jet-responsive-nav-link>
 
@@ -161,11 +161,11 @@
                             </div>
 
                             <!-- Team Settings -->
-                            <jet-responsive-nav-link :href="'/teams/' + $page.user.current_team.id" :active="$page.currentRouteName == 'teams.show'">
+                            <jet-responsive-nav-link :href="route('teams.show', $page.user.current_team)" :active="$page.currentRouteName == 'teams.show'">
                                 Team Settings
                             </jet-responsive-nav-link>
 
-                            <jet-responsive-nav-link href="/teams/create" :active="$page.currentRouteName == 'teams.create'">
+                            <jet-responsive-nav-link :href="route('teams.create')" :active="$page.currentRouteName == 'teams.create'">
                                 Create New Team
                             </jet-responsive-nav-link>
 
@@ -236,7 +236,7 @@
 
         methods: {
             switchToTeam(team) {
-                this.$inertia.put('/current-team', {
+                this.$inertia.put(route('current-team.update'), {
                     'team_id': team.id
                 }, {
                     preserveState: false
@@ -244,7 +244,7 @@
             },
 
             logout() {
-                axios.post('/logout').then(response => {
+                axios.post(route('logout')).then(response => {
                     window.location = '/';
                 })
             },

--- a/stubs/inertia/resources/js/Pages/API/ApiTokenManager.vue
+++ b/stubs/inertia/resources/js/Pages/API/ApiTokenManager.vue
@@ -225,7 +225,7 @@
 
         methods: {
             createApiToken() {
-                this.createApiTokenForm.post('/user/api-tokens', {
+                this.createApiTokenForm.post(route('api-tokens.store'), {
                     preserveScroll: true,
                 }).then(response => {
                     if (! this.createApiTokenForm.hasErrors()) {
@@ -241,7 +241,7 @@
             },
 
             updateApiToken() {
-                this.updateApiTokenForm.put('/user/api-tokens/' + this.managingPermissionsFor.id, {
+                this.updateApiTokenForm.put(route('api-tokens.update', this.managingPermissionsFor), {
                     preserveScroll: true,
                     preserveState: true,
                 }).then(response => {
@@ -254,7 +254,7 @@
             },
 
             deleteApiToken() {
-                this.deleteApiTokenForm.delete('/user/api-tokens/' + this.apiTokenBeingDeleted.id, {
+                this.deleteApiTokenForm.delete(route('api-tokens.destroy', this.managingPermissionsFor), {
                     preserveScroll: true,
                     preserveState: true,
                 }).then(() => {

--- a/stubs/inertia/resources/js/Pages/Profile/DeleteUserForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/DeleteUserForm.vue
@@ -98,7 +98,7 @@
             },
 
             deleteUser() {
-                this.form.post('/user', {
+                this.form.post(route('current-user.destroy'), {
                     preserveScroll: true
                 }).then(response => {
                     if (! this.form.hasErrors()) {

--- a/stubs/inertia/resources/js/Pages/Profile/LogoutOtherBrowserSessionsForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/LogoutOtherBrowserSessionsForm.vue
@@ -133,7 +133,7 @@
             },
 
             logoutOtherBrowserSessions() {
-                this.form.post('/user/other-browser-sessions', {
+                this.form.post(route('other-browser-sessions.destroy'), {
                     preserveScroll: true
                 }).then(response => {
                     if (! this.form.hasErrors()) {

--- a/stubs/inertia/resources/js/Pages/Profile/UpdatePasswordForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/UpdatePasswordForm.vue
@@ -72,7 +72,7 @@
 
         methods: {
             updatePassword() {
-                this.form.put('/user/password', {
+                this.form.put(route('user-password.update'), {
                     preserveScroll: true
                 }).then(() => {
                     this.$refs.current_password.focus()

--- a/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
@@ -112,7 +112,7 @@
                     this.form.photo = this.$refs.photo.files[0]
                 }
 
-                this.form.post('/user/profile-information', {
+                this.form.post(route('user-profile-information.update'), {
                     preserveScroll: true
                 });
             },
@@ -132,7 +132,7 @@
             },
 
             deletePhoto() {
-                this.$inertia.delete('/user/profile-photo', {
+                this.$inertia.delete(route('current-user-photo.destroy'), {
                     preserveScroll: true,
                 }).then(() => {
                     this.photoPreview = null

--- a/stubs/inertia/resources/js/Pages/Teams/CreateTeamForm.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/CreateTeamForm.vue
@@ -72,7 +72,7 @@
 
         methods: {
             createTeam() {
-                this.form.post('/teams', {
+                this.form.post(route('teams.store'), {
                     preserveScroll: true
                 });
             },

--- a/stubs/inertia/resources/js/Pages/Teams/DeleteTeamForm.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/DeleteTeamForm.vue
@@ -80,7 +80,7 @@
             },
 
             deleteTeam() {
-                this.form.delete('/teams/' + this.team.id, {
+                this.form.delete(route('teams.destroy', this.team), {
                     preserveScroll: true
                 });
             },

--- a/stubs/inertia/resources/js/Pages/Teams/TeamMemberManager.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/TeamMemberManager.vue
@@ -137,7 +137,7 @@
                         <div class="px-4 py-3"
                                         :class="{'border-t border-gray-200': i > 0}"
                                         @click="updateRoleForm.role = role.key"
-                                        v-for="(role, i) in availableRoles" 
+                                        v-for="(role, i) in availableRoles"
                                         :key="i"
                                         >
                             <div :class="{'opacity-50': updateRoleForm.role && updateRoleForm.role != role.key}">
@@ -289,7 +289,7 @@
 
         methods: {
             addTeamMember() {
-                this.addTeamMemberForm.post('/teams/' + this.team.id + '/members', {
+                this.addTeamMemberForm.post(route('team-members.store', this.team), {
                     preserveScroll: true
                 });
             },
@@ -301,7 +301,7 @@
             },
 
             updateRole() {
-                this.updateRoleForm.put('/teams/' + this.team.id + '/members/' + this.managingRoleFor.id, {
+                this.updateRoleForm.put(route('team-members.update', [this.team, this.managingRoleFor]), {
                     preserveScroll: true,
                 }).then(() => {
                     this.currentlyManagingRole = false
@@ -313,7 +313,7 @@
             },
 
             leaveTeam() {
-                this.leaveTeamForm.delete('/teams/' + this.team.id + '/members/' + this.$page.user.id)
+                this.leaveTeamForm.delete(route('team-members.destroy', [this.team, this.$page.user]))
             },
 
             confirmTeamMemberRemoval(teamMember) {
@@ -321,7 +321,7 @@
             },
 
             removeTeamMember() {
-                this.removeTeamMemberForm.delete('/teams/' + this.team.id + '/members/' + this.teamMemberBeingRemoved.id, {
+                this.removeTeamMemberForm.delete(route('team-members.destroy', [this.team, this.teamMemberBeingRemoved]), {
                     preserveScroll: true,
                     preserveState: true,
                 }).then(() => {

--- a/stubs/inertia/resources/js/Pages/Teams/UpdateTeamNameForm.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/UpdateTeamNameForm.vue
@@ -82,7 +82,7 @@
 
         methods: {
             updateTeamName() {
-                this.form.put('/teams/' + this.team.id, {
+                this.form.put(route('teams.update', this.team), {
                     preserveScroll: true
                 });
             },

--- a/stubs/inertia/resources/js/app.js
+++ b/stubs/inertia/resources/js/app.js
@@ -6,6 +6,7 @@ import { InertiaApp } from '@inertiajs/inertia-vue';
 import { InertiaForm } from 'laravel-jetstream';
 import PortalVue from 'portal-vue';
 
+Vue.mixin({ methods: { route } });
 Vue.use(InertiaApp);
 Vue.use(InertiaForm);
 Vue.use(PortalVue);

--- a/stubs/inertia/resources/views/app.blade.php
+++ b/stubs/inertia/resources/views/app.blade.php
@@ -14,6 +14,7 @@
         <link rel="stylesheet" href="{{ mix('css/app.css') }}">
 
         <!-- Scripts -->
+        @routes
         <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.26.0/moment.min.js"></script>
         <script src="{{ mix('js/app.js') }}" defer></script>
     </head>


### PR DESCRIPTION
## Description

This PR replaces all URLs on the Inertia skeleton with named routes, making use of [the Ziggy package from Tighten](https://github.com/tightenco/ziggy).

## Related Issues

Closes #157

## Future Improvements

I wasn't able to replace the URLs on the two-factor authentication component since their routes aren't named. If requested, I could submit a PR to fortify that adds names for these routes for completion's sake.