### PR TITLE
Fix axios routes

### DIFF
--- a/stubs/inertia/resources/js/Jetstream/ConfirmsPassword.vue
+++ b/stubs/inertia/resources/js/Jetstream/ConfirmsPassword.vue
@@ -80,7 +80,7 @@
             startConfirmingPassword() {
                 this.form.error = '';
 
-                axios.get(route('password.confirmation')).then(response => {
+                axios.get(route('password.confirmation').url()).then(response => {
                     if (response.data.confirmed) {
                         this.$emit('confirmed');
                     } else {
@@ -97,7 +97,7 @@
             confirmPassword() {
                 this.form.processing = true;
 
-                axios.post(route('password.confirm'), {
+                axios.post(route('password.confirm').url(), {
                     password: this.form.password,
                 }).then(response => {
                     this.confirmingPassword = false;

--- a/stubs/inertia/resources/js/Layouts/AppLayout.vue
+++ b/stubs/inertia/resources/js/Layouts/AppLayout.vue
@@ -244,7 +244,7 @@
             },
 
             logout() {
-                axios.post(route('logout')).then(response => {
+                axios.post(route('logout').url()).then(response => {
                     window.location = '/';
                 })
             },


### PR DESCRIPTION
Apparently, axios requires the URL to be a string to send the CSRF header (this doesn't seem to be a problem with Inertia though). This PR fixes the issues introduced in #314.