### PR TITLE
Correct visibility of Fortify features in profile view #321

### DIFF
--- a/stubs/livewire/resources/views/profile/show.blade.php
+++ b/stubs/livewire/resources/views/profile/show.blade.php
@@ -7,25 +7,27 @@
 
     <div>
         <div class="max-w-7xl mx-auto py-10 sm:px-6 lg:px-8">
-            @livewire('profile.update-profile-information-form')
+            @if (Laravel\Fortify\Features::enabled(Laravel\Fortify\Features::updateProfileInformation()))
+                @livewire('profile.update-profile-information-form')
+
+                <x-jet-section-border />
+            @endif
 
             @if (Laravel\Fortify\Features::enabled(Laravel\Fortify\Features::updatePasswords()))
-                <x-jet-section-border />
-            
                 <div class="mt-10 sm:mt-0">
                     @livewire('profile.update-password-form')
                 </div>
+
+                <x-jet-section-border />
             @endif
 
             @if (Laravel\Fortify\Features::canManageTwoFactorAuthentication())
-                <x-jet-section-border />
-
                 <div class="mt-10 sm:mt-0">
                     @livewire('profile.two-factor-authentication-form')
                 </div>
-            @endif
 
-            <x-jet-section-border />
+                <x-jet-section-border />
+            @endif
 
             <div class="mt-10 sm:mt-0">
                 @livewire('profile.logout-other-browser-sessions-form')


### PR DESCRIPTION
### What this PR does:
---
**Before**: On comment/disable updateProfileInformation as Fortify feature, it's still visible in profile and could get updated.
**After**: On comment/disable updateProfileInformation as Fortify feature, it's not anymore visible. Plus the `x-jet-section-border` I have moved inside the if statements. 

Checkout #321 

(My first PR for Laravel :blush: )