### PR TITLE
Give user object to update profile information form

### DIFF
--- a/stubs/inertia/resources/js/Pages/Profile/Show.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/Show.vue
@@ -9,8 +9,7 @@
         <div>
             <div class="max-w-7xl mx-auto py-10 sm:px-6 lg:px-8">
                 <update-profile-information-form
-                            :name="$page.user.name"
-                            :email="$page.user.email" />
+                    :user="$page.user" />
 
                 <jet-section-border />
 

--- a/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
@@ -20,7 +20,7 @@
 
                 <!-- Current Profile Photo -->
                 <div class="mt-2" v-show="! photoPreview">
-                    <img :src="$page.user.profile_photo_url" alt="Current Profile Photo" class="rounded-full h-20 w-20 object-cover">
+                    <img :src="user.profile_photo_url" alt="Current Profile Photo" class="rounded-full h-20 w-20 object-cover">
                 </div>
 
                 <!-- New Profile Photo Preview -->
@@ -34,7 +34,7 @@
                     Select A New Photo
                 </jet-secondary-button>
 
-                <jet-secondary-button type="button" class="mt-2" @click.native.prevent="deletePhoto" v-if="$page.user.profile_photo_path">
+                <jet-secondary-button type="button" class="mt-2" @click.native.prevent="deletePhoto" v-if="user.profile_photo_path">
                     Remove Photo
                 </jet-secondary-button>
 
@@ -88,14 +88,16 @@
             JetSecondaryButton,
         },
 
-        props: ['name', 'email'],
+        props: {
+            user: Object,
+        },
 
         data() {
             return {
                 form: this.$inertia.form({
                     '_method': 'PUT',
-                    name: this.name,
-                    email: this.email,
+                    name: this.user.name,
+                    email: this.user.email,
                     photo: null,
                 }, {
                     bag: 'updateProfileInformation',


### PR DESCRIPTION
The user profile is given name and email fields, but it would get the user photo url directly from the $page.
This makes it consistent to other components and much easier to add fields.