### PR TITLE
[1.x] Explicitly setting currentTeam relation on switchTeam to avoid refresh.

### DIFF
--- a/src/HasTeams.php
+++ b/src/HasTeams.php
@@ -45,6 +45,8 @@ trait HasTeams
             'current_team_id' => $team->id,
         ])->save();
 
+        $this->setRelation('currentTeam', $team);
+
         return true;
     }
 

--- a/tests/TeamBehaviorTest.php
+++ b/tests/TeamBehaviorTest.php
@@ -129,6 +129,31 @@ class TeamBehaviorTest extends OrchestraTestCase
         $this->assertTrue($john->hasTeamPermission($team, 'foo'));
     }
 
+    public function test_user_does_not_need_to_refresh_after_switching_teams()
+    {
+        $this->migrate();
+
+        $action = new CreateTeam;
+
+        $user = User::forceCreate([
+            'name' => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
+            'password' => 'secret',
+        ]);
+
+        $personalTeam = $action->create($user, ['name' => 'Personal Team']);
+
+        $personalTeam->forceFill(['personal_team' => true])->save();
+
+        $anotherTeam = $action->create($user, ['name' => 'Test Team']);
+
+        $this->assertTrue($user->isCurrentTeam($personalTeam));
+
+        $user->switchTeam($anotherTeam);
+
+        $this->assertTrue($user->isCurrentTeam($anotherTeam));
+    }
+
     protected function migrate()
     {
         $this->artisan('migrate', ['--database' => 'testbench'])->run();


### PR DESCRIPTION
This is probably a bit minor, but I think it adds value and saves time.

When switching the current team for the user, it's not immediately ready/accessible (if I'm doing things right) when trying to access.  That is:

```php
$personalTeam = $user->personalTeam;

$user->isCurrentTeam($personalTeam); // true

$user->switchTeam($anotherTeam);

$user->isCurrentTeam($anotherTeam); // false
```

This change simply uses `setRelation()` in `switchTeam()` (h/t: @reinink) to immediately set the relation.

AFAIK, there's no downside to this.  The relation is available, so no extra effort is needed hitting the database or anything.  The upside is that there's no need for the developer to call `fresh()` or `refresh()` or whatever....nor is there any time wasted wondering why the call to `switchTeam()` didn't appear to work as expected....which is what I experienced. 😝 

I created a test that hopefully demonstrates this in a simple manner.  The test will fail without the new line I added to `HasTeams`.

If I'm off base on this or have misunderstood something, please let me know.  If anyone has any questions/concerns, please do the same.

Thanks for Jetstream and thanks for your time...!

Much appreciated...!  🤓 