### PR TITLE
Numeric keyboard in Two Factor Challenge

### DIFF
--- a/stubs/resources/views/auth/two-factor-challenge.blade.php
+++ b/stubs/resources/views/auth/two-factor-challenge.blade.php
@@ -20,7 +20,7 @@
 
                 <div class="mt-4" x-show="! recovery">
                     <x-jet-label for="code" value="{{ __('Code') }}" />
-                    <x-jet-input id="code" class="block mt-1 w-full" type="text" name="code" autofocus x-ref="code" autocomplete="one-time-code" />
+                    <x-jet-input id="code" class="block mt-1 w-full" type="text" inputmode="numeric" name="code" autofocus x-ref="code" autocomplete="one-time-code" />
                 </div>
 
                 <div class="mt-4" x-show="recovery">


### PR DESCRIPTION
Because TOTP codes are numeric I propose hinting this `inputmode` (https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode) to the browser. 
This make entering it easier for mobile users, as only the digitblock keyboard is shown.



