### PR TITLE
Fix wrong variable used as param

### DIFF
--- a/stubs/inertia/resources/js/Pages/API/ApiTokenManager.vue
+++ b/stubs/inertia/resources/js/Pages/API/ApiTokenManager.vue
@@ -254,7 +254,7 @@
             },
 
             deleteApiToken() {
-                this.deleteApiTokenForm.delete(route('api-tokens.destroy', this.managingPermissionsFor), {
+                this.deleteApiTokenForm.delete(route('api-tokens.destroy', this.apiTokenBeingDeleted), {
                     preserveScroll: true,
                     preserveState: true,
                 }).then(() => {


### PR DESCRIPTION
A wrong variable is used at this point. 
The route which is called accepts an api token which should be deleted.