### PR TITLE
Added accessor for registers routes property

### DIFF
--- a/src/Jetstream.php
+++ b/src/Jetstream.php
@@ -379,4 +379,14 @@ class Jetstream
 
         return new static;
     }
+
+    /**
+     * Determines if Jetstream's routes should be registered.
+     *
+     * @return bool
+     */
+    public static function registersRoutes()
+    {
+        return static::$registersRoutes;
+    }
 }

--- a/src/JetstreamServiceProvider.php
+++ b/src/JetstreamServiceProvider.php
@@ -168,7 +168,7 @@ class JetstreamServiceProvider extends ServiceProvider
      */
     protected function configureRoutes()
     {
-        if (Jetstream::$registersRoutes) {
+        if (Jetstream::registersRoutes()) {
             Route::group([
                 'namespace' => 'Laravel\Jetstream\Http\Controllers',
                 'domain' => config('jetstream.domain', null),


### PR DESCRIPTION
Following the common conventions used throughout this package, this PR adds an accessor for the `$registersRoutes` property added in #67.