### PR TITLE
fix: do not show profile pic if it is disabled

### DIFF
--- a/stubs/inertia/resources/js/Layouts/AppLayout.vue
+++ b/stubs/inertia/resources/js/Layouts/AppLayout.vue
@@ -126,7 +126,7 @@
                 <!-- Responsive Settings Options -->
                 <div class="pt-4 pb-1 border-t border-gray-200">
                     <div class="flex items-center px-4">
-                        <div class="flex-shrink-0">
+                        <div class="flex-shrink-0" v-if="$page.jetstream.managesProfilePhotos">
                             <img class="h-10 w-10 rounded-full" :src="$page.user.profile_photo_url" :alt="$page.user.name" />
                         </div>
 


### PR DESCRIPTION
The profile photo is displayed in responsive setting options even with `Features::profilePhotos()` removed. This PR will hide it like the desktop version.