### PR TITLE
fix: don’t show profile pic if it’s disabled

### DIFF
--- a/stubs/inertia/resources/js/Layouts/AppLayout.vue
+++ b/stubs/inertia/resources/js/Layouts/AppLayout.vue
@@ -126,7 +126,7 @@
                 <!-- Responsive Settings Options -->
                 <div class="pt-4 pb-1 border-t border-gray-200">
                     <div class="flex items-center px-4">
-                        <div class="flex-shrink-0">
+                        <div class="flex-shrink-0" v-if="$page.jetstream.managesProfilePhotos">
                             <img class="h-10 w-10 rounded-full" :src="$page.user.profile_photo_url" :alt="$page.user.name" />
                         </div>
 

--- a/stubs/inertia/resources/js/Layouts/AppLayout.vue
+++ b/stubs/inertia/resources/js/Layouts/AppLayout.vue
@@ -130,7 +130,7 @@
                             <img class="h-10 w-10 rounded-full" :src="$page.user.profile_photo_url" :alt="$page.user.name" />
                         </div>
 
-                        <div class="ml-3">
+                        <div class="ml-3" :class="{ 'pl-1': !$page.jetstream.managesProfilePhotos }">
                             <div class="font-medium text-base text-gray-800">{{ $page.user.name }}</div>
                             <div class="font-medium text-sm text-gray-500">{{ $page.user.email }}</div>
                         </div>

--- a/stubs/livewire/resources/views/navigation-dropdown.blade.php
+++ b/stubs/livewire/resources/views/navigation-dropdown.blade.php
@@ -125,11 +125,13 @@
         <!-- Responsive Settings Options -->
         <div class="pt-4 pb-1 border-t border-gray-200">
             <div class="flex items-center px-4">
-                <div class="flex-shrink-0">
-                    <img class="h-10 w-10 rounded-full" src="{{ Auth::user()->profile_photo_url }}" alt="{{ Auth::user()->name }}" />
-                </div>
+                @if(Laravel\Jetstream\Jetstream::managesProfilePhotos())
+                    <div class="flex-shrink-0">
+                        <img class="h-10 w-10 rounded-full" src="{{ Auth::user()->profile_photo_url }}" alt="{{ Auth::user()->name }}" />
+                    </div>
+                @endif
 
-                <div class="ml-3">
+                <div class="ml-3 {{ !Laravel\Jetstream\Jetstream::managesProfilePhotos() ? 'pl-1' : '' }}">
                     <div class="font-medium text-base text-gray-800">{{ Auth::user()->name }}</div>
                     <div class="font-medium text-sm text-gray-500">{{ Auth::user()->email }}</div>
                 </div>


### PR DESCRIPTION
The profile photo is displayed in responsive layout even with Features::profilePhotos() removed. This PR will hide it from livewire and inertia, like the desktop version.