### PR TITLE
[1.x] Add Jetstream route prefix config

### DIFF
--- a/src/JetstreamServiceProvider.php
+++ b/src/JetstreamServiceProvider.php
@@ -171,6 +171,7 @@ class JetstreamServiceProvider extends ServiceProvider
             Route::group([
                 'namespace' => 'Laravel\Jetstream\Http\Controllers',
                 'domain' => config('jetstream.domain', null),
+                'prefix' => config('jetstream.path', null),
             ], function () {
                 $this->loadRoutesFrom(__DIR__.'/../routes/'.config('jetstream.stack').'.php');
             });


### PR DESCRIPTION
This PR adds config for prefixing jetstream routes in the same pattern that is used in Laravel Fortify route binding.

This allows adding prefix like /admin to routes if the application requires changes in url structure.