### PR TITLE
[1.x] Lock inertiajs/inertia-laravel to ^0.2.4

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -248,7 +248,7 @@ EOF;
     protected function installInertiaStack()
     {
         // Install Inertia...
-        (new Process(['composer', 'require', 'inertiajs/inertia-laravel', 'laravel/sanctum:^2.6', 'tightenco/ziggy'], base_path()))
+        (new Process(['composer', 'require', 'inertiajs/inertia-laravel:^0.2.4', 'laravel/sanctum:^2.6', 'tightenco/ziggy'], base_path()))
                 ->setTimeout(null)
                 ->run(function ($type, $output) {
                     $this->output->write($output);


### PR DESCRIPTION
This prevents issues with `PUT`/`POST`/`PATCH` requests due to the Middleware changes introduced in `inertiajs/inertia-laravel` `^0.3`. This is not an issue on `master`, because on that version these changes are already implemented (#327)

See https://twitter.com/don_jon243/status/1318926992645959683 for more info