### PR TITLE
[2.x] Align min. inertiajs/inertia-laravel version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "laravel/fortify": "^1.6.1"
     },
     "require-dev": {
-        "inertiajs/inertia-laravel": "^0.2.4",
+        "inertiajs/inertia-laravel": "^0.3",
         "laravel/sanctum": "^2.6",
         "mockery/mockery": "^1.0",
         "orchestra/testbench": "^6.0",


### PR DESCRIPTION
Because of changes implemented in #326, the minimum `inertiajs/inertia-laravel` version [is now `^0.3`](https://github.com/laravel/jetstream/pull/327/files#diff-5cffa5eda5bfb718c5f416e0c6e95cf6913e8a092d70581ec5f3e1dfae349941R233). 

This however isn't reflected in the `composer.json`, which might cause issues with existing installs as well as with what's displayed on packagist. Apologies for not catching this earlier!