### PR TITLE
[1.x] Update webpack.mix.js to use const instead of require

### DIFF
--- a/stubs/webpack.mix.js
+++ b/stubs/webpack.mix.js
@@ -1,5 +1,5 @@
 const mix = require('laravel-mix');
-const config = require('.webpack.config');
+const config = require('./webpack.config');
 
 /*
  |--------------------------------------------------------------------------

--- a/stubs/webpack.mix.js
+++ b/stubs/webpack.mix.js
@@ -1,4 +1,5 @@
 const mix = require('laravel-mix');
+const config = require('.webpack.config');
 
 /*
  |--------------------------------------------------------------------------
@@ -16,4 +17,4 @@ mix.js('resources/js/app.js', 'public/js')
         require('postcss-import'),
         require('tailwindcss'),
     ])
-    .webpackConfig(require('./webpack.config'));
+    .webpackConfig(config);


### PR DESCRIPTION
This commit adds a `const` for `webpack.config.js` for more readability in the code. 

I know this may seem futile and pointless, but I think not using require in the middle of a file is better
