### PR TITLE
[1.x] Make livewire modal scrollable

### DIFF
--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -41,6 +41,13 @@ switch ($maxWidth ?? '2xl') {
         nextFocusableIndex() { return (this.focusables().indexOf(document.activeElement) + 1) % (this.focusables().length + 1) },
         prevFocusableIndex() { return Math.max(0, this.focusables().indexOf(document.activeElement)) -1 },
     }"
+    x-init="$watch('show', value => {
+        if (value) {
+            document.body.classList.add('overflow-y-hidden');
+        } else {
+            document.body.classList.remove('overflow-y-hidden');
+        }
+    })"
     x-on:close.stop="show = false"
     x-on:keydown.escape.window="show = false"
     x-on:keydown.tab.prevent="$event.shiftKey || nextFocusable().focus()"

--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -54,7 +54,7 @@ switch ($maxWidth ?? '2xl') {
     x-on:keydown.shift.tab.prevent="prevFocusable().focus()"
     x-show="show"
     id="{{ $id }}"
-    class="fixed top-0 inset-x-0 px-4 pt-6 z-50 sm:px-0"
+    class="fixed inset-0 overflow-y-auto px-4 py-6 z-50 sm:px-0"
     style="display: none;"
 >
     <div x-show="show" class="fixed inset-0 transform transition-all" x-on:click="show = false" x-transition:enter="ease-out duration-300"

--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -54,7 +54,7 @@ switch ($maxWidth ?? '2xl') {
     x-on:keydown.shift.tab.prevent="prevFocusable().focus()"
     x-show="show"
     id="{{ $id }}"
-    class="fixed top-0 inset-x-0 px-4 pt-6 z-50 sm:px-0 sm:flex sm:items-top sm:justify-center"
+    class="fixed top-0 inset-x-0 px-4 pt-6 z-50 sm:px-0"
     style="display: none;"
 >
     <div x-show="show" class="fixed inset-0 transform transition-all" x-on:click="show = false" x-transition:enter="ease-out duration-300"
@@ -66,7 +66,7 @@ switch ($maxWidth ?? '2xl') {
         <div class="absolute inset-0 bg-gray-500 opacity-75"></div>
     </div>
 
-    <div x-show="show" class="bg-white rounded-lg overflow-hidden shadow-xl transform transition-all sm:w-full {{ $maxWidth }}"
+    <div x-show="show" class="bg-white rounded-lg overflow-hidden shadow-xl transform transition-all sm:w-full {{ $maxWidth }} sm:mx-auto"
                     x-transition:enter="ease-out duration-300"
                     x-transition:enter-start="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
                     x-transition:enter-end="opacity-100 translate-y-0 sm:scale-100"

--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -54,7 +54,7 @@ switch ($maxWidth ?? '2xl') {
     x-on:keydown.shift.tab.prevent="prevFocusable().focus()"
     x-show="show"
     id="{{ $id }}"
-    class="fixed inset-0 overflow-y-auto px-4 py-6 z-50 sm:px-0"
+    class="fixed inset-0 overflow-y-auto px-4 pt-6 z-50 sm:px-0"
     style="display: none;"
 >
     <div x-show="show" class="fixed inset-0 transform transition-all" x-on:click="show = false" x-transition:enter="ease-out duration-300"
@@ -66,7 +66,7 @@ switch ($maxWidth ?? '2xl') {
         <div class="absolute inset-0 bg-gray-500 opacity-75"></div>
     </div>
 
-    <div x-show="show" class="bg-white rounded-lg overflow-hidden shadow-xl transform transition-all sm:w-full {{ $maxWidth }} sm:mx-auto"
+    <div x-show="show" class="mb-6 bg-white rounded-lg overflow-hidden shadow-xl transform transition-all sm:w-full {{ $maxWidth }} sm:mx-auto"
                     x-transition:enter="ease-out duration-300"
                     x-transition:enter-start="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
                     x-transition:enter-end="opacity-100 translate-y-0 sm:scale-100"

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -248,7 +248,7 @@ EOF;
     protected function installInertiaStack()
     {
         // Install Inertia...
-        (new Process(['composer', 'require', 'inertiajs/inertia-laravel', 'laravel/sanctum:^2.6', 'tightenco/ziggy'], base_path()))
+        (new Process(['composer', 'require', 'inertiajs/inertia-laravel:^0.2.4', 'laravel/sanctum:^2.6', 'tightenco/ziggy'], base_path()))
                 ->setTimeout(null)
                 ->run(function ($type, $output) {
                     $this->output->write($output);

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -248,7 +248,7 @@ EOF;
     protected function installInertiaStack()
     {
         // Install Inertia...
-        (new Process(['composer', 'require', 'inertiajs/inertia-laravel:^0.2.4', 'laravel/sanctum:^2.6', 'tightenco/ziggy'], base_path()))
+        (new Process(['composer', 'require', 'inertiajs/inertia-laravel', 'laravel/sanctum:^2.6', 'tightenco/ziggy'], base_path()))
                 ->setTimeout(null)
                 ->run(function ($type, $output) {
                     $this->output->write($output);

--- a/stubs/inertia/resources/js/Jetstream/Modal.vue
+++ b/stubs/inertia/resources/js/Jetstream/Modal.vue
@@ -1,7 +1,7 @@
 <template>
     <portal to="modal">
         <transition leave-active-class="duration-200">
-            <div v-show="show" class="fixed top-0 inset-x-0 px-4 pt-6 sm:px-0 sm:flex sm:items-top sm:justify-center">
+            <div v-show="show" class="fixed top-0 inset-x-0 px-4 pt-6 sm:px-0">
                 <transition enter-active-class="ease-out duration-300"
                         enter-class="opacity-0"
                         enter-to-class="opacity-100"
@@ -19,7 +19,7 @@
                         leave-active-class="ease-in duration-200"
                         leave-class="opacity-100 translate-y-0 sm:scale-100"
                         leave-to-class="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95">
-                    <div v-show="show" class="bg-white rounded-lg overflow-hidden shadow-xl transform transition-all sm:w-full" :class="maxWidthClass">
+                    <div v-show="show" class="bg-white rounded-lg overflow-hidden shadow-xl transform transition-all sm:w-full sm:mx-auto" :class="maxWidthClass">
                         <slot></slot>
                     </div>
                 </transition>

--- a/stubs/inertia/resources/js/Jetstream/Modal.vue
+++ b/stubs/inertia/resources/js/Jetstream/Modal.vue
@@ -19,7 +19,7 @@
                         leave-active-class="ease-in duration-200"
                         leave-class="opacity-100 translate-y-0 sm:scale-100"
                         leave-to-class="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95">
-                    <div v-show="show" class="bg-white rounded-lg overflow-hidden shadow-xl transform transition-all sm:w-full sm:mx-auto" :class="maxWidthClass">
+                    <div v-show="show" class="mb-6 bg-white rounded-lg overflow-hidden shadow-xl transform transition-all sm:w-full sm:mx-auto" :class="maxWidthClass">
                         <slot></slot>
                     </div>
                 </transition>

--- a/stubs/inertia/resources/js/Jetstream/Modal.vue
+++ b/stubs/inertia/resources/js/Jetstream/Modal.vue
@@ -1,7 +1,7 @@
 <template>
     <portal to="modal">
         <transition leave-active-class="duration-200">
-            <div v-show="show" class="fixed top-0 inset-x-0 px-4 pt-6 sm:px-0">
+            <div v-show="show" class="fixed inset-0 overflow-y-auto px-4 pt-6 sm:px-0">
                 <transition enter-active-class="ease-out duration-300"
                         enter-class="opacity-0"
                         enter-to-class="opacity-100"


### PR DESCRIPTION
## The problem

When using `x-jet-dialog-modal` on mobile and if the dialog has a lot of content you can't scroll to reach the content that doesn't fit in the screen.
Also the body of the document scrolls when modal is open.


## The solution

This PR makes Modal scrollable when it is taller than the screen.

It is based on the #305 (it just disabled the body scrolling when modal is open) but also makes the modal itself scrollable.

It contains a hack for Firefox that can't work with `padding bottom` and `overflow: auto` as described on [SO](https://stackoverflow.com/a/38177668/3071884).

P.S. During the testing I have noticed that there's `sm:items-top` class that doesn't even exist. It should be `sm:items-start`.
Thinking about it - these classes just make the modal centered horizontally on larger screens`sm:flex sm:items-start sm:justify-center`. 
We can achieve the same with just `sm:mx-auto` on the child element. And it will also help with the bottom space mentioned above. When we use `flex` the hack doesn't work.

## How to test the PR

I tested this PR locally on Windows in fresh Chrome and Firefox.

You might want to recompile your assets to make sure that the classes I use here were not purged.
And you might want to _hard refresh_ browser page Ctrl+F5 to prevent it using cached version of the `app.css`.

To test this PR I created a fresh Laravel project with Livewire stack.

```bash
laravel new jetstream-test --jet --stack=livewire
```

Set up your local database
```env
DB_CONNECTION=sqlite
```

```bash
touch database/database.sqlite
php artisan migrate
```
 
Create a Livewire component

```bash
php artisan livewire:make TestModal
```

Edit the component and the view
```php
class TestModal extends Component
{
    public $isOpen = false; // Add this public property

    public function render()
    {
        return view('livewire.test-modal');
    }
}
```

```blade
<div class="p-6">
    <x-jet-button wire:click="$set('isOpen', true)">Open Modal</x-jet-button>

    <x-jet-dialog-modal wire:model="isOpen">
        <x-slot name="title">Title</x-slot>

        <x-slot name="content">
            <div class="space-y-32">
                <div>Content</div>
                <div>Content</div>
                <div>Content</div>
                <div>Content</div>
                <div>Content</div>
                <div>Content</div>
                <div>Content</div>
                <div>Content</div>
                <div>Content</div>
            </div>
        </x-slot>

        <x-slot name="footer">
            <x-jet-secondary-button wire:click="$toggle('isOpen')" wire:loading.attr="disabled">Close</x-jet-secondary-button>
        </x-slot>
    </x-jet-dialog-modal>
</div>
```

Prepare the welcome page to use the modal

```blade
{{-- resources\views\welcome.blade.php --}}
<x-app-layout>
    <x-slot name="header">
        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
            {{ __('Dashboard') }}
        </h2>
    </x-slot>

    <div class="py-6 pb-64">
        @livewire('test-modal')
    </div>
</x-app-layout>
```

Don't forget to add a repository to the `composer.json` as described [here](https://getcomposer.org/doc/05-repositories.md#path)

Run the website `php artisan server` and open http://127.0.0.1:8000/ in your browser.

Make the browser window smaller and this is what you should see
![изображение](https://user-images.githubusercontent.com/17148882/96843794-64c0cf80-1457-11eb-979b-48af8090f22d.png)

Click the button and try to scroll the modal.

![изображение](https://user-images.githubusercontent.com/17148882/96843940-9174e700-1457-11eb-8bd2-696e4c2a87ba.png)

![изображение](https://user-images.githubusercontent.com/17148882/96843967-9afe4f00-1457-11eb-9a02-235ad51a918c.png)

Notice that the body of the document doesn't scroll when modal is open.

Hope you'll like it.