### PR TITLE
[1.x] Make team show use policies

### DIFF
--- a/src/Http/Controllers/Inertia/TeamController.php
+++ b/src/Http/Controllers/Inertia/TeamController.php
@@ -25,7 +25,7 @@ class TeamController extends Controller
     {
         $team = Jetstream::newTeamModel()->findOrFail($teamId);
 
-        if (Gate::denies('show', $team)) {
+        if (Gate::denies('view', $team)) {
             abort(403);
         }
 

--- a/src/Http/Controllers/Inertia/TeamController.php
+++ b/src/Http/Controllers/Inertia/TeamController.php
@@ -25,7 +25,7 @@ class TeamController extends Controller
     {
         $team = Jetstream::newTeamModel()->findOrFail($teamId);
 
-        if (Gate::denies('show', $team )) {
+        if (Gate::denies('show', $team)) {
             abort(403);
         }
 

--- a/src/Http/Controllers/Inertia/TeamController.php
+++ b/src/Http/Controllers/Inertia/TeamController.php
@@ -25,7 +25,7 @@ class TeamController extends Controller
     {
         $team = Jetstream::newTeamModel()->findOrFail($teamId);
 
-        if(Gate::denies('show', $team )) {
+        if (Gate::denies('show', $team )) {
             abort(403);
         }
 

--- a/src/Http/Controllers/Inertia/TeamController.php
+++ b/src/Http/Controllers/Inertia/TeamController.php
@@ -25,7 +25,7 @@ class TeamController extends Controller
     {
         $team = Jetstream::newTeamModel()->findOrFail($teamId);
 
-        if (! $request->user()->belongsToTeam($team)) {
+        if(Gate::denies('show', $team )) {
             abort(403);
         }
 

--- a/src/Http/Controllers/Livewire/TeamController.php
+++ b/src/Http/Controllers/Livewire/TeamController.php
@@ -20,7 +20,7 @@ class TeamController extends Controller
     {
         $team = Jetstream::newTeamModel()->findOrFail($teamId);
 
-        if (Gate::denies('show', $team)) {
+        if (Gate::denies('view', $team)) {
             abort(403);
         }
 

--- a/src/Http/Controllers/Livewire/TeamController.php
+++ b/src/Http/Controllers/Livewire/TeamController.php
@@ -4,6 +4,7 @@ namespace Laravel\Jetstream\Http\Controllers\Livewire;
 
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Gate;
 use Laravel\Jetstream\Jetstream;
 
 class TeamController extends Controller
@@ -19,7 +20,7 @@ class TeamController extends Controller
     {
         $team = Jetstream::newTeamModel()->findOrFail($teamId);
 
-        if (! $request->user()->belongsToTeam($team)) {
+        if(Gate::denies('show', $team )) {
             abort(403);
         }
 

--- a/src/Http/Controllers/Livewire/TeamController.php
+++ b/src/Http/Controllers/Livewire/TeamController.php
@@ -20,7 +20,7 @@ class TeamController extends Controller
     {
         $team = Jetstream::newTeamModel()->findOrFail($teamId);
 
-        if(Gate::denies('show', $team )) {
+        if (Gate::denies('show', $team )) {
             abort(403);
         }
 

--- a/src/Http/Controllers/Livewire/TeamController.php
+++ b/src/Http/Controllers/Livewire/TeamController.php
@@ -20,7 +20,7 @@ class TeamController extends Controller
     {
         $team = Jetstream::newTeamModel()->findOrFail($teamId);
 
-        if (Gate::denies('show', $team )) {
+        if (Gate::denies('show', $team)) {
             abort(403);
         }
 


### PR DESCRIPTION
### Problem

I have a need to customise whether a team should be shown. At the moment, the `TeamController` show method checks if the user `belongsToTeam` and aborts if not:

**Http\Inertia\TeamController**
**Http\LIvewire\TeamController**

```php
public function show(Request $request, $teamId)
{
        $team = Jetstream::newTeamModel()->findOrFail($teamId);

        if (! $request->user()->belongsToTeam($team)) {
            abort(403);
        }

        return view('teams.show', [
            'user' => $request->user(),
            'team' => $team,
        ]);
}
```

If I want to change this, I would need to override the `TeamController` show method rather than use the original.

### Solution

I inspected the code and noted that the stub and test fixture for the `TeamPolicy` already checks for `belongsToTeam`:

```php
public function view(User $user, Team $team)
{
        return $user->belongsToTeam($team);
}
```

With that in mind, I changed the Livewire and Inertia controllers to the following code so that it uses the policy, thus allowing the developer to customise the access policy. The tests still pass.

**From**
```php
if (! $request->user()->belongsToTeam($team)) {
      abort(403);
}
```

**To**
```php
if(Gate::denies('view', $team )) {
       abort(403);
}
```