### PR TITLE
[1.x] Adds custom redirects after creating or deleting a team

### DIFF
--- a/src/Http/Controllers/Inertia/TeamController.php
+++ b/src/Http/Controllers/Inertia/TeamController.php
@@ -11,9 +11,12 @@ use Laravel\Jetstream\Contracts\CreatesTeams;
 use Laravel\Jetstream\Contracts\DeletesTeams;
 use Laravel\Jetstream\Contracts\UpdatesTeamNames;
 use Laravel\Jetstream\Jetstream;
+use Laravel\Jetstream\RedirectsActions;
 
 class TeamController extends Controller
 {
+    use RedirectsActions;
+
     /**
      * Show the team management screen.
      *
@@ -62,9 +65,11 @@ class TeamController extends Controller
      */
     public function store(Request $request)
     {
-        app(CreatesTeams::class)->create($request->user(), $request->all());
+        $creator = app(CreatesTeams::class);
 
-        return redirect(config('fortify.home'));
+        $creator->create($request->user(), $request->all());
+
+        return redirect($this->redirectPath($creator));
     }
 
     /**
@@ -96,8 +101,10 @@ class TeamController extends Controller
 
         app(ValidateTeamDeletion::class)->validate($request->user(), $team);
 
-        app(DeletesTeams::class)->delete($team);
+        $deleter = app(DeletesTeams::class);
 
-        return redirect(config('fortify.home'));
+        $deleter->delete($team);
+
+        return redirect($this->redirectPath($deleter));
     }
 }

--- a/src/Http/Livewire/CreateTeamForm.php
+++ b/src/Http/Livewire/CreateTeamForm.php
@@ -4,10 +4,13 @@ namespace Laravel\Jetstream\Http\Livewire;
 
 use Illuminate\Support\Facades\Auth;
 use Laravel\Jetstream\Contracts\CreatesTeams;
+use Laravel\Jetstream\RedirectsActions;
 use Livewire\Component;
 
 class CreateTeamForm extends Component
 {
+    use RedirectsActions;
+
     /**
      * The component's state.
      *
@@ -27,7 +30,7 @@ class CreateTeamForm extends Component
 
         $creator->create(Auth::user(), $this->state);
 
-        return redirect(config('fortify.home'));
+        return redirect($this->redirectPath($creator));
     }
 
     /**

--- a/src/Http/Livewire/DeleteTeamForm.php
+++ b/src/Http/Livewire/DeleteTeamForm.php
@@ -47,7 +47,7 @@ class DeleteTeamForm extends Component
 
         $deleter->delete($this->team);
 
-        return redirect(config('fortify.home'));
+        return redirect($this->redirectPath($deleter));
     }
 
     /**

--- a/src/RedirectsActions.php
+++ b/src/RedirectsActions.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Laravel\Jetstream;
+
+trait RedirectsActions
+{
+    /**
+     * Get the redirect path for the action.
+     *
+     * @param $action
+     * @return string
+     */
+    public function redirectPath($action)
+    {
+        if (method_exists($action, 'redirectTo')) {
+            return $action->redirectTo();
+        }
+
+        return property_exists($action, 'redirectTo') ? $action->redirectTo : config('fortify.home');
+    }
+}


### PR DESCRIPTION
### Problem

In the application I'm developing, I would like the user to be redirected to a specific page after creating or deleting a team. Currently when a new team is created or deleted, the user is redirected to path defined by the `fortify.home` configuration variable. 

### Solution

In Laravel (without Jetstream) this is accomplished by implementing the `redirectTo()` method or a `$redirectTo` property on the LoginController, ResetPasswordController, etc...

My proposal is to allow customization of the redirects by allowing a `redirectTo()` method or a `$redirectTo` property on the following actions.

- CreatesTeams
- DeletesTeams

The consuming controllers would look for the existence of `redirectTo()` on the action and use it, otherwise default to `fortify.home`.

