### PR TITLE
[2.x] Simplify banner component

### DIFF
--- a/resources/views/components/banner.blade.php
+++ b/resources/views/components/banner.blade.php
@@ -19,13 +19,7 @@
                     </svg>
                 </span>
 
-                <p class="ml-3 font-medium text-sm text-white truncate">
-                    <span class="md:hidden" x-text="message">
-                    </span>
-
-                    <span class="hidden md:inline" x-text="message">
-                    </span>
-                </p>
+                <p class="ml-3 font-medium text-sm text-white truncate" x-text="message"></p>
             </div>
 
             <div class="flex-shrink-0 sm:ml-3">

--- a/resources/views/components/banner.blade.php
+++ b/resources/views/components/banner.blade.php
@@ -12,7 +12,7 @@
             ">
     <div class="max-w-screen-xl mx-auto py-2 px-3 sm:px-6 lg:px-8">
         <div class="flex items-center justify-between flex-wrap">
-            <div class="w-0 flex-1 flex items-center">
+            <div class="w-0 flex-1 flex items-center min-w-0">
                 <span class="flex p-2 rounded-lg" :class="{ 'bg-indigo-600': style == 'success', 'bg-red-600': style == 'danger' }">
                     <svg class="h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />

--- a/stubs/inertia/resources/js/Jetstream/Banner.vue
+++ b/stubs/inertia/resources/js/Jetstream/Banner.vue
@@ -3,7 +3,7 @@
         <div :class="{ 'bg-indigo-500': style == 'success', 'bg-red-700': style == 'danger' }" v-if="show && message">
             <div class="max-w-screen-xl mx-auto py-2 px-3 sm:px-6 lg:px-8">
                 <div class="flex items-center justify-between flex-wrap">
-                    <div class="w-0 flex-1 flex items-center">
+                    <div class="w-0 flex-1 flex items-center min-w-0">
                         <span class="flex p-2 rounded-lg" :class="{ 'bg-indigo-600': style == 'success', 'bg-red-600': style == 'danger' }">
                             <svg class="h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" v-if="style == 'success'">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />

--- a/stubs/inertia/resources/js/Jetstream/Banner.vue
+++ b/stubs/inertia/resources/js/Jetstream/Banner.vue
@@ -15,13 +15,7 @@
                         </span>
 
                         <p class="ml-3 font-medium text-sm text-white truncate">
-                            <span class="md:hidden">
-                                {{ message }}
-                            </span>
-
-                            <span class="hidden md:inline">
-                                {{ message }}
-                            </span>
+                            {{ message }}
                         </p>
                     </div>
 


### PR DESCRIPTION
There is no need to wrap the message in `<span>` tag (and duplicate the content) because it's always visible, no matter of screen size.

Also, the message wasn't truncated in Firefox, and I fixed it by using `min-w-0` class on the parent element.

**Make sure to recompile the assets before testing.**

| Before 	| After 	|
|-	|-	|
| ![Zrzut ekranu 2020-10-23 o 23 24 38](https://user-images.githubusercontent.com/98191/97055638-84571580-1587-11eb-89fa-ca962f63d4cd.png) 	| ![Zrzut ekranu 2020-10-23 o 23 24 53](https://user-images.githubusercontent.com/98191/97055642-87520600-1587-11eb-877f-3dc7f92e5fab.png) 	|