### PR TITLE
[1.x] Slot Empty Checking & Return Default Value

### DIFF
--- a/resources/views/components/action-message.blade.php
+++ b/resources/views/components/action-message.blade.php
@@ -5,5 +5,5 @@
     x-show.transition.opacity.out.duration.1500ms="shown"
     style="display: none;"
     {{ $attributes->merge(['class' => 'text-sm text-gray-600']) }}>
-    {{ $slot->isEmpty() ? 'Saved.' : $slot}}
+    {{ $slot->isEmpty() ? 'Saved.' : $slot }}
 </div>

--- a/resources/views/components/action-message.blade.php
+++ b/resources/views/components/action-message.blade.php
@@ -5,5 +5,5 @@
     x-show.transition.opacity.out.duration.1500ms="shown"
     style="display: none;"
     {{ $attributes->merge(['class' => 'text-sm text-gray-600']) }}>
-    {{ $slot ?? 'Saved.' }}
+    {{ $slot->isEmpty() ? 'Saved.' : $slot}}
 </div>


### PR DESCRIPTION
Component slot return always HtmlString. That's why while using <x-action-message on="saved" /> isset isn't checking & default 'saved.' text not showing. isEmpty() check could show default message.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
