### PR TITLE
[2.x] Update for Ziggy v1

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -226,7 +226,7 @@ EOF;
     protected function installInertiaStack()
     {
         // Install Inertia...
-        $this->requireComposerPackages('inertiajs/inertia-laravel:^0.3', 'laravel/sanctum:^2.6', 'tightenco/ziggy');
+        $this->requireComposerPackages('inertiajs/inertia-laravel:^0.3', 'laravel/sanctum:^2.6', 'tightenco/ziggy:^1.0');
 
         // Install NPM packages...
         $this->updateNodePackages(function ($packages) {

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -230,7 +230,7 @@ EOF;
     protected function installInertiaStack()
     {
         // Install Inertia...
-        (new Process(['composer', 'require', 'inertiajs/inertia-laravel:^0.3', 'laravel/sanctum:^2.6', 'tightenco/ziggy'], base_path()))
+        (new Process(['composer', 'require', 'inertiajs/inertia-laravel:^0.3', 'laravel/sanctum:^2.6', 'tightenco/ziggy:^1.0'], base_path()))
                 ->setTimeout(null)
                 ->run(function ($type, $output) {
                     $this->output->write($output);

--- a/stubs/inertia/resources/js/Jetstream/ConfirmsPassword.vue
+++ b/stubs/inertia/resources/js/Jetstream/ConfirmsPassword.vue
@@ -80,7 +80,7 @@
             startConfirmingPassword() {
                 this.form.error = '';
 
-                axios.get(route('password.confirmation').url()).then(response => {
+                axios.get(route('password.confirmation')).then(response => {
                     if (response.data.confirmed) {
                         this.$emit('confirmed');
                     } else {
@@ -97,7 +97,7 @@
             confirmPassword() {
                 this.form.processing = true;
 
-                axios.post(route('password.confirm').url(), {
+                axios.post(route('password.confirm'), {
                     password: this.form.password,
                 }).then(response => {
                     this.confirmingPassword = false;


### PR DESCRIPTION
This PR makes Jetstream's Inertia preset compatible with Ziggy v1, which will be released shortly.

I _think_ this has to target Jetstream v2, because for anyone who has already installed Jetstream (and therefore Ziggy v0.9.4), this would be a breaking change that would require them to manually upgrade their whole app to Ziggy v1. If Jetstream users publish all these components immediately, and changing them here would not update them for existing installs, then I guess technically it isn't a breaking change, but I think it could still be confusing.

Since the Inertia preset installs `tightenco/ziggy` with no version constraint, it will start installing Ziggy v1 as soon as it's tagged, so ideally this change would be merged right after we tag it. I'm opening a PR now so that it's on your radar and we don't miss the Jetstream v2 bus—my plan is to tag Ziggy v1 in the next week or two at most, and I'll mark this PR ready for review as soon as I do.

For details about v1 see Ziggy's [Changelog](https://github.com/tighten/ziggy/tree/develop/CHANGELOG.md) and [`0.9.x` → `1.0.0` Upgrade Guide](https://github.com/tighten/ziggy/blob/jbk/upgrading/UPGRADING.md) (draft). Thanks!