### PR TITLE
[1.x] Constrain Ziggy version to ^0.9.4

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -248,7 +248,7 @@ EOF;
     protected function installInertiaStack()
     {
         // Install Inertia...
-        (new Process(['composer', 'require', 'inertiajs/inertia-laravel:^0.2.4', 'laravel/sanctum:^2.6', 'tightenco/ziggy'], base_path()))
+        (new Process(['composer', 'require', 'inertiajs/inertia-laravel:^0.2.4', 'laravel/sanctum:^2.6', 'tightenco/ziggy:^0.9.4'], base_path()))
                 ->setTimeout(null)
                 ->run(function ($type, $output) {
                     $this->output->write($output);


### PR DESCRIPTION
Related to #392, this PR ensures that Jetstream v1 will install Ziggy `^0.9.4` (current as of today), _not_ Ziggy v1.

@mattstauffer pointed out that if a user adds Jetstream to their project now but doesn't run the `install` command for a month, they'll get Ziggy v1 which isn't compatible with Jetstream v1. Adding this version constraint will prevent that.