### PR TITLE
[1.x] Fix Livewire Modal Closing Issue By Bumping Alpine To 2.7.3

### DIFF
--- a/stubs/livewire/resources/views/layouts/app.blade.php
+++ b/stubs/livewire/resources/views/layouts/app.blade.php
@@ -16,7 +16,7 @@
         @livewireStyles
 
         <!-- Scripts -->
-        <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.7.0/dist/alpine.js" defer></script>
+        <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.7.3/dist/alpine.js" defer></script>
     </head>
     <body class="font-sans antialiased">
         <div class="min-h-screen bg-gray-100">

--- a/stubs/resources/views/layouts/guest.blade.php
+++ b/stubs/resources/views/layouts/guest.blade.php
@@ -14,7 +14,7 @@
         <link rel="stylesheet" href="{{ asset('css/app.css') }}">
 
         <!-- Scripts -->
-        <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.7.0/dist/alpine.js" defer></script>
+        <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.7.3/dist/alpine.js" defer></script>
     </head>
     <body>
         <div class="font-sans text-gray-900 antialiased">


### PR DESCRIPTION
Closes #384 

The issue where modals transition in, but not out when Livewire is the one to trigger the state change has been fixed in the latest versions of Livewire and Alpine:

Livewire: v2.3.1
Alpine: v2.7.3

The original issue should be partially fixed in older versions of Alpine (for existing installs), but a few more edge cases have been addressed that will only be fixed for people running Alpine 2.7.3 and above.

Namely, without 2.7.3 there are few transition interruption edge cases.

For example: if a user closes a modal in Jetstream, and while it's transitioning out, they somehow re-open it, it will disappear.

I'm not even sure if this case is possible to re-create in Jetstream, but just noting it here.