### PR TITLE
[1.x] Remove unused import

### DIFF
--- a/stubs/inertia/resources/js/Layouts/AppLayout.vue
+++ b/stubs/inertia/resources/js/Layouts/AppLayout.vue
@@ -211,7 +211,6 @@
 </template>
 
 <script>
-    import JetApplicationLogo from '@/Jetstream/ApplicationLogo'
     import JetApplicationMark from '@/Jetstream/ApplicationMark'
     import JetDropdown from '@/Jetstream/Dropdown'
     import JetDropdownLink from '@/Jetstream/DropdownLink'
@@ -220,7 +219,6 @@
 
     export default {
         components: {
-            JetApplicationLogo,
             JetApplicationMark,
             JetDropdown,
             JetDropdownLink,


### PR DESCRIPTION
The `ApplicationLogo` component is not used in the layout, so it's safe to remove the import.