### PR TITLE
Delete user tokens when user is deleted

### DIFF
--- a/stubs/app/Actions/Jetstream/DeleteUser.php
+++ b/stubs/app/Actions/Jetstream/DeleteUser.php
@@ -15,6 +15,7 @@ class DeleteUser implements DeletesUsers
     public function delete($user)
     {
         $user->deleteProfilePhoto();
+        $user->tokens->each->delete();
         $user->delete();
     }
 }

--- a/stubs/app/Actions/Jetstream/DeleteUserWithTeams.php
+++ b/stubs/app/Actions/Jetstream/DeleteUserWithTeams.php
@@ -37,6 +37,7 @@ class DeleteUser implements DeletesUsers
         DB::transaction(function () use ($user) {
             $this->deleteTeams($user);
             $user->deleteProfilePhoto();
+            $user->tokens->each->delete();
             $user->delete();
         });
     }


### PR DESCRIPTION
Currently if a user is deleted, their api tokens will remain inside the database. The api tokens are now deleted at the same time the user will be deleted.