### PR TITLE
[1.x] Fix composer memory limit crashes

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -113,11 +113,7 @@ class InstallCommand extends Command
     protected function installLivewireStack()
     {
         // Install Livewire...
-        (new Process(['composer', 'require', 'livewire/livewire:^2.0', 'laravel/sanctum:^2.6'], base_path()))
-                ->setTimeout(null)
-                ->run(function ($type, $output) {
-                    $this->output->write($output);
-                });
+        $this->requireComposerPackages('livewire/livewire:^2.0', 'laravel/sanctum:^2.6');
 
         // Sanctum...
         (new Process(['php', 'artisan', 'vendor:publish', '--provider=Laravel\Sanctum\SanctumServiceProvider', '--force'], base_path()))
@@ -248,11 +244,7 @@ EOF;
     protected function installInertiaStack()
     {
         // Install Inertia...
-        (new Process(['composer', 'require', 'inertiajs/inertia-laravel:^0.2.4', 'laravel/sanctum:^2.6', 'tightenco/ziggy:^0.9.4'], base_path()))
-                ->setTimeout(null)
-                ->run(function ($type, $output) {
-                    $this->output->write($output);
-                });
+        $this->requireComposerPackages('inertiajs/inertia-laravel:^0.2.4', 'laravel/sanctum:^2.6', 'tightenco/ziggy:^0.9.4');
 
         // Install NPM packages...
         $this->updateNodePackages(function ($packages) {
@@ -441,6 +433,26 @@ EOF;
                 $appConfig
             ));
         }
+    }
+
+    /**
+     * Installs the given Composer Packages into the application.
+     *
+     * @param  mixed  $package
+     * @return void
+     */
+    protected function requireComposerPackages($package)
+    {
+        $command = array_merge(
+            ['composer', 'require'],
+            is_array($package) ? $package : func_get_args()
+        );
+
+        (new Process($command, base_path(), ['COMPOSER_MEMORY_LIMIT' => '-1']))
+            ->setTimeout(null)
+            ->run(function ($type, $output) {
+                $this->output->write($output);
+            });
     }
 
     /**

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -438,14 +438,14 @@ EOF;
     /**
      * Installs the given Composer Packages into the application.
      *
-     * @param  mixed  $package
+     * @param  mixed  $packages
      * @return void
      */
-    protected function requireComposerPackages($package)
+    protected function requireComposerPackages($packages)
     {
         $command = array_merge(
             ['composer', 'require'],
-            is_array($package) ? $package : func_get_args()
+            is_array($packages) ? $packages : func_get_args()
         );
 
         (new Process($command, base_path(), ['COMPOSER_MEMORY_LIMIT' => '-1']))


### PR DESCRIPTION
This PR fixes an issue where Composer (1.x?) runs out of memory while Jetstream installs stack-dependent packages.
I personally ran into this issue a few weeks ago, but after seeing others on the Inertia.js discord run into it today, I decided to PR it.

Basically, what they'll see is the following:
```
Fatal error: Allowed memory size of 1610612736 bytes exhausted (tried to allocate 4096 bytes) in phar:///usr/local/Cellar/composer/1.10.8/bin/composer/src/Composer/DependencyResolver/RuleWatchGraph.php on line 52
PHP Fatal error:  Allowed memory size of 1610612736 bytes exhausted (tried to allocate 4096 bytes) in phar:///usr/local/Cellar/composer/1.10.8/bin/composer/src/Composer/DependencyResolver/RuleWatchGraph.php on line 52
```

By setting the [`COMPOSER_MEMORY_LIMIT=-1`](https://getcomposer.org/doc/articles/troubleshooting.md#memory-limit-errors) environment variable, we temporarily unrestrict composer's memory limit to allow for the install to succeed on the first try.