### PR TITLE
[1.x] Update two-factor-authentication-form.blade.php

### DIFF
--- a/stubs/livewire/resources/views/profile/two-factor-authentication-form.blade.php
+++ b/stubs/livewire/resources/views/profile/two-factor-authentication-form.blade.php
@@ -30,7 +30,7 @@
                     </p>
                 </div>
 
-                <div class="mt-4">
+                <div class="mt-4 p-4 w-56 bg-white">
                     {!! $this->user->twoFactorQrCodeSvg() !!}
                 </div>
             @endif

--- a/stubs/livewire/resources/views/profile/two-factor-authentication-form.blade.php
+++ b/stubs/livewire/resources/views/profile/two-factor-authentication-form.blade.php
@@ -30,7 +30,7 @@
                     </p>
                 </div>
 
-                <div class="mt-4 p-4 w-56 bg-white">
+                <div class="mt-4 dark:p-4 dark:w-56 dark:bg-white">
                     {!! $this->user->twoFactorQrCodeSvg() !!}
                 </div>
             @endif


### PR DESCRIPTION
I had an issue where I couldn't scan the barcode when setting up 2FA. Determined the issue was using darkmode tailwind css styling. The Google authenticator app and VIP Access Authenticator don't pick up the barcode if it has a dark background right up against it. Add a p-4 white background resolved the issue on both apps. Propose adding this white border out of the box to prevent this issue if the user chooses a dark color adjacent to the barcode.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
