### PR TITLE
PHP8 Support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.3, 7.4]
+        php: [7.3, 7.4, 8.0]
         laravel: [^8.0]
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }}

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^8.0",
         "ext-json": "*",
         "illuminate/support": "^8.0",
         "jenssegers/agent": "^2.6",


### PR DESCRIPTION
Dependencies updated to support PHP8:

- [x] inertiajs/inertia-laravel
- [x] jenssegers/agent

Dependencies missing:

- [x] laravel/sanctum https://github.com/laravel/sanctum/pull/213
- [x] laravel/fortify https://github.com/laravel/fortify/pull/130