### PR TITLE
[2.x] Accessibility Keyboard Navigation Improvements for Add Team Member Role Options

### DIFF
--- a/stubs/inertia/resources/js/Pages/Teams/TeamMemberManager.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/TeamMemberManager.vue
@@ -32,9 +32,9 @@
                         <jet-label for="roles" value="Role" />
                         <jet-input-error :message="addTeamMemberForm.error('role')" class="mt-2" />
 
-                        <div class="mt-1 border border-gray-200 rounded-lg cursor-pointer">
-                            <div class="px-4 py-3"
-                                            :class="{'border-t border-gray-200': i > 0}"
+                        <div class="mt-1 border border-gray-200 rounded-lg cursor-pointer relative z-0">
+                            <button type="button" class="px-4 py-3 relative inline-flex rounded-lg w-full focus:z-10 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue"
+                                            :class="{'border-t border-gray-200 rounded-t-none': i > 0, 'rounded-b-none': i != Object.keys(availableRoles).length - 1}"
                                             @click="addTeamMemberForm.role = role.key"
                                             v-for="(role, i) in availableRoles"
                                             :key="role.key"
@@ -54,7 +54,7 @@
                                         {{ role.description }}
                                     </div>
                                 </div>
-                            </div>
+                            </button>
                         </div>
                     </div>
                 </template>

--- a/stubs/livewire/resources/views/teams/team-member-manager.blade.php
+++ b/stubs/livewire/resources/views/teams/team-member-manager.blade.php
@@ -33,9 +33,9 @@
                             <x-jet-label for="role" value="{{ __('Role') }}" />
                             <x-jet-input-error for="role" class="mt-2" />
 
-                            <div class="mt-1 border border-gray-200 rounded-lg cursor-pointer">
+                            <div class="mt-1 border border-gray-200 rounded-lg cursor-pointer relative z-0">
                                 @foreach ($this->roles as $index => $role)
-                                        <div class="px-4 py-3 {{ $index > 0 ? 'border-t border-gray-200' : '' }}"
+                                        <button class="px-4 py-3 relative inline-flex rounded-lg w-full focus:z-10 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue {{ $index > 0 ? 'border-t border-gray-200 rounded-t-none' : '' }} {{ !$loop->last ? 'rounded-b-none' : '' }}"
                                                         wire:click="$set('addTeamMemberForm.role', '{{ $role->key }}')">
                                             <div class="{{ isset($addTeamMemberForm['role']) && $addTeamMemberForm['role'] !== $role->key ? 'opacity-50' : '' }}">
                                                 <!-- Role Name -->
@@ -54,7 +54,7 @@
                                                     {{ $role->description }}
                                                 </div>
                                             </div>
-                                        </div>
+                                        </button>
                                 @endforeach
                             </div>
                         </div>

--- a/stubs/livewire/resources/views/teams/team-member-manager.blade.php
+++ b/stubs/livewire/resources/views/teams/team-member-manager.blade.php
@@ -35,26 +35,26 @@
 
                             <div class="mt-1 border border-gray-200 rounded-lg cursor-pointer relative z-0">
                                 @foreach ($this->roles as $index => $role)
-                                        <button type="button" class="px-4 py-3 relative inline-flex rounded-lg w-full focus:z-10 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue {{ $index > 0 ? 'border-t border-gray-200 rounded-t-none' : '' }} {{ !$loop->last ? 'rounded-b-none' : '' }}"
-                                                        wire:click="$set('addTeamMemberForm.role', '{{ $role->key }}')">
-                                            <div class="{{ isset($addTeamMemberForm['role']) && $addTeamMemberForm['role'] !== $role->key ? 'opacity-50' : '' }}">
-                                                <!-- Role Name -->
-                                                <div class="flex items-center">
-                                                    <div class="text-sm text-gray-600 {{ $addTeamMemberForm['role'] == $role->key ? 'font-semibold' : '' }}">
-                                                        {{ $role->name }}
-                                                    </div>
-
-                                                    @if ($addTeamMemberForm['role'] == $role->key)
-                                                        <svg class="ml-2 h-5 w-5 text-green-400" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" stroke="currentColor" viewBox="0 0 24 24"><path d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
-                                                    @endif
+                                    <button type="button" class="px-4 py-3 relative inline-flex rounded-lg w-full focus:z-10 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue {{ $index > 0 ? 'border-t border-gray-200 rounded-t-none' : '' }} {{ !$loop->last ? 'rounded-b-none' : '' }}"
+                                                    wire:click="$set('addTeamMemberForm.role', '{{ $role->key }}')">
+                                        <div class="{{ isset($addTeamMemberForm['role']) && $addTeamMemberForm['role'] !== $role->key ? 'opacity-50' : '' }}">
+                                            <!-- Role Name -->
+                                            <div class="flex items-center">
+                                                <div class="text-sm text-gray-600 {{ $addTeamMemberForm['role'] == $role->key ? 'font-semibold' : '' }}">
+                                                    {{ $role->name }}
                                                 </div>
 
-                                                <!-- Role Description -->
-                                                <div class="mt-2 text-xs text-gray-600">
-                                                    {{ $role->description }}
-                                                </div>
+                                                @if ($addTeamMemberForm['role'] == $role->key)
+                                                    <svg class="ml-2 h-5 w-5 text-green-400" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" stroke="currentColor" viewBox="0 0 24 24"><path d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+                                                @endif
                                             </div>
-                                        </button>
+
+                                            <!-- Role Description -->
+                                            <div class="mt-2 text-xs text-gray-600">
+                                                {{ $role->description }}
+                                            </div>
+                                        </div>
+                                    </button>
                                 @endforeach
                             </div>
                         </div>

--- a/stubs/livewire/resources/views/teams/team-member-manager.blade.php
+++ b/stubs/livewire/resources/views/teams/team-member-manager.blade.php
@@ -35,7 +35,7 @@
 
                             <div class="mt-1 border border-gray-200 rounded-lg cursor-pointer relative z-0">
                                 @foreach ($this->roles as $index => $role)
-                                        <button class="px-4 py-3 relative inline-flex rounded-lg w-full focus:z-10 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue {{ $index > 0 ? 'border-t border-gray-200 rounded-t-none' : '' }} {{ !$loop->last ? 'rounded-b-none' : '' }}"
+                                        <button type="button" class="px-4 py-3 relative inline-flex rounded-lg w-full focus:z-10 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue {{ $index > 0 ? 'border-t border-gray-200 rounded-t-none' : '' }} {{ !$loop->last ? 'rounded-b-none' : '' }}"
                                                         wire:click="$set('addTeamMemberForm.role', '{{ $role->key }}')">
                                             <div class="{{ isset($addTeamMemberForm['role']) && $addTeamMemberForm['role'] !== $role->key ? 'opacity-50' : '' }}">
                                                 <!-- Role Name -->


### PR DESCRIPTION
This pull request proposes that the **Add Team Member** section **Role** options are changed to Buttons instead of Div's. Making this change will increase Accessibility and will allow the end-users to select a Role using the keyboard and not just the mouse.

Tailwind focus border styles have been applied to improve accessibility and the loop has been modified to allow for rounded corners as appropriate in the button grouping.

I've made changes to both the Livewire and Inertia stubs.

![image](https://user-images.githubusercontent.com/18236969/97774904-f942c600-1b18-11eb-834e-af25bf801904.png)
![image](https://user-images.githubusercontent.com/18236969/97774883-cb5d8180-1b18-11eb-888a-5d888bf07c13.png)
![image](https://user-images.githubusercontent.com/18236969/97774887-d6b0ad00-1b18-11eb-8e86-4f900b3bd33a.png)
