### PR TITLE
[1.x] Removed ui-avatars.com for GDPR compliance

### DIFF
--- a/src/HasProfilePhoto.php
+++ b/src/HasProfilePhoto.php
@@ -72,6 +72,7 @@ trait HasProfilePhoto
         if (! Features::managesProfilePhotos()) {
             return '';
         }
+
         return 'https://ui-avatars.com/api/?name='.urlencode($this->name).'&color=7F9CF5&background=EBF4FF';
     }
 

--- a/src/HasProfilePhoto.php
+++ b/src/HasProfilePhoto.php
@@ -97,8 +97,9 @@ trait HasProfilePhoto
         $tag = '';
 
         for ($i = 0; $i < 2; $i++) {
-            if (count($segments) >= $i + 1)
+            if (count($segments) >= $i + 1) {
                 $tag .= Str::of($segments[$i])->ucfirst()->substr(0, 1);
+            }
         }
 
         return $tag;

--- a/src/HasProfilePhoto.php
+++ b/src/HasProfilePhoto.php
@@ -57,7 +57,7 @@ trait HasProfilePhoto
     {
         return $this->profile_photo_path
                     ? Storage::disk($this->profilePhotoDisk())->url($this->profile_photo_path)
-                    : '';
+                    : $this->defaultProfilePhotoUrl();
     }
 
     /**
@@ -69,10 +69,6 @@ trait HasProfilePhoto
      */
     protected function defaultProfilePhotoUrl()
     {
-        if (! Features::managesProfilePhotos()) {
-            return '';
-        }
-
         return 'https://ui-avatars.com/api/?name='.urlencode($this->name).'&color=7F9CF5&background=EBF4FF';
     }
 
@@ -94,11 +90,12 @@ trait HasProfilePhoto
     public function getProfileTagAttribute()
     {
         $segments = Str::of($this->name)->split('/[\s ]+/');
+        $segmentNumber = count($segments);
 
         $tag = '';
 
         for ($i = 0; $i < 2; $i++) {
-            if (count($segments) >= $i + 1) {
+            if ($segmentNumber >= $i + 1) {
                 $tag .= Str::of($segments[$i])->ucfirst()->substr(0, 1);
             }
         }

--- a/src/HasProfilePhoto.php
+++ b/src/HasProfilePhoto.php
@@ -97,8 +97,8 @@ trait HasProfilePhoto
         $tag = '';
 
         for ($i = 0; $i < 2; $i++) {
-            if (count($segments) >= $i+1)
-                $tag .= Str::of($segments[$i])->ucfirst()->substr(0,1);
+            if (count($segments) >= $i + 1)
+                $tag .= Str::of($segments[$i])->ucfirst()->substr(0, 1);
         }
 
         return $tag;

--- a/stubs/app/Models/User.php
+++ b/stubs/app/Models/User.php
@@ -57,5 +57,7 @@ class User extends Authenticatable
      */
     protected $appends = [
         'profile_photo_url',
+        'profile_tag',
+        'has_profile_photo',
     ];
 }

--- a/stubs/inertia/resources/js/Layouts/AppLayout.vue
+++ b/stubs/inertia/resources/js/Layouts/AppLayout.vue
@@ -26,7 +26,10 @@
                             <jet-dropdown align="right" width="48">
                                 <template #trigger>
                                     <button v-if="$page.jetstream.managesProfilePhotos" class="flex text-sm border-2 border-transparent rounded-full focus:outline-none focus:border-gray-300 transition duration-150 ease-in-out">
-                                        <img class="h-8 w-8 rounded-full object-cover" :src="$page.user.profile_photo_url" :alt="$page.user.name" />
+                                        <img class="h-8 w-8 rounded-full object-cover" v-if="$page.user.has_profile_photo" :src="$page.user.profile_photo_url" :alt="$page.user.name" />
+                                        <div class="h-8 w-8 rounded-full object-center text-center bg-blue-100 text-indigo-700" v-else>
+                                            <span class="absolute inset-0 flex items-center justify-center">{{ $page.user.profile_tag }}</span>
+                                        </div>
                                     </button>
 
                                     <button v-else class="flex items-center text-sm font-medium text-gray-500 hover:text-gray-700 hover:border-gray-300 focus:outline-none focus:text-gray-700 focus:border-gray-300 transition duration-150 ease-in-out">

--- a/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
@@ -20,7 +20,10 @@
 
                 <!-- Current Profile Photo -->
                 <div class="mt-2" v-show="! photoPreview">
-                    <img :src="user.profile_photo_url" alt="Current Profile Photo" class="rounded-full h-20 w-20 object-cover">
+                    <img v-if="user.has_profile_photo" :src="user.profile_photo_url" alt="Current Profile Photo" class="rounded-full h-20 w-20 object-cover">
+                    <div class="h-20 w-20 rounded-full object-center text-center relative bg-blue-100 text-indigo-700 text-2xl" v-else>
+                        <span class="absolute inset-0 flex items-center justify-center">{{ user.profile_tag }}</span>
+                    </div>
                 </div>
 
                 <!-- New Profile Photo Preview -->

--- a/stubs/livewire/resources/views/navigation-dropdown.blade.php
+++ b/stubs/livewire/resources/views/navigation-dropdown.blade.php
@@ -24,7 +24,13 @@
                     <x-slot name="trigger">
                         @if (Laravel\Jetstream\Jetstream::managesProfilePhotos())
                             <button class="flex text-sm border-2 border-transparent rounded-full focus:outline-none focus:border-gray-300 transition duration-150 ease-in-out">
-                                <img class="h-8 w-8 rounded-full object-cover" src="{{ Auth::user()->profile_photo_url }}" alt="{{ Auth::user()->name }}" />
+                                @if (Auth::user()->has_profile_photo)
+                                    <img class="h-8 w-8 rounded-full object-cover" src="{{ Auth::user()->profile_photo_url }}" alt="{{ Auth::user()->name }}" />
+                                @else
+                                    <div class="h-8 w-8 rounded-full object-center text-center bg-blue-100 text-indigo-700">
+                                        <span class="absolute inset-0 flex items-center justify-center">{{ Auth::user()->profile_tag }}</span>
+                                    </div>
+                                @endif
                             </button>
                         @else
                             <button class="flex items-center text-sm font-medium text-gray-500 hover:text-gray-700 hover:border-gray-300 focus:outline-none focus:text-gray-700 focus:border-gray-300 transition duration-150 ease-in-out">

--- a/stubs/livewire/resources/views/profile/update-profile-information-form.blade.php
+++ b/stubs/livewire/resources/views/profile/update-profile-information-form.blade.php
@@ -28,7 +28,13 @@
 
                 <!-- Current Profile Photo -->
                 <div class="mt-2" x-show="! photoPreview">
-                    <img src="{{ $this->user->profile_photo_url }}" alt="{{ $this->user->name }}" class="rounded-full h-20 w-20 object-cover">
+                    @if ($this->user->has_profile_photo)
+                        <img src="{{ $this->user->profile_photo_url }}" alt="{{ $this->user->name }}" class="rounded-full h-20 w-20 object-cover">
+                    @else
+                        <div class="h-20 w-20 rounded-full object-center text-center relative bg-blue-100 text-indigo-700 text-2xl">
+                            <span class="absolute inset-0 flex items-center justify-center">{{ $this->user->profile_tag }}</span>
+                        </div>
+                    @endif
                 </div>
 
                 <!-- New Profile Photo Preview -->


### PR DESCRIPTION
To make this package compliant with GDPR rules by default (not sending the users name to a third party website), I have changed the default behaviour for inertia and livewire.

I have removed the ui-avatars.com profile photo generator.
Instead the default "profile photo" will be generated with pure tailwind and php.

We check if the user currently has an profile photo, if that is true, the image will be displayed.
If there is no image assigned to the user, a div will be generated containing the "profile tag".

The profile tag is created from the first letter of the first two words in the user name.
It will be displayed the same way as the default profile photo.