### PR TITLE
[2.x] Accessibility Update, Keyboard Nav for Team Role Modals and Fix ID for Email Input

### DIFF
--- a/stubs/inertia/resources/js/Pages/Teams/TeamMemberManager.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/TeamMemberManager.vue
@@ -166,9 +166,9 @@
 
             <template #content>
                 <div v-if="managingRoleFor">
-                    <div class="mt-1 border border-gray-200 rounded-lg cursor-pointer">
-                        <div class="px-4 py-3"
-                                        :class="{'border-t border-gray-200': i > 0}"
+                    <div class="relative z-0 mt-1 border border-gray-200 rounded-lg cursor-pointer">
+                        <button type="button" class="relative px-4 py-3 inline-flex w-full rounded-lg focus:z-10 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue"
+                                        :class="{'border-t border-gray-200 rounded-t-none': i > 0, 'rounded-b-none': i != Object.keys(availableRoles).length - 1}"
                                         @click="updateRoleForm.role = role.key"
                                         v-for="(role, i) in availableRoles"
                                         :key="role.key"
@@ -188,11 +188,11 @@
                                     {{ role.description }}
                                 </div>
                             </div>
-                        </div>
+                        </button>
                     </div>
                 </div>
             </template>
-
+            
             <template #footer>
                 <jet-secondary-button @click.native="currentlyManagingRole = false">
                     Nevermind

--- a/stubs/livewire/resources/views/teams/team-member-manager.blade.php
+++ b/stubs/livewire/resources/views/teams/team-member-manager.blade.php
@@ -23,7 +23,7 @@
                     <!-- Member Email -->
                     <div class="col-span-6 sm:col-span-4">
                         <x-jet-label for="email" value="{{ __('Email') }}" />
-                        <x-jet-input id="name" type="text" class="mt-1 block w-full" wire:model.defer="addTeamMemberForm.email" />
+                        <x-jet-input id="email" type="text" class="mt-1 block w-full" wire:model.defer="addTeamMemberForm.email" />
                         <x-jet-input-error for="email" class="mt-2" />
                     </div>
 

--- a/stubs/livewire/resources/views/teams/team-member-manager.blade.php
+++ b/stubs/livewire/resources/views/teams/team-member-manager.blade.php
@@ -175,28 +175,28 @@
         </x-slot>
 
         <x-slot name="content">
-                <div class="mt-1 border border-gray-200 rounded-lg cursor-pointer">
-                    @foreach ($this->roles as $index => $role)
-                        <div class="px-4 py-3 {{ $index > 0 ? 'border-t border-gray-200' : '' }}"
-                                        wire:click="$set('currentRole', '{{ $role->key }}')">
-                            <div class="{{ $currentRole !== $role->key ? 'opacity-50' : '' }}">
-                                <!-- Role Name -->
-                                <div class="flex items-center">
-                                    <div class="text-sm text-gray-600 {{ $currentRole == $role->key ? 'font-semibold' : '' }}">
-                                        {{ $role->name }}
-                                    </div>
-
-                                    @if ($currentRole == $role->key)
-                                        <svg class="ml-2 h-5 w-5 text-green-400" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" stroke="currentColor" viewBox="0 0 24 24"><path d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
-                                    @endif
+            <div class="relative z-0 mt-1 border border-gray-200 rounded-lg cursor-pointer">
+                @foreach ($this->roles as $index => $role)
+                    <button type="button" class="relative px-4 py-3 inline-flex w-full rounded-lg focus:z-10 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue {{ $index > 0 ? 'border-t border-gray-200 rounded-t-none' : '' }} {{ ! $loop->last ? 'rounded-b-none' : '' }}"
+                                    wire:click="$set('currentRole', '{{ $role->key }}')">
+                        <div class="{{ $currentRole !== $role->key ? 'opacity-50' : '' }}">
+                            <!-- Role Name -->
+                            <div class="flex items-center">
+                                <div class="text-sm text-gray-600 {{ $currentRole == $role->key ? 'font-semibold' : '' }}">
+                                    {{ $role->name }}
                                 </div>
 
-                                <!-- Role Description -->
-                                <div class="mt-2 text-xs text-gray-600">
-                                    {{ $role->description }}
-                                </div>
+                                @if ($currentRole == $role->key)
+                                    <svg class="ml-2 h-5 w-5 text-green-400" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" stroke="currentColor" viewBox="0 0 24 24"><path d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+                                @endif
+                            </div>
+
+                            <!-- Role Description -->
+                            <div class="mt-2 text-xs text-gray-600">
+                                {{ $role->description }}
                             </div>
                         </div>
+                    </button>
                 @endforeach
             </div>
         </x-slot>


### PR DESCRIPTION
Accessibility fix. PR changes the ID of the Input to match the Email Label. Issue only applies to Livewire stubs, the Inertia stub looks fine.

Accessibility update, Added Keyboard Navigation to Team Role Management Modals by converting Div to Button and applied Tailwind focus styles. Same as the previous PR that was already merged yesterday but this time for the Modals. This update includes Inertia and Livewire stubs.
