### PR TITLE
[2.x] Adapt hasTeamRole check to only check the role even for team owners

### DIFF
--- a/src/HasTeams.php
+++ b/src/HasTeams.php
@@ -143,10 +143,6 @@ trait HasTeams
      */
     public function hasTeamRole($team, string $role)
     {
-        if ($this->ownsTeam($team)) {
-            return true;
-        }
-
         return $this->belongsToTeam($team) && optional(Jetstream::findRole($team->users->where(
             'id', $this->id
         )->first()->membership->role))->key === $role;

--- a/tests/TeamBehaviorTest.php
+++ b/tests/TeamBehaviorTest.php
@@ -129,6 +129,33 @@ class TeamBehaviorTest extends OrchestraTestCase
         $this->assertTrue($john->hasTeamPermission($team, 'foo'));
     }
 
+    public function test_has_team_role_check()
+    {
+        Jetstream::role('admin', 'Administrator', ['foo']);
+        Jetstream::role('editor', 'Editor', ['foo']);
+
+        $this->migrate();
+
+        $action = new CreateTeam;
+
+        $user = User::forceCreate([
+            'name' => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
+            'password' => 'secret',
+        ]);
+
+        $team = $action->create($user, ['name' => 'Test Team']);
+
+        $authToken = new Sanctum;
+        $owner = $authToken->actingAs($team->owner, ['bar'], []);
+
+        $team->users()->attach($owner, ['role' => 'admin']);
+
+        $this->assertTrue($team->owner->hasTeamrole($team, 'admin'));
+        $this->assertFalse($team->owner->hasTeamrole($team, 'editor'));
+    }
+
+
     public function test_user_does_not_need_to_refresh_after_switching_teams()
     {
         $this->migrate();

--- a/tests/TeamBehaviorTest.php
+++ b/tests/TeamBehaviorTest.php
@@ -155,7 +155,6 @@ class TeamBehaviorTest extends OrchestraTestCase
         $this->assertFalse($team->owner->hasTeamrole($team, 'editor'));
     }
 
-
     public function test_user_does_not_need_to_refresh_after_switching_teams()
     {
         $this->migrate();


### PR DESCRIPTION
The current `hasTeamRole` method, always returns `true` if the user is the owner. This makes sense for the `hasTeamPermission` check, but not for the role. Even the owner has just one role that should be checked.


```php
public function hasTeamRole($team, string $role)
{
        if ($this->ownsTeam($team)) {
            return true; // here we just return true for every owner no matter the given role
        }

        // Check the role
        // ...
}
```

If you show some data depending on the role (I know there are permission too but some prefer to check the role), you will run into issues where the owner will be shown things that you only wanted to be seen by a specific role.

This PR changes the `hasTeamRole` method to check the role for the given user, even for owners.

Since developers currently already use this method as it works, it makes sense to see it as a feature for the next major release.