### PR TITLE
[1.x] Option for custom name field for default profile photo URL

### DIFF
--- a/src/HasProfilePhoto.php
+++ b/src/HasProfilePhoto.php
@@ -66,7 +66,7 @@ trait HasProfilePhoto
      */
     protected function defaultProfilePhotoUrl()
     {
-        return 'https://ui-avatars.com/api/?name='.urlencode($this->name).'&color=7F9CF5&background=EBF4FF';
+        return 'https://ui-avatars.com/api/?name='.urlencode($this->{$this->defaultProfilePhotoKey ?? 'name'}).'&color=7F9CF5&background=EBF4FF';
     }
 
     /**


### PR DESCRIPTION
Right now HasProfilePhoto trait uses "name" field to generate the default profile photo.

With this change the field key can be overwritten as :

protected $defaultProfilePhotoKey = 'first_name';

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
