### PR TITLE
[2.x] Fix invalid key name

### DIFF
--- a/stubs/inertia/resources/js/Pages/Profile/Show.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/Show.vue
@@ -24,7 +24,7 @@
 
                 <logout-other-browser-sessions-form :sessions="sessions" class="mt-10 sm:mt-0" />
 
-                <template v-if="$page.props.jetsteam.hasAccountDeletionFeatures">
+                <template v-if="$page.props.jetstream.hasAccountDeletionFeatures">
                     <jet-section-border />
 
                     <delete-user-form class="mt-10 sm:mt-0" />


### PR DESCRIPTION
Profile page isn't accessible because of invalid key name:

> [Vue warn]: Error in render: "TypeError: Cannot read property 'hasAccountDeletionFeatures' of undefined"