### PR TITLE
[1.x] Use mix helper and remove CDNs

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -129,6 +129,7 @@ class InstallCommand extends Command
         // NPM Packages...
         $this->updateNodePackages(function ($packages) {
             return [
+                'alpinejs' => '^2.7.3',
                 '@tailwindcss/ui' => '^0.6.0',
                 'postcss-import' => '^12.0.1',
                 'tailwindcss' => '^1.8.0',
@@ -193,6 +194,7 @@ class InstallCommand extends Command
         // Assets...
         copy(__DIR__.'/../../stubs/public/css/app.css', public_path('css/app.css'));
         copy(__DIR__.'/../../stubs/resources/css/app.css', resource_path('css/app.css'));
+        copy(__DIR__.'/../../stubs/resources/js/app.js', resource_path('js/app.js'));
 
         // Teams...
         if ($this->option('teams')) {
@@ -253,6 +255,7 @@ EOF;
                 '@inertiajs/inertia-vue' => '^0.2.0',
                 '@tailwindcss/ui' => '^0.6.0',
                 'laravel-jetstream' => '^0.0.3',
+                'moment' => '^2.26.0',
                 'portal-vue' => '^2.1.7',
                 'postcss-import' => '^12.0.1',
                 'tailwindcss' => '^1.8.0',

--- a/stubs/inertia/resources/js/app.js
+++ b/stubs/inertia/resources/js/app.js
@@ -1,5 +1,7 @@
 require('./bootstrap');
 
+require('moment');
+
 import Vue from 'vue';
 
 import { InertiaApp } from '@inertiajs/inertia-vue';

--- a/stubs/inertia/resources/views/app.blade.php
+++ b/stubs/inertia/resources/views/app.blade.php
@@ -15,7 +15,6 @@
 
         <!-- Scripts -->
         @routes
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.26.0/moment.min.js"></script>
         <script src="{{ mix('js/app.js') }}" defer></script>
     </head>
     <body class="font-sans antialiased">

--- a/stubs/livewire/resources/views/layouts/app.blade.php
+++ b/stubs/livewire/resources/views/layouts/app.blade.php
@@ -11,12 +11,12 @@
         <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap">
 
         <!-- Styles -->
-        <link rel="stylesheet" href="{{ asset('css/app.css') }}">
+        <link rel="stylesheet" href="{{ mix('css/app.css') }}">
 
         @livewireStyles
 
         <!-- Scripts -->
-        <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.7.3/dist/alpine.js" defer></script>
+        <script src="{{ mix('js/app.js') }}" defer></script>
     </head>
     <body class="font-sans antialiased">
         <div class="min-h-screen bg-gray-100">

--- a/stubs/resources/js/app.js
+++ b/stubs/resources/js/app.js
@@ -1,0 +1,1 @@
+require('alpinejs');

--- a/stubs/resources/views/layouts/guest.blade.php
+++ b/stubs/resources/views/layouts/guest.blade.php
@@ -11,10 +11,10 @@
         <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap">
 
         <!-- Styles -->
-        <link rel="stylesheet" href="{{ asset('css/app.css') }}">
+        <link rel="stylesheet" href="{{ mix('css/app.css') }}">
 
         <!-- Scripts -->
-        <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.7.3/dist/alpine.js" defer></script>
+        <script src="{{ mix('js/app.js') }}" defer></script>
     </head>
     <body>
         <div class="font-sans text-gray-900 antialiased">


### PR DESCRIPTION
Two things in this PR:
- Use the `mix` helper wherever possible to support hot reloading (see https://github.com/laravel/jetstream/pull/217)
- This removes the CDNs in favor of a dedicated installed NPM library. See the reasoning below.

As for the alpine.js import it's the same reasoning as here: https://github.com/laravel/breeze/pull/10. I realize the Livewire stack technically doesn't needs JS except for Alpine but this way all libraries are imported the same locally and Alpine's version number can be managed in one place instead of multiple. Another reasoning is that if developers *do* want to make use of JavaScript in their Livewire app, this setup makes that just a bit more easier for them to do so. I've left the import of the `bootstrap.js` file out for the Livewire stack.

I've moved the moment.js CDN dependency for Inertia into the `app.js` file as well so this dependency is also managed in the same place as all the other package.json dependencies for Inertia. Also: the current CDN import for moment.js was throwing this console error:

<img width="781" alt="Screenshot 2020-11-12 at 11 21 38" src="https://user-images.githubusercontent.com/594614/98929183-18f3ca00-24db-11eb-8337-997a45741c8c.png">
