### PR TITLE
[1.x] Updating response status code to prevent method not allowed

### DIFF
--- a/src/Http/Controllers/Inertia/ApiTokenController.php
+++ b/src/Http/Controllers/Inertia/ApiTokenController.php
@@ -62,7 +62,7 @@ class ApiTokenController extends Controller
             'abilities' => Jetstream::validPermissions($request->input('permissions', [])),
         ])->save();
 
-        return back();
+        return back(303);
     }
 
     /**
@@ -76,6 +76,6 @@ class ApiTokenController extends Controller
     {
         $request->user()->tokens()->where('id', $tokenId)->delete();
 
-        return back();
+        return back(303);
     }
 }


### PR DESCRIPTION
Return back with 303 when requesting with DELETE  and PUT to prevent 405 on the subsequent request.
`back()` returns 302 by default.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/303
https://inertiajs.com/redirects

