### PR TITLE
[2.x] Improve translation string

### DIFF
--- a/stubs/resources/views/auth/register.blade.php
+++ b/stubs/resources/views/auth/register.blade.php
@@ -35,10 +35,9 @@
                         <input class="mr-2 leading-tight" type="checkbox" name="terms" id="terms">
 
                         <span class="mt-1">
-                            {!! __('I agree to the :tlo Terms of Service :lc and :plo Privacy Policy :lc', [
-                                    'tlo' => '<a target="_blank" href="/terms" class="underline text-sm text-gray-600 hover:text-gray-900">',
-                                    'plo' => '<a target="_blank" href="/policy" class="underline text-sm text-gray-600 hover:text-gray-900">',
-                                    'lc' => '</a>'
+                            {!! __('I agree to the :terms_of_service and :privacy_policy', [
+                                    'terms_of_service' => '<a target="_blank" href="/terms" class="underline text-sm text-gray-600 hover:text-gray-900">'.__('Terms of Service').'</a>',
+                                    'privacy_policy' => '<a target="_blank" href="/policy" class="underline text-sm text-gray-600 hover:text-gray-900">'.__('Privacy Policy').'</a>',
                             ]) !!}
                         </span>
                     </x-jet-label>


### PR DESCRIPTION
Placeholders should not be used as a replacement for HTML tags.

Instead, I propose to use two placeholders - `terms_of_service` and `privacy_policy` - which can be replaced with either a link, or a text. Thanks to this, we can also reuse existing translations for `Terms of Service` and `Privacy Policy` if they were previously defined in our app.