### PR TITLE
[2.x] Remove unused shared inertia data

### DIFF
--- a/src/Http/Middleware/ShareInertiaData.php
+++ b/src/Http/Middleware/ShareInertiaData.php
@@ -56,8 +56,7 @@ class ShareInertiaData
                 return collect(optional(Session::get('errors'))->getBags() ?: [])->mapWithKeys(function ($bag, $key) {
                     return [$key => $bag->messages()];
                 })->all();
-            },
-            'currentRouteName' => Route::currentRouteName(),
+            }
         ]));
 
         return $next($request);

--- a/src/Http/Middleware/ShareInertiaData.php
+++ b/src/Http/Middleware/ShareInertiaData.php
@@ -56,7 +56,7 @@ class ShareInertiaData
                 return collect(optional(Session::get('errors'))->getBags() ?: [])->mapWithKeys(function ($bag, $key) {
                     return [$key => $bag->messages()];
                 })->all();
-            }
+            },
         ]));
 
         return $next($request);


### PR DESCRIPTION
This *breaking change* pull request removes the `currentRouteName` shared inertia data since the active route check was replaced with ziggy's `current()` method here https://github.com/laravel/jetstream/pull/402.