### PR TITLE
Remove unused form params

### DIFF
--- a/stubs/inertia/resources/js/Pages/Auth/VerifyEmail.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/VerifyEmail.vue
@@ -42,11 +42,7 @@
 
         data() {
             return {
-                form: this.$inertia.form({
-                    email: '',
-                    password: '',
-                    remember: false,
-                })
+                form: this.$inertia.form()
             }
         },
 


### PR DESCRIPTION
Remove unused form params in VerifyEmail.vue (looks like it was copy/pasted from Login.vue)