### PR TITLE
Use local route methods

### DIFF
--- a/stubs/inertia/resources/js/Jetstream/ConfirmsPassword.vue
+++ b/stubs/inertia/resources/js/Jetstream/ConfirmsPassword.vue
@@ -80,7 +80,7 @@
             startConfirmingPassword() {
                 this.form.error = '';
 
-                axios.get(route('password.confirmation').url()).then(response => {
+                axios.get(this.route('password.confirmation').url()).then(response => {
                     if (response.data.confirmed) {
                         this.$emit('confirmed');
                     } else {
@@ -97,7 +97,7 @@
             confirmPassword() {
                 this.form.processing = true;
 
-                axios.post(route('password.confirm').url(), {
+                axios.post(this.route('password.confirm').url(), {
                     password: this.form.password,
                 }).then(response => {
                     this.confirmingPassword = false;

--- a/stubs/inertia/resources/js/Layouts/AppLayout.vue
+++ b/stubs/inertia/resources/js/Layouts/AppLayout.vue
@@ -234,7 +234,7 @@
 
         methods: {
             switchToTeam(team) {
-                this.$inertia.put(route('current-team.update'), {
+                this.$inertia.put(this.route('current-team.update'), {
                     'team_id': team.id
                 }, {
                     preserveState: false
@@ -242,7 +242,7 @@
             },
 
             logout() {
-                axios.post(route('logout').url()).then(response => {
+                axios.post(this.route('logout').url()).then(response => {
                     window.location = '/';
                 })
             },

--- a/stubs/inertia/resources/js/Pages/API/ApiTokenManager.vue
+++ b/stubs/inertia/resources/js/Pages/API/ApiTokenManager.vue
@@ -225,7 +225,7 @@
 
         methods: {
             createApiToken() {
-                this.createApiTokenForm.post(route('api-tokens.store'), {
+                this.createApiTokenForm.post(this.route('api-tokens.store'), {
                     preserveScroll: true,
                 }).then(response => {
                     if (! this.createApiTokenForm.hasErrors()) {
@@ -241,7 +241,7 @@
             },
 
             updateApiToken() {
-                this.updateApiTokenForm.put(route('api-tokens.update', this.managingPermissionsFor), {
+                this.updateApiTokenForm.put(this.route('api-tokens.update', this.managingPermissionsFor), {
                     preserveScroll: true,
                     preserveState: true,
                 }).then(response => {
@@ -254,7 +254,7 @@
             },
 
             deleteApiToken() {
-                this.deleteApiTokenForm.delete(route('api-tokens.destroy', this.apiTokenBeingDeleted), {
+                this.deleteApiTokenForm.delete(this.route('api-tokens.destroy', this.apiTokenBeingDeleted), {
                     preserveScroll: true,
                     preserveState: true,
                 }).then(() => {

--- a/stubs/inertia/resources/js/Pages/Profile/DeleteUserForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/DeleteUserForm.vue
@@ -95,7 +95,7 @@
             },
 
             deleteUser() {
-                this.form.post(route('current-user.destroy'), {
+                this.form.post(this.route('current-user.destroy'), {
                     preserveScroll: true
                 }).then(response => {
                     if (! this.form.hasErrors()) {

--- a/stubs/inertia/resources/js/Pages/Profile/LogoutOtherBrowserSessionsForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/LogoutOtherBrowserSessionsForm.vue
@@ -133,7 +133,7 @@
             },
 
             logoutOtherBrowserSessions() {
-                this.form.post(route('other-browser-sessions.destroy'), {
+                this.form.post(this.route('other-browser-sessions.destroy'), {
                     preserveScroll: true
                 }).then(response => {
                     if (! this.form.hasErrors()) {

--- a/stubs/inertia/resources/js/Pages/Profile/UpdatePasswordForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/UpdatePasswordForm.vue
@@ -72,7 +72,7 @@
 
         methods: {
             updatePassword() {
-                this.form.put(route('user-password.update'), {
+                this.form.put(this.route('user-password.update'), {
                     preserveScroll: true
                 }).then(() => {
                     this.$refs.current_password.focus()

--- a/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
@@ -112,7 +112,7 @@
                     this.form.photo = this.$refs.photo.files[0]
                 }
 
-                this.form.post(route('user-profile-information.update'), {
+                this.form.post(this.route('user-profile-information.update'), {
                     preserveScroll: true
                 });
             },
@@ -132,7 +132,7 @@
             },
 
             deletePhoto() {
-                this.$inertia.delete(route('current-user-photo.destroy'), {
+                this.$inertia.delete(this.route('current-user-photo.destroy'), {
                     preserveScroll: true,
                 }).then(() => {
                     this.photoPreview = null

--- a/stubs/inertia/resources/js/Pages/Teams/CreateTeamForm.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/CreateTeamForm.vue
@@ -72,7 +72,7 @@
 
         methods: {
             createTeam() {
-                this.form.post(route('teams.store'), {
+                this.form.post(this.route('teams.store'), {
                     preserveScroll: true
                 });
             },

--- a/stubs/inertia/resources/js/Pages/Teams/DeleteTeamForm.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/DeleteTeamForm.vue
@@ -80,7 +80,7 @@
             },
 
             deleteTeam() {
-                this.form.delete(route('teams.destroy', this.team), {
+                this.form.delete(this.route('teams.destroy', this.team), {
                     preserveScroll: true
                 });
             },

--- a/stubs/inertia/resources/js/Pages/Teams/TeamMemberManager.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/TeamMemberManager.vue
@@ -289,7 +289,7 @@
 
         methods: {
             addTeamMember() {
-                this.addTeamMemberForm.post(route('team-members.store', this.team), {
+                this.addTeamMemberForm.post(this.route('team-members.store', this.team), {
                     preserveScroll: true
                 });
             },
@@ -301,7 +301,7 @@
             },
 
             updateRole() {
-                this.updateRoleForm.put(route('team-members.update', [this.team, this.managingRoleFor]), {
+                this.updateRoleForm.put(this.route('team-members.update', [this.team, this.managingRoleFor]), {
                     preserveScroll: true,
                 }).then(() => {
                     this.currentlyManagingRole = false
@@ -313,7 +313,7 @@
             },
 
             leaveTeam() {
-                this.leaveTeamForm.delete(route('team-members.destroy', [this.team, this.$page.user]))
+                this.leaveTeamForm.delete(this.route('team-members.destroy', [this.team, this.$page.user]))
             },
 
             confirmTeamMemberRemoval(teamMember) {
@@ -321,7 +321,7 @@
             },
 
             removeTeamMember() {
-                this.removeTeamMemberForm.delete(route('team-members.destroy', [this.team, this.teamMemberBeingRemoved]), {
+                this.removeTeamMemberForm.delete(this.route('team-members.destroy', [this.team, this.teamMemberBeingRemoved]), {
                     preserveScroll: true,
                     preserveState: true,
                 }).then(() => {

--- a/stubs/inertia/resources/js/Pages/Teams/UpdateTeamNameForm.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/UpdateTeamNameForm.vue
@@ -82,7 +82,7 @@
 
         methods: {
             updateTeamName() {
-                this.form.put(route('teams.update', this.team), {
+                this.form.put(this.route('teams.update', this.team), {
                     preserveScroll: true
                 });
             },


### PR DESCRIPTION
This PR replaces all usage of global (window) method `route()` to use the local method defined in mixin in app.js