### PR TITLE
[2.x] Checking for photos feature in mobile navigation

### DIFF
--- a/stubs/inertia/resources/js/Layouts/AppLayout.vue
+++ b/stubs/inertia/resources/js/Layouts/AppLayout.vue
@@ -147,11 +147,11 @@
                     <!-- Responsive Settings Options -->
                     <div class="pt-4 pb-1 border-t border-gray-200">
                         <div class="flex items-center px-4">
-                            <div class="flex-shrink-0">
+                            <div v-if="$page.props.jetstream.managesProfilePhotos" class="flex-shrink-0 mr-3" >
                                 <img class="h-10 w-10 rounded-full" :src="$page.props.user.profile_photo_url" :alt="$page.props.user.name" />
                             </div>
 
-                            <div class="ml-3">
+                            <div>
                                 <div class="font-medium text-base text-gray-800">{{ $page.props.user.name }}</div>
                                 <div class="font-medium text-sm text-gray-500">{{ $page.props.user.email }}</div>
                             </div>

--- a/stubs/livewire/resources/views/navigation-dropdown.blade.php
+++ b/stubs/livewire/resources/views/navigation-dropdown.blade.php
@@ -146,12 +146,12 @@
         <div class="pt-4 pb-1 border-t border-gray-200">
             <div class="flex items-center px-4">
                 @if (Laravel\Jetstream\Jetstream::managesProfilePhotos())
-                <div class="flex-shrink-0">
-                    <img class="h-10 w-10 rounded-full" src="{{ Auth::user()->profile_photo_url }}" alt="{{ Auth::user()->name }}" />
-                </div>
+                    <div class="flex-shrink-0 mr-3">
+                        <img class="h-10 w-10 rounded-full" src="{{ Auth::user()->profile_photo_url }}" alt="{{ Auth::user()->name }}" />
+                    </div>
                 @endif
 
-                <div class="ml-3">
+                <div>
                     <div class="font-medium text-base text-gray-800">{{ Auth::user()->name }}</div>
                     <div class="font-medium text-sm text-gray-500">{{ Auth::user()->email }}</div>
                 </div>

--- a/stubs/livewire/resources/views/navigation-dropdown.blade.php
+++ b/stubs/livewire/resources/views/navigation-dropdown.blade.php
@@ -145,9 +145,11 @@
         <!-- Responsive Settings Options -->
         <div class="pt-4 pb-1 border-t border-gray-200">
             <div class="flex items-center px-4">
+                @if (Laravel\Jetstream\Jetstream::managesProfilePhotos())
                 <div class="flex-shrink-0">
                     <img class="h-10 w-10 rounded-full" src="{{ Auth::user()->profile_photo_url }}" alt="{{ Auth::user()->name }}" />
                 </div>
+                @endif
 
                 <div class="ml-3">
                     <div class="font-medium text-base text-gray-800">{{ Auth::user()->name }}</div>


### PR DESCRIPTION
This pull request adds verification that Jetstream's `profilePhotos` feature is enabled in order to display the photo in mobile navigation; today, this check exists only for desktop navigation, trying to show the profile picture on the responsive navigation even if the feature is disabled.

- [x] Update the `inertia` layout.
- [x] Update the `livewire` component.

Screenshots 📸 

> Tests performed with the `profilePhotos` feature **disabled**.

Without the verification             |  With the verification
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/25041169/99701931-e9f9cd00-2a73-11eb-9db3-a325cacd584d.png)  | ![image](https://user-images.githubusercontent.com/25041169/99701966-fa11ac80-2a73-11eb-8037-6e8fba1e15f5.png)

