### PR TITLE
[1.x] Use Alpine directly for guest layout

### DIFF
--- a/stubs/resources/views/layouts/guest.blade.php
+++ b/stubs/resources/views/layouts/guest.blade.php
@@ -14,7 +14,7 @@
         <link rel="stylesheet" href="{{ mix('css/app.css') }}">
 
         <!-- Scripts -->
-        <script src="{{ mix('js/app.js') }}" defer></script>
+        <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.7.3/dist/alpine.js" defer></script>
     </head>
     <body>
         <div class="font-sans text-gray-900 antialiased">


### PR DESCRIPTION
This reverts a small part of https://github.com/laravel/jetstream/pull/450. What happened was that because the guest layout isn't an SPA in Inertia the console starts to throw errors because it cannot resolve routes. This is technically solved in Jetstream v2 where the guest layout isn't copied anymore and all views are Inertia scripts. But for Jetstream 1.x we'll need to reference Alpine directly instead of loading in the entire `app.js` on the guest layout.

I have to note that nothing was actually broken, just the console which was showing the errors from the screenshots in the issue below.

Fixes https://github.com/laravel/jetstream/issues/482