### PR TITLE
Clears any validation error message before re-displaying confirmation

### DIFF
--- a/src/Http/Livewire/DeleteUserForm.php
+++ b/src/Http/Livewire/DeleteUserForm.php
@@ -32,6 +32,8 @@ class DeleteUserForm extends Component
      */
     public function confirmUserDeletion()
     {
+        $this->resetErrorBag();
+
         $this->password = '';
 
         $this->dispatchBrowserEvent('confirming-delete-user');


### PR DESCRIPTION
It's a small change, but it should be OK.  🤓 

Previously, there was a **very minor** issue if the following steps were followed:
- log in
- navigate to profile
- delete account
- enter incorrect password
- note the validation error message
- close confirmation window via ESC or Nevermind
- delete account...again

The issue: the validation error message is still displayed.

I've simply added `$this->resetErrorBag();` to make sure that validation errors are cleared each time the user attempts to delete their account.

Please let me know if there are any problems/questions.  Thx...!  🤓

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
