### PR TITLE
Publish "RemoveTeamMember" to allow it to be modified

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -414,6 +414,7 @@ EOF;
         copy(__DIR__.'/../../stubs/app/Actions/Jetstream/CreateTeam.php', app_path('Actions/Jetstream/CreateTeam.php'));
         copy(__DIR__.'/../../stubs/app/Actions/Jetstream/DeleteTeam.php', app_path('Actions/Jetstream/DeleteTeam.php'));
         copy(__DIR__.'/../../stubs/app/Actions/Jetstream/DeleteUserWithTeams.php', app_path('Actions/Jetstream/DeleteUser.php'));
+        copy(__DIR__.'/../../stubs/app/Actions/Jetstream/RemoveTeamMember.php', app_path('Actions/Jetstream/RemoveTeamMember.php'));
         copy(__DIR__.'/../../stubs/app/Actions/Jetstream/UpdateTeamName.php', app_path('Actions/Jetstream/UpdateTeamName.php'));
 
         copy(__DIR__.'/../../stubs/app/Actions/Fortify/CreateNewUserWithTeams.php', app_path('Actions/Fortify/CreateNewUser.php'));

--- a/src/Contracts/RemovesTeamMembers.php
+++ b/src/Contracts/RemovesTeamMembers.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Laravel\Jetstream\Contracts;
+
+interface RemovesTeamMembers
+{
+    /**
+     * Remove the team member from the given team.
+     *
+     * @param  mixed  $user
+     * @param  mixed  $team
+     * @param  mixed  $teamMember
+     * @return void
+     */
+    public function remove($user, $team, $teamMember);
+}

--- a/src/Http/Controllers/Inertia/TeamMemberController.php
+++ b/src/Http/Controllers/Inertia/TeamMemberController.php
@@ -4,9 +4,9 @@ namespace Laravel\Jetstream\Http\Controllers\Inertia;
 
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
-use Laravel\Jetstream\Actions\RemoveTeamMember;
 use Laravel\Jetstream\Actions\UpdateTeamMemberRole;
 use Laravel\Jetstream\Contracts\AddsTeamMembers;
+use Laravel\Jetstream\Contracts\RemovesTeamMembers;
 use Laravel\Jetstream\Jetstream;
 
 class TeamMemberController extends Controller
@@ -64,7 +64,7 @@ class TeamMemberController extends Controller
     {
         $team = Jetstream::newTeamModel()->findOrFail($teamId);
 
-        app(RemoveTeamMember::class)->remove(
+        app(RemovesTeamMembers::class)->remove(
             $request->user(),
             $team,
             $user = Jetstream::findUserByIdOrFail($userId)

--- a/src/Http/Livewire/TeamMemberManager.php
+++ b/src/Http/Livewire/TeamMemberManager.php
@@ -3,9 +3,9 @@
 namespace Laravel\Jetstream\Http\Livewire;
 
 use Illuminate\Support\Facades\Auth;
-use Laravel\Jetstream\Actions\RemoveTeamMember;
 use Laravel\Jetstream\Actions\UpdateTeamMemberRole;
 use Laravel\Jetstream\Contracts\AddsTeamMembers;
+use Laravel\Jetstream\Contracts\RemovesTeamMembers;
 use Laravel\Jetstream\Jetstream;
 use Livewire\Component;
 
@@ -152,10 +152,10 @@ class TeamMemberManager extends Component
     /**
      * Remove the currently authenticated user from the team.
      *
-     * @param  \Laravel\Jetstream\Actions\RemoveTeamMember  $remover
+     * @param  \Laravel\Jetstream\Contracts\RemovesTeamMembers  $remover
      * @return void
      */
-    public function leaveTeam(RemoveTeamMember $remover)
+    public function leaveTeam(RemovesTeamMembers $remover)
     {
         $remover->remove(
             $this->user,

--- a/src/Jetstream.php
+++ b/src/Jetstream.php
@@ -6,6 +6,7 @@ use Laravel\Jetstream\Contracts\AddsTeamMembers;
 use Laravel\Jetstream\Contracts\CreatesTeams;
 use Laravel\Jetstream\Contracts\DeletesTeams;
 use Laravel\Jetstream\Contracts\DeletesUsers;
+use Laravel\Jetstream\Contracts\RemovesTeamMembers;
 use Laravel\Jetstream\Contracts\UpdatesTeamNames;
 
 class Jetstream
@@ -352,6 +353,17 @@ class Jetstream
     public static function deleteUsersUsing(string $class)
     {
         return app()->singleton(DeletesUsers::class, $class);
+    }
+
+    /**
+     * Register a class / callback that should be used to remove team members.
+     *
+     * @param  string  $class
+     * @return void
+     */
+    public static function removeTeamMembersUsing(string $class)
+    {
+        return app()->singleton(RemovesTeamMembers::class, $class);
     }
 
     /**

--- a/stubs/app/Actions/Jetstream/RemoveTeamMember.php
+++ b/stubs/app/Actions/Jetstream/RemoveTeamMember.php
@@ -1,13 +1,14 @@
 <?php
 
-namespace Laravel\Jetstream\Actions;
+namespace App\Actions\Jetstream;
 
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\ValidationException;
+use Laravel\Jetstream\Contracts\RemovesTeamMembers;
 use Laravel\Jetstream\Events\TeamMemberRemoved;
 
-class RemoveTeamMember
+class RemoveTeamMember implements RemovesTeamMembers
 {
     /**
      * Remove the team member from the given team.

--- a/stubs/app/Providers/JetstreamWithTeamsServiceProvider.php
+++ b/stubs/app/Providers/JetstreamWithTeamsServiceProvider.php
@@ -6,6 +6,7 @@ use App\Actions\Jetstream\AddTeamMember;
 use App\Actions\Jetstream\CreateTeam;
 use App\Actions\Jetstream\DeleteTeam;
 use App\Actions\Jetstream\DeleteUser;
+use App\Actions\Jetstream\RemoveTeamMember;
 use App\Actions\Jetstream\UpdateTeamName;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Jetstream\Jetstream;
@@ -36,6 +37,7 @@ class JetstreamServiceProvider extends ServiceProvider
         Jetstream::addTeamMembersUsing(AddTeamMember::class);
         Jetstream::deleteTeamsUsing(DeleteTeam::class);
         Jetstream::deleteUsersUsing(DeleteUser::class);
+        Jetstream::removeTeamMembersUsing(RemoveTeamMember::class);
     }
 
     /**

--- a/tests/RemoveTeamMemberTest.php
+++ b/tests/RemoveTeamMemberTest.php
@@ -3,13 +3,13 @@
 namespace Laravel\Jetstream\Tests;
 
 use App\Actions\Jetstream\CreateTeam;
+use App\Actions\Jetstream\RemoveTeamMember;
 use App\Models\Team;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\ValidationException;
-use Laravel\Jetstream\Actions\RemoveTeamMember;
 use Laravel\Jetstream\Events\RemovingTeamMember;
 use Laravel\Jetstream\Events\TeamMemberRemoved;
 use Laravel\Jetstream\Jetstream;


### PR DESCRIPTION
This PR publishes the `RemoveTeamMember` action, allowing develops to tap into the functionality of what happens when you remove a team member.

### Example problem

_For the purposes of this PR, we consider an application where users can create either personal or team "reports". When a user creates a team report, they also own that report, only they can remove it_

1. User 1 (admin) invites User 2 (editor) to a team.
2. User 2 creates a team report.
3. User 1 removes user 2 from the team, but the report remains part of the team and owned by the user 2.


In this scenario, the remove team member functionality should allow developers to determine what happens to the report that user 2 is the owner of. (For example, programmatically make user 1 (the admin, and remover of user 2) the new owner of that report.
