### PR TITLE
[2.x] Fix RemovesTeamMembers typos

### DIFF
--- a/src/Http/Livewire/TeamMemberManager.php
+++ b/src/Http/Livewire/TeamMemberManager.php
@@ -214,10 +214,10 @@ class TeamMemberManager extends Component
     /**
      * Remove a team member from the team.
      *
-     * @param  \Laravel\Jetstream\Actions\RemoveTeamMember  $remover
+     * @param  \Laravel\Jetstream\Contracts\RemovesTeamMembers  $remover
      * @return void
      */
-    public function removeTeamMember(RemoveTeamMember $remover)
+    public function removeTeamMember(RemovesTeamMembers $remover)
     {
         $remover->remove(
             $this->user,


### PR DESCRIPTION
The latest PR merged included the RemovesTeamMembers contract.

In the removeTeamMember method, a typos was introduced.

Thanks to @joelbutcher btw, it was the missing feature for me :]