### PR TITLE
[2.x] Set role nullable on team invitations table

### DIFF
--- a/database/migrations/2020_05_21_300000_create_team_invitations_table.php
+++ b/database/migrations/2020_05_21_300000_create_team_invitations_table.php
@@ -17,7 +17,7 @@ class CreateTeamInvitationsTable extends Migration
             $table->id();
             $table->foreignId('team_id')->constrained()->cascadeOnDelete();
             $table->string('email')->unique();
-            $table->string('role');
+            $table->string('role')->nullable();
             $table->timestamps();
         });
     }


### PR DESCRIPTION
Because it should be:
- https://github.com/laravel/jetstream/blob/master/database/migrations/2020_05_21_200000_create_team_user_table.php#L20
- https://github.com/laravel/jetstream/blob/master/stubs/app/Actions/Jetstream/InviteTeamMember.php#L72