### PR TITLE
[2.x] Assets Versioning and Sourcemaps Based on Build Environment

### DIFF
--- a/stubs/inertia/webpack.mix.js
+++ b/stubs/inertia/webpack.mix.js
@@ -17,5 +17,10 @@ mix.js('resources/js/app.js', 'public/js')
         require('tailwindcss'),
         require('autoprefixer'),
     ])
-    .webpackConfig(require('./webpack.config'))
-    .version();
+    .webpackConfig(require('./webpack.config'));
+
+if (mix.inProduction()) {
+    mix.version();
+} else {
+    mix.sourceMaps();
+}


### PR DESCRIPTION
Versioned files are usually unnecessary in development environment and should be enabled in production.

In development mode more useful will be to generate source maps for providing appropriate debugging experience.
