### PR TITLE
[1.x] Rename path to prefix for route config

### DIFF
--- a/src/JetstreamServiceProvider.php
+++ b/src/JetstreamServiceProvider.php
@@ -171,7 +171,7 @@ class JetstreamServiceProvider extends ServiceProvider
             Route::group([
                 'namespace' => 'Laravel\Jetstream\Http\Controllers',
                 'domain' => config('jetstream.domain', null),
-                'prefix' => config('jetstream.path', null),
+                'prefix' => config('jetstream.prefix', null),
             ], function () {
                 $this->loadRoutesFrom(__DIR__.'/../routes/'.config('jetstream.stack').'.php');
             });

--- a/src/JetstreamServiceProvider.php
+++ b/src/JetstreamServiceProvider.php
@@ -171,7 +171,7 @@ class JetstreamServiceProvider extends ServiceProvider
             Route::group([
                 'namespace' => 'Laravel\Jetstream\Http\Controllers',
                 'domain' => config('jetstream.domain', null),
-                'prefix' => config('jetstream.prefix', null),
+                'prefix' => config('jetstream.prefix', 'jetstream.path'),
             ], function () {
                 $this->loadRoutesFrom(__DIR__.'/../routes/'.config('jetstream.stack').'.php');
             });

--- a/src/JetstreamServiceProvider.php
+++ b/src/JetstreamServiceProvider.php
@@ -171,7 +171,7 @@ class JetstreamServiceProvider extends ServiceProvider
             Route::group([
                 'namespace' => 'Laravel\Jetstream\Http\Controllers',
                 'domain' => config('jetstream.domain', null),
-                'prefix' => config('jetstream.prefix', 'jetstream.path'),
+                'prefix' => config('jetstream.prefix', config('jetstream.path')),
             ], function () {
                 $this->loadRoutesFrom(__DIR__.'/../routes/'.config('jetstream.stack').'.php');
             });


### PR DESCRIPTION
This changes the config key used to determine the prefix for Jetstream routes from `path` to `prefix`. This keeps it consistent with the same config key used in Fortify (see https://github.com/laravel/fortify/blob/1.x/src/FortifyServiceProvider.php#L128).