### PR TITLE
Depends on Ziggy ^1.0.3 and fixed inertia stack still using .url()

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -246,7 +246,7 @@ EOF;
     protected function installInertiaStack()
     {
         // Install Inertia...
-        $this->requireComposerPackages('inertiajs/inertia-laravel:^0.2.4', 'laravel/sanctum:^2.6', 'tightenco/ziggy:^0.9.4');
+        $this->requireComposerPackages('inertiajs/inertia-laravel:^0.2.4', 'laravel/sanctum:^2.6', 'tightenco/ziggy:^1.0.3');
 
         // Install NPM packages...
         $this->updateNodePackages(function ($packages) {

--- a/stubs/inertia/resources/js/Jetstream/ConfirmsPassword.vue
+++ b/stubs/inertia/resources/js/Jetstream/ConfirmsPassword.vue
@@ -80,7 +80,7 @@
             startConfirmingPassword() {
                 this.form.error = '';
 
-                axios.get(route('password.confirmation').url()).then(response => {
+                axios.get(route('password.confirmation')).then(response => {
                     if (response.data.confirmed) {
                         this.$emit('confirmed');
                     } else {
@@ -97,7 +97,7 @@
             confirmPassword() {
                 this.form.processing = true;
 
-                axios.post(route('password.confirm').url(), {
+                axios.post(route('password.confirm'), {
                     password: this.form.password,
                 }).then(response => {
                     this.confirmingPassword = false;

--- a/stubs/inertia/resources/js/Layouts/AppLayout.vue
+++ b/stubs/inertia/resources/js/Layouts/AppLayout.vue
@@ -242,7 +242,7 @@
             },
 
             logout() {
-                axios.post(route('logout').url()).then(response => {
+                axios.post(route('logout')).then(response => {
                     window.location = '/';
                 })
             },


### PR DESCRIPTION
This PR fixes bug #503
Ziggy 1.0 was released and deprecated route(...).url() calls in favor of route(...).