### PR TITLE
[2.x] Enable assets versioning only in production

### DIFF
--- a/stubs/inertia/webpack.mix.js
+++ b/stubs/inertia/webpack.mix.js
@@ -17,5 +17,8 @@ mix.js('resources/js/app.js', 'public/js')
         require('tailwindcss'),
         require('autoprefixer'),
     ])
-    .webpackConfig(require('./webpack.config'))
-    .version();
+    .webpackConfig(require('./webpack.config'));
+
+if (mix.inProduction()) {
+    mix.version();
+}

--- a/stubs/livewire/webpack.mix.js
+++ b/stubs/livewire/webpack.mix.js
@@ -17,3 +17,7 @@ mix.js('resources/js/app.js', 'public/js')
         require('tailwindcss'),
         require('autoprefixer'),
     ]);
+
+if (mix.inProduction()) {
+    mix.version();
+}


### PR DESCRIPTION
Quote from Laravel Docs, which is true:

> Because versioned files are usually unnecessary in development, you may instruct the versioning process to only run during npm run production

Link - https://laravel.com/docs/8.x/mix#versioning-and-cache-busting

The same in laravel-mix docs - https://laravel-mix.com/docs/5.0/versioning#optionally-versioning-files

Related to - https://github.com/laravel/jetstream/pull/502