### PR TITLE
[1.x] Add vertical scroll to modal.blade component

### DIFF
--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -3,24 +3,13 @@
 @php
 $id = $id ?? md5($attributes->wire('model'));
 
-switch ($maxWidth ?? '2xl') {
-    case 'sm':
-        $maxWidth = 'sm:max-w-sm';
-        break;
-    case 'md':
-        $maxWidth = 'sm:max-w-md';
-        break;
-    case 'lg':
-        $maxWidth = 'sm:max-w-lg';
-        break;
-    case 'xl':
-        $maxWidth = 'sm:max-w-xl';
-        break;
-    case '2xl':
-    default:
-        $maxWidth = 'sm:max-w-2xl';
-        break;
-}
+$maxWidth = [
+    'sm' => 'sm:max-w-sm',
+    'md' => 'sm:max-w-md',
+    'lg' => 'sm:max-w-lg',
+    'xl' => 'sm:max-w-xl',
+    '2xl' => 'sm:max-w-2xl',
+][$maxWidth ?? '2xl'];
 @endphp
 
 <div
@@ -47,7 +36,7 @@ switch ($maxWidth ?? '2xl') {
     x-on:keydown.shift.tab.prevent="prevFocusable().focus()"
     x-show="show"
     id="{{ $id }}"
-    class="fixed top-0 inset-x-0 px-4 pt-6 z-50 sm:px-0 sm:flex sm:items-top sm:justify-center"
+    class="fixed top-0 inset-x-0 px-4 py-6 z-50 sm:px-0 sm:flex sm:items-top sm:justify-center"
     style="display: none;"
 >
     <div x-show="show" class="fixed inset-0 transform transition-all" x-on:click="show = false" x-transition:enter="ease-out duration-300"
@@ -59,7 +48,7 @@ switch ($maxWidth ?? '2xl') {
         <div class="absolute inset-0 bg-gray-500 opacity-75"></div>
     </div>
 
-    <div x-show="show" class="bg-white rounded-lg overflow-hidden shadow-xl transform transition-all sm:w-full {{ $maxWidth }}"
+    <div x-show="show" class="my-auto bg-white rounded-lg overflow-hidden shadow-xl transform transition-all sm:w-full {{ $maxWidth }}"
                     x-transition:enter="ease-out duration-300"
                     x-transition:enter-start="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
                     x-transition:enter-end="opacity-100 translate-y-0 sm:scale-100"


### PR DESCRIPTION
This enables the vertical scroll for long modals, still working for small ones and still centralized.
Also reduces a little bit the way of setting the `$maxWidth` variable. It's not a php8 pattern matching
but it's very similar.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
