### PR TITLE
[2.x] Generate Sourcemaps for Development Environment

### DIFF
--- a/stubs/inertia/webpack.mix.js
+++ b/stubs/inertia/webpack.mix.js
@@ -21,4 +21,6 @@ mix.js('resources/js/app.js', 'public/js')
 
 if (mix.inProduction()) {
     mix.version();
+} else {
+    mix.sourceMaps();
 }

--- a/stubs/livewire/webpack.mix.js
+++ b/stubs/livewire/webpack.mix.js
@@ -20,4 +20,6 @@ mix.js('resources/js/app.js', 'public/js')
 
 if (mix.inProduction()) {
     mix.version();
+} else {
+    mix.sourceMaps();
 }


### PR DESCRIPTION
Sourcemaps should be provided preferably for development environment to provide appropriate debugging experience.

In general, we shouldn't generate it and host on production because of 2 reasons:

1. Most projects under NDA, so we can't open our source code to public view.
2. Security purposes. We shouldn't open our source code to eliminate the possibility for malefactors to investigate the source code for founding vulnerabilities.

As a point you can check out Bugsnag docs which recommend uploading source maps directly to service - [Uploading Source Maps](https://docs.bugsnag.com/platforms/javascript/source-maps/#uploading-source-maps-recommended) and not recommends hosting them.

I see only one reason to host sourcemaps **temporarily** in production - debug a complex issue that appears only in production mode.

Sourcemaps needs not only for minified assets but for every build where debugging needs.

This is development build **without** sourcemaps:

![without-sourcemaps](https://user-images.githubusercontent.com/5820718/100995810-f5172780-3560-11eb-84a7-a9efc7440876.jpeg)

It has only final `app.js` file which isn't minified, but totally not readable and debuggable because it has transpiled by webpack.

This is development build **with** sourcemaps:

![with-sourcemaps](https://user-images.githubusercontent.com/5820718/100995805-f3e5fa80-3560-11eb-9338-1a70cc32dc34.jpeg)

It has `webpack` and `webpack-internals` directories which has our application source code structure with all components and JavaScript files where we can place breakpoints, evaluate expressions and other debugging purposes.

**Conclusion**:
We always should generate sourcemaps in development environment to provide appropriate debugging experience and usually shouldn't generate it in production.

**P.S.**: @taylorotwell, take a look into original discussion with @driesvints - https://github.com/laravel/jetstream/pull/502