### PR TITLE
[1.x] Add vertical scroll to modal for blade and inertia

### DIFF
--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -3,24 +3,13 @@
 @php
 $id = $id ?? md5($attributes->wire('model'));
 
-switch ($maxWidth ?? '2xl') {
-    case 'sm':
-        $maxWidth = 'sm:max-w-sm';
-        break;
-    case 'md':
-        $maxWidth = 'sm:max-w-md';
-        break;
-    case 'lg':
-        $maxWidth = 'sm:max-w-lg';
-        break;
-    case 'xl':
-        $maxWidth = 'sm:max-w-xl';
-        break;
-    case '2xl':
-    default:
-        $maxWidth = 'sm:max-w-2xl';
-        break;
-}
+$maxWidth = [
+    'sm' => 'sm:max-w-sm',
+    'md' => 'sm:max-w-md',
+    'lg' => 'sm:max-w-lg',
+    'xl' => 'sm:max-w-xl',
+    '2xl' => 'sm:max-w-2xl',
+][$maxWidth ?? '2xl'];
 @endphp
 
 <div
@@ -47,7 +36,7 @@ switch ($maxWidth ?? '2xl') {
     x-on:keydown.shift.tab.prevent="prevFocusable().focus()"
     x-show="show"
     id="{{ $id }}"
-    class="fixed top-0 inset-x-0 px-4 pt-6 z-50 sm:px-0 sm:flex sm:items-top sm:justify-center"
+    class="fixed top-0 inset-x-0 px-4 py-6 z-50 sm:px-0 sm:flex sm:items-top sm:justify-center"
     style="display: none;"
 >
     <div x-show="show" class="fixed inset-0 transform transition-all" x-on:click="show = false" x-transition:enter="ease-out duration-300"
@@ -59,7 +48,7 @@ switch ($maxWidth ?? '2xl') {
         <div class="absolute inset-0 bg-gray-500 opacity-75"></div>
     </div>
 
-    <div x-show="show" class="bg-white rounded-lg overflow-hidden shadow-xl transform transition-all sm:w-full {{ $maxWidth }}"
+    <div x-show="show" class="my-auto bg-white rounded-lg overflow-hidden shadow-xl transform transition-all sm:w-full {{ $maxWidth }}"
                     x-transition:enter="ease-out duration-300"
                     x-transition:enter-start="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
                     x-transition:enter-end="opacity-100 translate-y-0 sm:scale-100"

--- a/stubs/inertia/resources/js/Jetstream/Modal.vue
+++ b/stubs/inertia/resources/js/Jetstream/Modal.vue
@@ -1,7 +1,7 @@
 <template>
     <portal to="modal">
         <transition leave-active-class="duration-200">
-            <div v-show="show" class="fixed top-0 inset-x-0 px-4 pt-6 sm:px-0 sm:flex sm:items-top sm:justify-center">
+            <div v-show="show" class="fixed top-0 inset-x-0 px-4 py-6 sm:px-0 sm:flex sm:items-top sm:justify-center">
                 <transition enter-active-class="ease-out duration-300"
                         enter-class="opacity-0"
                         enter-to-class="opacity-100"
@@ -19,7 +19,7 @@
                         leave-active-class="ease-in duration-200"
                         leave-class="opacity-100 translate-y-0 sm:scale-100"
                         leave-to-class="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95">
-                    <div v-show="show" class="bg-white rounded-lg overflow-hidden shadow-xl transform transition-all sm:w-full" :class="maxWidthClass">
+                    <div v-show="show" class="my-auto bg-white rounded-lg overflow-hidden shadow-xl transform transition-all sm:w-full" :class="maxWidthClass">
                         <slot></slot>
                     </div>
                 </transition>


### PR DESCRIPTION
This enables the vertical scroll for long modals, still working for small ones and still centralized.
Also reduces a little bit the way of setting the `$maxWidth` variable. It's not a php8 pattern matching
but it's very similar.

Before:
![Screen Recording 2020-12-04 at 10 09 28 PM](https://user-images.githubusercontent.com/3236791/101229393-cbecb900-367e-11eb-97f0-96d7ebd71be0.gif)

After:
![Screen Recording 2020-12-04 at 10 12 28 PM](https://user-images.githubusercontent.com/3236791/101229402-d6a74e00-367e-11eb-87af-678032a84a6d.gif)
