### PR TITLE
[2.x] Allows to use a custom TeamInvitation Model

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -393,6 +393,7 @@ EOF;
         // Models...
         copy(__DIR__.'/../../stubs/app/Models/Membership.php', app_path('Models/Membership.php'));
         copy(__DIR__.'/../../stubs/app/Models/Team.php', app_path('Models/Team.php'));
+        copy(__DIR__.'/../../stubs/app/Models/TeamInvitation.php', app_path('Models/TeamInvitation.php'));
         copy(__DIR__.'/../../stubs/app/Models/UserWithTeams.php', app_path('Models/User.php'));
 
         // Actions...

--- a/src/Jetstream.php
+++ b/src/Jetstream.php
@@ -307,7 +307,7 @@ class Jetstream
     }
 
     /**
-     * Get the name of the team model used by the application.
+     * Get the name of the membership model used by the application.
      *
      * @return string
      */

--- a/src/Jetstream.php
+++ b/src/Jetstream.php
@@ -63,6 +63,13 @@ class Jetstream
     public static $membershipModel = 'App\\Models\\Membership';
 
     /**
+     * The team invitation model that should be used by Jetstream.
+     *
+     * @var string
+     */
+    public static $teamInvitationModel = 'App\\Models\\TeamInvitation';
+
+    /**
      * The Inertia manager instance.
      *
      * @var \Laravel\Jetstream\InertiaManager
@@ -318,6 +325,29 @@ class Jetstream
     public static function useMembershipModel(string $model)
     {
         static::$membershipModel = $model;
+
+        return new static;
+    }
+
+    /**
+     * Get the name of the team invitation model used by the application.
+     *
+     * @return string
+     */
+    public static function teamInvitationModel()
+    {
+        return static::$teamInvitationModel;
+    }
+
+    /**
+     * Specify the team invitation model that should be used by Jetstream.
+     *
+     * @param  string  $model
+     * @return static
+     */
+    public static function useTeamInvitationModel(string $model)
+    {
+        static::$teamInvitationModel = $model;
 
         return new static;
     }

--- a/src/Team.php
+++ b/src/Team.php
@@ -76,7 +76,7 @@ abstract class Team extends Model
      */
     public function teamInvitations()
     {
-        return $this->hasMany(TeamInvitation::class);
+        return $this->hasMany(Jetstream::teamInvitationModel());
     }
 
     /**

--- a/stubs/app/Models/TeamInvitation.php
+++ b/stubs/app/Models/TeamInvitation.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Laravel\Jetstream\TeamInvitation as JetstreamTeamInvitation;
+use Laravel\Jetstream\Jetstream;
+
+class TeamInvitation extends JetstreamTeamInvitation
+{
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'email',
+        'role',
+    ];
+
+    /**
+     * Get the team that the invitation belongs to.
+     */
+    public function team()
+    {
+        return $this->belongsTo(Jetstream::teamModel());
+    }
+}

--- a/stubs/app/Models/TeamInvitation.php
+++ b/stubs/app/Models/TeamInvitation.php
@@ -2,8 +2,8 @@
 
 namespace App\Models;
 
-use Laravel\Jetstream\TeamInvitation as JetstreamTeamInvitation;
 use Laravel\Jetstream\Jetstream;
+use Laravel\Jetstream\TeamInvitation as JetstreamTeamInvitation;
 
 class TeamInvitation extends JetstreamTeamInvitation
 {


### PR DESCRIPTION
Like all other models in Jetstream, TeamInvitation should be easily overridable.

A basic use case occurs when we don't want to send an email invitation but notify the user with another method (in-app notification for example).
In that case, we should be able to remove the email field and add another field to identify the user and send him the invitation the way we want using the already overridable `InvitesTeamMembers` contract.

*In the same time I fixed a (not-mine) typo in -probably- copy/pasted comment*