### PR TITLE
[2.x] Update lang attribute

### DIFF
--- a/stubs/inertia/resources/js/app.js
+++ b/stubs/inertia/resources/js/app.js
@@ -37,7 +37,11 @@ new Vue({
     created() {
         this.$inertia.on(
             'success',
-            (event) => (i18n.locale = event.detail.page.props.jetstream?.locale || i18n.locale)
+            (event) => {
+                const locale = event.detail.page.props.jetstream?.locale || i18n.locale;
+
+                document.documentElement.lang = i18n.locale = locale;
+            }
         );
     },
 

--- a/stubs/inertia/resources/js/app.js
+++ b/stubs/inertia/resources/js/app.js
@@ -35,14 +35,11 @@ new Vue({
     i18n,
 
     created() {
-        this.$inertia.on(
-            'success',
-            (event) => {
-                const locale = event.detail.page.props.jetstream?.locale || i18n.locale;
+        this.$inertia.on('success', (event) => {
+            const locale = event.detail.page.props.jetstream?.locale || i18n.locale;
 
-                document.documentElement.lang = i18n.locale = locale;
-            }
-        );
+            document.documentElement.lang = i18n.locale = locale;
+        });
     },
 
     render: (h) =>


### PR DESCRIPTION
When the user changes language, it's correctly reflected in the `vue-i18n` plugin (using the `success` event), but the `lang` attribute in the `<html>` tag remains unchanged until the page is fully refreshed.