### PR TITLE
[2.x] Transfer team owner

### DIFF
--- a/routes/inertia.php
+++ b/routes/inertia.php
@@ -51,6 +51,7 @@ Route::group(['middleware' => config('jetstream.middleware', ['web'])], function
             Route::get('/teams/{team}', [TeamController::class, 'show'])->name('teams.show');
             Route::put('/teams/{team}', [TeamController::class, 'update'])->name('teams.update');
             Route::delete('/teams/{team}', [TeamController::class, 'destroy'])->name('teams.destroy');
+            Route::post('/teams/{team}/transfer/{user}', [TeamController::class, 'transfer'])->name('teams.transfer');
             Route::put('/current-team', [CurrentTeamController::class, 'update'])->name('current-team.update');
             Route::post('/teams/{team}/members', [TeamMemberController::class, 'store'])->name('team-members.store');
             Route::put('/teams/{team}/members/{user}', [TeamMemberController::class, 'update'])->name('team-members.update');

--- a/src/Actions/ValidateTeamTransfer.php
+++ b/src/Actions/ValidateTeamTransfer.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Laravel\Jetstream\Actions;
+
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\ValidationException;
+
+class ValidateTeamTransfer
+{
+    /**
+     * Validate that the team can be deleted by the given user.
+     *
+     * @param  mixed  $user
+     * @param  mixed  $team
+     * @return void
+     */
+    public function validate($user, $team)
+    {
+        Gate::forUser($user)->authorize('transferTeam', $team);
+
+        if ($team->personal_team) {
+            throw ValidationException::withMessages([
+                'team' => __('You may not transfer your personal team.'),
+            ]);
+        }
+    }
+}

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -403,6 +403,7 @@ EOF;
         copy(__DIR__.'/../../stubs/app/Actions/Jetstream/DeleteUserWithTeams.php', app_path('Actions/Jetstream/DeleteUser.php'));
         copy(__DIR__.'/../../stubs/app/Actions/Jetstream/InviteTeamMember.php', app_path('Actions/Jetstream/InviteTeamMember.php'));
         copy(__DIR__.'/../../stubs/app/Actions/Jetstream/RemoveTeamMember.php', app_path('Actions/Jetstream/RemoveTeamMember.php'));
+        copy(__DIR__.'/../../stubs/app/Actions/Jetstream/TransferTeam.php', app_path('Actions/Jetstream/TransferTeam.php'));
         copy(__DIR__.'/../../stubs/app/Actions/Jetstream/UpdateTeamName.php', app_path('Actions/Jetstream/UpdateTeamName.php'));
 
         copy(__DIR__.'/../../stubs/app/Actions/Fortify/CreateNewUserWithTeams.php', app_path('Actions/Fortify/CreateNewUser.php'));

--- a/src/Contracts/TransfersTeams.php
+++ b/src/Contracts/TransfersTeams.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Laravel\Jetstream\Contracts;
+
+interface TransfersTeams
+{
+    /**
+     * Transfer the given app to the given team.
+     *
+     * @param  \App\Models\User  $user
+     * @param  \App\Models\Team  $team
+     * @param  \App\Models\User  $teamMember
+     * @return void
+     */
+    public function transfer($user, $team, $teamMember);
+}

--- a/src/Events/TeamTransferred.php
+++ b/src/Events/TeamTransferred.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Laravel\Jetstream\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+
+class TeamTransferred
+{
+    use Dispatchable;
+
+    /**
+     * The team instance.
+     *
+     * @var mixed
+     */
+    public $team;
+
+    /**
+     * The original team owner.
+     *
+     * @var mixed
+     */
+    public $from;
+
+    /**
+     * The team member that the team was transferred to.
+     *
+     * @var mixed
+     */
+    public $to;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  mixed  $team
+     * @param  mixed  $from
+     * @param  mixed  $to
+     * @return void
+     */
+    public function __construct($team, $from, $to)
+    {
+        $this->team = $team;
+        $this->from = $from;
+        $this->to = $to;
+    }
+}

--- a/src/Http/Controllers/Inertia/TeamController.php
+++ b/src/Http/Controllers/Inertia/TeamController.php
@@ -5,10 +5,13 @@ namespace Laravel\Jetstream\Http\Controllers\Inertia;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Validator;
 use Inertia\Inertia;
 use Laravel\Jetstream\Actions\ValidateTeamDeletion;
+use Laravel\Jetstream\Actions\ValidateTeamTransfer;
 use Laravel\Jetstream\Contracts\CreatesTeams;
 use Laravel\Jetstream\Contracts\DeletesTeams;
+use Laravel\Jetstream\Contracts\TransfersTeams;
 use Laravel\Jetstream\Contracts\UpdatesTeamNames;
 use Laravel\Jetstream\Jetstream;
 use Laravel\Jetstream\RedirectsActions;
@@ -41,6 +44,7 @@ class TeamController extends Controller
                 'canAddTeamMembers' => Gate::check('addTeamMember', $team),
                 'canDeleteTeam' => Gate::check('delete', $team),
                 'canRemoveTeamMembers' => Gate::check('removeTeamMember', $team),
+                'canTransferTeam' => Gate::check('transferTeam', $team),
                 'canUpdateTeam' => Gate::check('update', $team),
             ],
         ]);
@@ -106,5 +110,30 @@ class TeamController extends Controller
         $deleter->delete($team);
 
         return $this->redirectPath($deleter);
+    }
+
+    /**
+     * Transfer the given team to a given user.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $teamId
+     * @param  int  $userId
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function transfer(Request $request, $teamId, $userId)
+    {
+        $team = Jetstream::newTeamModel()->findOrFail($teamId);
+
+        app(ValidateTeamTransfer::class)->validate($request->user(), $team);
+
+        $transferrer = app(TransfersTeams::class);
+
+        $transferrer->transfer(
+            $team,
+            $request->user(),
+            Jetstream::findUserByIdOrFail($request->user_id)
+        );
+
+        return back(303)->banner('Team transfer successful');
     }
 }

--- a/src/Http/Controllers/Inertia/TeamController.php
+++ b/src/Http/Controllers/Inertia/TeamController.php
@@ -129,8 +129,8 @@ class TeamController extends Controller
         $transferrer = app(TransfersTeams::class);
 
         $transferrer->transfer(
-            $team,
             $request->user(),
+            $team,
             Jetstream::findUserByIdOrFail($request->user_id)
         );
 

--- a/src/Http/Livewire/UpdateTeamNameForm.php
+++ b/src/Http/Livewire/UpdateTeamNameForm.php
@@ -9,6 +9,15 @@ use Livewire\Component;
 class UpdateTeamNameForm extends Component
 {
     /**
+     * The component's listeners.
+     *
+     * @var array
+     */
+    protected $listeners = [
+        'refresh-update-team-name-form' => '$refresh',
+    ];
+
+    /**
      * The team instance.
      *
      * @var mixed

--- a/src/Jetstream.php
+++ b/src/Jetstream.php
@@ -9,6 +9,7 @@ use Laravel\Jetstream\Contracts\DeletesTeams;
 use Laravel\Jetstream\Contracts\DeletesUsers;
 use Laravel\Jetstream\Contracts\InvitesTeamMembers;
 use Laravel\Jetstream\Contracts\RemovesTeamMembers;
+use Laravel\Jetstream\Contracts\TransfersTeams;
 use Laravel\Jetstream\Contracts\UpdatesTeamNames;
 
 class Jetstream
@@ -405,6 +406,17 @@ class Jetstream
     public static function removeTeamMembersUsing(string $class)
     {
         return app()->singleton(RemovesTeamMembers::class, $class);
+    }
+
+    /**
+     * Register a class / callback that should be use to transfer teams.
+     *
+     * @param  string  $class
+     * @return void
+     */
+    public static function transferTeamsUsing(string $class)
+    {
+        return app()->singleton(TransfersTeams::class, $class);
     }
 
     /**

--- a/src/Team.php
+++ b/src/Team.php
@@ -80,16 +80,6 @@ abstract class Team extends Model
     }
 
     /**
-     * Determine if the team is transferrable.
-     *
-     * @return bool
-     */
-    public function isTransferrable()
-    {
-        return !$this->personal_team && $this->users->isNotEmpty();
-    }
-
-    /**
      * Transfers the teams ownership to the given user.
      *
      * @param  \App\Models\User  $from

--- a/src/Team.php
+++ b/src/Team.php
@@ -80,6 +80,37 @@ abstract class Team extends Model
     }
 
     /**
+     * Determine if the team is transferrable.
+     *
+     * @return bool
+     */
+    public function isTransferrable()
+    {
+        return !$this->personal_team && $this->users->isNotEmpty();
+    }
+
+    /**
+     * Transfers the teams ownership to the given user.
+     *
+     * @param  \App\Models\User  $from
+     * @param  \App\Models\User  $to
+     */
+    public function transfer($from, $to)
+    {
+        $this->users()->detach($to);
+
+        if (! is_null(Jetstream::findRole('admin'))) {
+            $this->users()->attach(
+                $from, ['role' => 'admin']
+            );
+        }
+
+        $this->owner()->associate($to);
+
+        $this->save();
+    }
+
+    /**
      * Remove the given user from the team.
      *
      * @param  \App\Models\User  $user

--- a/stubs/app/Actions/Jetstream/TransferTeam.php
+++ b/stubs/app/Actions/Jetstream/TransferTeam.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Actions\Jetstream;
+
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Support\Facades\Gate;
+use Laravel\Jetstream\Contracts\TransfersTeams;
+use Laravel\Jetstream\Events\TeamTransferred;
+
+class TransferTeam implements TransfersTeams
+{
+    /**
+     * Transfer the given app to the given team.
+     *
+     * @param  \App\Models\User  $user
+     * @param  \App\Models\Team  $team
+     * @param  \App\Models\User  $teamMember
+     * @return void
+     */
+    public function transfer($user, $team, $teamMember)
+    {
+        $this->authorize($user, $team, $teamMember);
+
+        $team->transfer($user, $teamMember);
+
+        TeamTransferred::dispatch($team, $user, $teamMember);
+    }
+
+    /**
+     * Authorize that the user can transfer team ownership to the team member.
+     *
+     * @param  mixed  $user
+     * @param  mixed  $team
+     * @param  mixed  $teamMember
+     * @return void
+     */
+    protected function authorize($user, $team, $teamMember)
+    {
+        if (! Gate::forUser($user)->check('transferTeam', $team) &&
+            $user->id !== $teamMember->id) {
+            throw new AuthorizationException;
+        }
+    }
+}

--- a/stubs/app/Policies/TeamPolicy.php
+++ b/stubs/app/Policies/TeamPolicy.php
@@ -93,6 +93,18 @@ class TeamPolicy
     }
 
     /**
+     * Determine whether the user can transfer a team to another member.
+     *
+     * @param  \App\Models\User  $user
+     * @param  \App\Models\Team  $team
+     * @return mixed
+     */
+    public function transferTeam(User $user, Team $team)
+    {
+        return $user->ownsTeam($team) && !$team->isTransferrable();
+    }
+
+    /**
      * Determine whether the user can delete the model.
      *
      * @param  \App\Models\User  $user

--- a/stubs/app/Policies/TeamPolicy.php
+++ b/stubs/app/Policies/TeamPolicy.php
@@ -101,7 +101,7 @@ class TeamPolicy
      */
     public function transferTeam(User $user, Team $team)
     {
-        return $user->ownsTeam($team) && !$team->isTransferrable();
+        return $user->ownsTeam($team) && $team->isTransferrable();
     }
 
     /**

--- a/stubs/app/Policies/TeamPolicy.php
+++ b/stubs/app/Policies/TeamPolicy.php
@@ -101,7 +101,7 @@ class TeamPolicy
      */
     public function transferTeam(User $user, Team $team)
     {
-        return $user->ownsTeam($team) && $team->isTransferrable();
+        return $user->ownsTeam($team);
     }
 
     /**

--- a/stubs/app/Providers/JetstreamWithTeamsServiceProvider.php
+++ b/stubs/app/Providers/JetstreamWithTeamsServiceProvider.php
@@ -8,6 +8,7 @@ use App\Actions\Jetstream\DeleteTeam;
 use App\Actions\Jetstream\DeleteUser;
 use App\Actions\Jetstream\InviteTeamMember;
 use App\Actions\Jetstream\RemoveTeamMember;
+use App\Actions\Jetstream\TransferTeam;
 use App\Actions\Jetstream\UpdateTeamName;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Jetstream\Jetstream;
@@ -39,6 +40,7 @@ class JetstreamServiceProvider extends ServiceProvider
         Jetstream::inviteTeamMembersUsing(InviteTeamMember::class);
         Jetstream::removeTeamMembersUsing(RemoveTeamMember::class);
         Jetstream::deleteTeamsUsing(DeleteTeam::class);
+        Jetstream::transferTeamsUsing(TransferTeam::class);
         Jetstream::deleteUsersUsing(DeleteUser::class);
     }
 

--- a/stubs/inertia/resources/js/Pages/Teams/TeamMemberManager.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/TeamMemberManager.vue
@@ -420,7 +420,7 @@
             },
 
             transferTeam() {
-                this.transferTeamForm.post(route('team.transfer', [this.team, this.teamMemberForTransfer]), {
+                this.transferTeamForm.post(route('teams.transfer', [this.team, this.teamMemberForTransfer]), {
                     preserveScroll: true,
                     onSuccess: () => {
                         this.transferTeamForm.password = '';

--- a/stubs/livewire/resources/views/teams/team-member-manager.blade.php
+++ b/stubs/livewire/resources/views/teams/team-member-manager.blade.php
@@ -263,7 +263,7 @@
         </x-slot>
     </x-jet-confirmation-modal>
 
-    <!-- Delete User Confirmation Modal -->
+    <!-- Transfer Team Confirmation Modal -->
     <x-jet-dialog-modal wire:model="confirmingTeamTransfer">
         <x-slot name="title">
             {{ __('Transfer Team') }}

--- a/stubs/livewire/resources/views/teams/team-member-manager.blade.php
+++ b/stubs/livewire/resources/views/teams/team-member-manager.blade.php
@@ -154,10 +154,19 @@
                                         </button>
 
                                     <!-- Remove Team Member -->
-                                    @elseif (Gate::check('removeTeamMember', $team))
-                                        <button class="cursor-pointer ml-6 text-sm text-red-500" wire:click="confirmTeamMemberRemoval('{{ $user->id }}')">
-                                            {{ __('Remove') }}
-                                        </button>
+                                    @else
+
+                                        @if (Gate::check('transferTeam', $team))
+                                            <button class="cursor-pointer ml-6 text-sm text-red-500" wire:click="confirmTeamTransfer('{{ $user->id }}')">
+                                                {{ __('Transfer Team') }}
+                                            </button>
+                                        @endif
+
+                                        @if (Gate::check('removeTeamMember', $team))
+                                            <button class="cursor-pointer ml-6 text-sm text-red-500" wire:click="confirmTeamMemberRemoval('{{ $user->id }}')">
+                                                {{ __('Remove') }}
+                                            </button>
+                                        @endif
                                     @endif
                                 </div>
                             </div>
@@ -253,4 +262,34 @@
             </x-jet-danger-button>
         </x-slot>
     </x-jet-confirmation-modal>
+
+    <!-- Delete User Confirmation Modal -->
+    <x-jet-dialog-modal wire:model="confirmingTeamTransfer">
+        <x-slot name="title">
+            {{ __('Transfer Team') }}
+        </x-slot>
+
+        <x-slot name="content">
+            {{ __('Are you sure you want to transfer this team? Once complete, all of this teams resources will be controlled by this user. Please enter your password to confirm you would like to transfer this team.') }}
+
+            <div class="mt-4" x-data="{}" x-on:confirming-transfer-team.window="setTimeout(() => $refs.password.focus(), 250)">
+                <x-jet-input type="password" class="mt-1 block w-3/4" placeholder="{{ __('Password') }}"
+                            x-ref="password"
+                            wire:model.defer="password"
+                            wire:keydown.enter="deleteUser" />
+
+                <x-jet-input-error for="password" class="mt-2" />
+            </div>
+        </x-slot>
+
+        <x-slot name="footer">
+            <x-jet-secondary-button wire:click="$toggle('confirmingTeamTransfer')" wire:loading.attr="disabled">
+                {{ __('Nevermind') }}
+            </x-jet-secondary-button>
+
+            <x-jet-danger-button class="ml-2" wire:click="transferTeam" wire:loading.attr="disabled">
+                {{ __('Transfer Team') }}
+            </x-jet-danger-button>
+        </x-slot>
+    </x-jet-dialog-modal>
 </div>

--- a/tests/Fixtures/TeamPolicy.php
+++ b/tests/Fixtures/TeamPolicy.php
@@ -92,6 +92,18 @@ class TeamPolicy
     }
 
     /**
+     * Determine whether the user can transfer a team to another member.
+     *
+     * @param  \App\Models\User  $user
+     * @param  \App\Models\Team  $team
+     * @return mixed
+     */
+    public function transferTeam(User $user, Team $team)
+    {
+        return $user->ownsTeam($team);
+    }
+
+    /**
      * Determine whether the user can delete the model.
      *
      * @param  \App\Models\User  $user

--- a/tests/TransferTeamTest.php
+++ b/tests/TransferTeamTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Laravel\Jetstream\Tests;
+
+use App\Actions\Jetstream\CreateTeam;
+use App\Actions\Jetstream\TransferTeam;
+use App\Models\Team;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\ValidationException;
+use Laravel\Jetstream\Actions\ValidateTeamTransfer;
+use Laravel\Jetstream\Jetstream;
+use Laravel\Jetstream\Tests\Fixtures\TeamPolicy;
+use Laravel\Jetstream\Tests\Fixtures\User;
+
+class TransferTeamTest extends OrchestraTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Gate::policy(Team::class, TeamPolicy::class);
+        Jetstream::useUserModel(User::class);
+    }
+
+    public function test_team_can_be_transferred()
+    {
+        $this->migrate();
+
+        $team = $this->createTeam();
+
+        $team->users()->attach($otherUser = User::forceCreate([
+            'name' => 'Adam Wathan',
+            'email' => 'adam@laravel.com',
+            'password' => 'secret',
+        ]), ['role' => 'admin']);
+
+        $action = new TransferTeam;
+
+        $action->transfer($team->owner, $team, $otherUser);
+
+        $this->assertEquals($otherUser->id, $team->owner->id);
+    }
+
+    public function test_team_transfer_can_be_validated()
+    {
+        $this->migrate();
+
+        $team = $this->createTeam();
+
+        $action = new ValidateTeamTransfer;
+
+        $action->validate($team->owner, $team);
+
+        $this->assertTrue(true);
+    }
+
+    public function test_personal_team_cant_be_transferred()
+    {
+        $this->expectException(ValidationException::class);
+
+        $this->migrate();
+
+        $team = $this->createTeam();
+
+        $team->forceFill(['personal_team' => true])->save();
+
+        $action = new ValidateTeamTransfer;
+
+        $action->validate($team->owner, $team);
+    }
+
+    public function test_non_owner_cant_transfer_team()
+    {
+        $this->expectException(AuthorizationException::class);
+
+        Jetstream::useUserModel(User::class);
+
+        $this->migrate();
+
+        $team = $this->createTeam();
+
+        $action = new ValidateTeamTransfer;
+
+        $action->validate(User::forceCreate([
+            'name' => 'Adam Wathan',
+            'email' => 'adam@laravel.com',
+            'password' => 'secret',
+        ]), $team);
+    }
+
+    protected function createTeam()
+    {
+        $action = new CreateTeam;
+
+        $user = User::forceCreate([
+            'name' => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
+            'password' => 'secret',
+        ]);
+
+        $team = $action->create($user, ['name' => 'Test Team']);
+
+        return $team;
+    }
+
+    protected function migrate()
+    {
+        $this->artisan('migrate', ['--database' => 'testbench'])->run();
+    }
+}


### PR DESCRIPTION
This PR adds team transfer functionality to both Inertia and Livewire stacks. Addresses #358 

## Background

Currently, deleting a users account also deletes all teams that user owns. This isn't ideal as if there are other members of that team, using the resources associated to that team, their ability to access those resources will be compromised.

## Use case

As an employee working, I have previously created a team in my companies management app, inviting a number of colleagues to the team, so we can collaborate on multiple projects together.

I've accepted a job offer in a different company and have been asked to remove my user account from my current employers management app. However, there are projects associated with the teams that I own. I want to be able to transfer ownership of these teams, in order to close my account without disrupting the work of others.

## Walkthrough

This PR adds a `Transfer Team` button left of the `Remove` button on each team member.

![Screenshot 2020-12-10 at 12 22 46](https://user-images.githubusercontent.com/7163152/101771827-6c5d3600-3ae2-11eb-971a-44b346a9a567.png)

A confirmation modal is presented for the user to enter their password and confirm transfer. After which, the selected team member is detached from the team and associated as the new owner. The original owner is made an admin (open for debate).

## Testing

Tests have been added for this PR under `TransferTeamTest`
