### PR TITLE
[1.x] add missing import must verify email interface

### DIFF
--- a/stubs/app/Models/UserWithTeams.php
+++ b/stubs/app/Models/UserWithTeams.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;


### PR DESCRIPTION
This is similar to #182 but for when `--teams` is enabled.