### PR TITLE
[2.x] Cleanup team creation page

### DIFF
--- a/stubs/inertia/resources/js/Pages/Teams/Create.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/Create.vue
@@ -17,15 +17,11 @@
 <script>
     import AppLayout from '@/Layouts/AppLayout'
     import CreateTeamForm from './CreateTeamForm'
-    import JetSectionBorder from '@/Jetstream/SectionBorder'
 
     export default {
-        props: ['team'],
-
         components: {
             AppLayout,
             CreateTeamForm,
-            JetSectionBorder,
         },
     }
 </script>


### PR DESCRIPTION
This PR removes unused `JetSectionBorder` component and the `team` prop:

https://github.com/laravel/jetstream/blob/master/src/Http/Controllers/Inertia/TeamController.php#L57