### PR TITLE
[2.x] Set the error bag name

### DIFF
--- a/src/Actions/ValidateTeamDeletion.php
+++ b/src/Actions/ValidateTeamDeletion.php
@@ -21,7 +21,7 @@ class ValidateTeamDeletion
         if ($team->personal_team) {
             throw ValidationException::withMessages([
                 'team' => __('You may not delete your personal team.'),
-            ]);
+            ])->errorBag('deleteTeam');
         }
     }
 }


### PR DESCRIPTION
Inertia uses the `deleteTeam` bag when making the request, but the name is missing in the `ValidateTeamDeletion` action.

https://github.com/laravel/jetstream/blob/master/stubs/inertia/resources/js/Pages/Teams/DeleteTeamForm.vue#L72

It can be useful for showing the error in the modal window.