### PR TITLE
[2.x] Use name in the alt attribute

### DIFF
--- a/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
@@ -20,7 +20,7 @@
 
                 <!-- Current Profile Photo -->
                 <div class="mt-2" v-show="! photoPreview">
-                    <img :src="user.profile_photo_url" alt="Current Profile Photo" class="rounded-full h-20 w-20 object-cover">
+                    <img :src="user.profile_photo_url" :alt="user.name" class="rounded-full h-20 w-20 object-cover">
                 </div>
 
                 <!-- New Profile Photo Preview -->


### PR DESCRIPTION
Livewire version uses the user's name in the `alt` attribute:

https://github.com/laravel/jetstream/blob/master/stubs/livewire/resources/views/profile/update-profile-information-form.blade.php#L31