### PR TITLE
[2.x] Team member updated event

### DIFF
--- a/src/Actions/UpdateTeamMemberRole.php
+++ b/src/Actions/UpdateTeamMemberRole.php
@@ -4,6 +4,8 @@ namespace Laravel\Jetstream\Actions;
 
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Validator;
+use Laravel\Jetstream\Events\TeamMemberUpdated;
+use Laravel\Jetstream\Jetstream;
 use Laravel\Jetstream\Rules\Role;
 
 class UpdateTeamMemberRole
@@ -30,5 +32,7 @@ class UpdateTeamMemberRole
         $team->users()->updateExistingPivot($teamMemberId, [
             'role' => $role,
         ]);
+
+        TeamMemberUpdated::dispatch($team->fresh(), Jetstream::findUserByIdOrFail($teamMemberId));
     }
 }

--- a/src/Events/TeamMemberUpdated.php
+++ b/src/Events/TeamMemberUpdated.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Laravel\Jetstream\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+
+class TeamMemberUpdated
+{
+    use Dispatchable;
+
+    /**
+     * The team instance.
+     *
+     * @var mixed
+     */
+    public $team;
+
+    /**
+     * The team member that was updated.
+     *
+     * @var mixed
+     */
+    public $user;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  mixed  $team
+     * @param  mixed  $user
+     * @return void
+     */
+    public function __construct($team, $user)
+    {
+        $this->team = $team;
+        $this->user = $user;
+    }
+}


### PR DESCRIPTION
This PR adds a new `TeamMemberUpdated` event. The event get's dispatched at the end of the `UpdateTeamMemberRole` action.

As an example, developers might want to notify a user that their privileges have changed. Now that can do this more easily by reacting to this event.