### PR TITLE
Update banner so that the navigation does not "jump" in height on slow connections

### DIFF
--- a/resources/views/components/banner.blade.php
+++ b/resources/views/components/banner.blade.php
@@ -3,6 +3,7 @@
 <div x-data="{{ json_encode(['show' => true, 'style' => $style, 'message' => $message]) }}"
             :class="{ 'bg-indigo-500': style == 'success', 'bg-red-700': style == 'danger' }"
             x-show="show && message"
+            x-cloak
             x-init="
                 document.addEventListener('banner-message', event => {
                     style = event.detail.style;

--- a/stubs/resources/css/app.css
+++ b/stubs/resources/css/app.css
@@ -1,3 +1,7 @@
 @import 'tailwindcss/base';
 @import 'tailwindcss/components';
 @import 'tailwindcss/utilities';
+
+[x-cloak] {
+    display: none;
+}


### PR DESCRIPTION
There is a short delay when the page loads and the banner gets hidden.
This has the effect that the navigation "jumps" in height.
X-cloak is used to hide the element until alpine is finished loading. Alpine will the automatically delete the x-cloak attribute from the element.

https://github.com/alpinejs/alpine#x-cloak