### PR TITLE
Determine if the current stack is officially supported

### DIFF
--- a/src/Jetstream.php
+++ b/src/Jetstream.php
@@ -77,6 +77,23 @@ class Jetstream
     public static $inertiaManager;
 
     /**
+     * The officially supported stacks.
+     *
+     * @var array
+     */
+    public static $stacks = ['livewire', 'inertia'];
+
+    /**
+     * Determine if the current stack is officially supported.
+     *
+     * @return bool
+     */
+    public static function official()
+    {
+        return in_array(config('jetstream.stack'), static::$stacks);
+    }
+
+    /**
      * Determine if Jetstream has registered roles.
      *
      * @return bool

--- a/src/JetstreamServiceProvider.php
+++ b/src/JetstreamServiceProvider.php
@@ -187,7 +187,7 @@ class JetstreamServiceProvider extends ServiceProvider
      */
     protected function configureRoutes()
     {
-        if (Jetstream::$registersRoutes) {
+        if (Jetstream::$registersRoutes && Jetstream::official()) {
             Route::group([
                 'namespace' => 'Laravel\Jetstream\Http\Controllers',
                 'domain' => config('jetstream.domain', null),

--- a/tests/JetstreamTest.php
+++ b/tests/JetstreamTest.php
@@ -6,6 +6,15 @@ use Laravel\Jetstream\Jetstream;
 
 class JetstreamTest extends OrchestraTestCase
 {
+    public function test_detect_custom_stacks()
+    {
+        config()->set('jetstream.stack', 'react');
+        $this->assertFalse(Jetstream::official());
+
+        config()->set('jetstream.stack', 'inertia');
+        $this->assertTrue(Jetstream::official());
+    }
+
     public function test_roles_can_be_registered()
     {
         Jetstream::$permissions = [];


### PR DESCRIPTION
## Problem

I'm creating a custom Jetstream stack.

Everything looks great so far except that Jetstream always tries to register livewire or inertia routes.

## Solution

This PR makes Jetstream register routes only when the current stack is officially supported.