### PR TITLE
[2.x] Inertia: Revert default Vue i18n implementation

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -269,7 +269,6 @@ EOF;
             return [
                 '@inertiajs/inertia' => '^0.4.0',
                 '@inertiajs/inertia-vue' => '^0.3.0',
-                '@intlify/vue-i18n-loader' => '^1.0.0',
                 '@tailwindcss/forms' => '^0.2.1',
                 '@tailwindcss/typography' => '^0.3.0',
                 'laravel-jetstream' => '^1.0.0',
@@ -279,7 +278,6 @@ EOF;
                 'tailwindcss' => 'npm:@tailwindcss/postcss7-compat@^2.0.1',
                 'autoprefixer' => '^9.8.6',
                 'vue' => '^2.5.17',
-                'vue-i18n' => '^8.22.1',
                 'vue-template-compiler' => '^2.6.10',
             ] + $packages;
         });

--- a/src/Http/Middleware/ShareInertiaData.php
+++ b/src/Http/Middleware/ShareInertiaData.php
@@ -29,13 +29,11 @@ class ShareInertiaData
                     'canManageTwoFactorAuthentication' => Features::canManageTwoFactorAuthentication(),
                     'canUpdatePassword' => Features::enabled(Features::updatePasswords()),
                     'canUpdateProfileInformation' => Features::canUpdateProfileInformation(),
-                    'fallbackLocale' => app()->getFallbackLocale(),
                     'flash' => $request->session()->get('flash', []),
                     'hasAccountDeletionFeatures' => Jetstream::hasAccountDeletionFeatures(),
                     'hasApiFeatures' => Jetstream::hasApiFeatures(),
                     'hasTeamFeatures' => Jetstream::hasTeamFeatures(),
                     'hasTermsAndPrivacyPolicyFeature' => Jetstream::hasTermsAndPrivacyPolicyFeature(),
-                    'locale' => app()->getLocale(),
                     'managesProfilePhotos' => Jetstream::managesProfilePhotos(),
                 ];
             },

--- a/stubs/inertia/resources/js/Jetstream/Banner.vue
+++ b/stubs/inertia/resources/js/Jetstream/Banner.vue
@@ -24,7 +24,7 @@
                             type="button"
                             class="-mr-1 flex p-2 rounded-md focus:outline-none sm:-mr-2 transition ease-in-out duration-150"
                             :class="{ 'hover:bg-indigo-600 focus:bg-indigo-600': style == 'success', 'hover:bg-red-600 focus:bg-red-600': style == 'danger' }"
-                            :aria-label="$t('Dismiss')"
+                            aria-label="Dismiss"
                             @click.prevent="show = false">
                             <svg class="h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />

--- a/stubs/inertia/resources/js/Jetstream/ConfirmsPassword.vue
+++ b/stubs/inertia/resources/js/Jetstream/ConfirmsPassword.vue
@@ -13,7 +13,7 @@
                 {{ content }}
 
                 <div class="mt-4">
-                    <jet-input type="password" class="mt-1 block w-3/4" :placeholder="$t('Password')"
+                    <jet-input type="password" class="mt-1 block w-3/4" placeholder="Password"
                                 ref="password"
                                 v-model="form.password"
                                 @keyup.enter.native="confirmPassword" />
@@ -24,7 +24,7 @@
 
             <template #footer>
                 <jet-secondary-button @click.native="confirmingPassword = false">
-                    {{ $t('Nevermind') }}
+                    Nevermind
                 </jet-secondary-button>
 
                 <jet-button class="ml-2" @click.native="confirmPassword" :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
@@ -45,19 +45,13 @@
     export default {
         props: {
             title: {
-                default: function () {
-                    return this.$t('Confirm Password')
-                },
+                default: 'Confirm Password',
             },
             content: {
-                default: function () {
-                    return this.$t('For your security, please confirm your password to continue.')
-                },
+                default: 'For your security, please confirm your password to continue.',
             },
             button: {
-                default: function () {
-                    return this.$t('Confirm')
-                },
+                default: 'Confirm',
             }
         },
 

--- a/stubs/inertia/resources/js/Jetstream/ValidationErrors.vue
+++ b/stubs/inertia/resources/js/Jetstream/ValidationErrors.vue
@@ -1,6 +1,6 @@
 <template>
     <div v-if="hasErrors">
-        <div class="font-medium text-red-600">{{ $t('Whoops! Something went wrong.') }}</div>
+        <div class="font-medium text-red-600">Whoops! Something went wrong.</div>
 
         <ul class="mt-3 list-disc list-inside text-sm text-red-600">
             <li v-for="(error, key) in flattenedErrors" :key="key">{{ error }}</li>

--- a/stubs/inertia/resources/js/Layouts/AppLayout.vue
+++ b/stubs/inertia/resources/js/Layouts/AppLayout.vue
@@ -18,7 +18,7 @@
                             <!-- Navigation Links -->
                             <div class="hidden space-x-8 sm:-my-px sm:ml-10 sm:flex">
                                 <jet-nav-link :href="route('dashboard')" :active="route().current('dashboard')">
-                                    {{ $t('Dashboard') }}
+                                    Dashboard
                                 </jet-nav-link>
                             </div>
                         </div>
@@ -44,23 +44,23 @@
                                             <!-- Team Management -->
                                             <template v-if="$page.props.jetstream.hasTeamFeatures">
                                                 <div class="block px-4 py-2 text-xs text-gray-400">
-                                                    {{ $t('Manage Team') }}
+                                                    Manage Team
                                                 </div>
 
                                                 <!-- Team Settings -->
                                                 <jet-dropdown-link :href="route('teams.show', $page.props.user.current_team)">
-                                                    {{ $t('Team Settings') }}
+                                                    Team Settings
                                                 </jet-dropdown-link>
 
                                                 <jet-dropdown-link :href="route('teams.create')" v-if="$page.props.jetstream.canCreateTeams">
-                                                    {{ $t('Create New Team') }}
+                                                    Create New Team
                                                 </jet-dropdown-link>
 
                                                 <div class="border-t border-gray-100"></div>
 
                                                 <!-- Team Switcher -->
                                                 <div class="block px-4 py-2 text-xs text-gray-400">
-                                                    {{ $t('Switch Teams') }}
+                                                    Switch Teams
                                                 </div>
 
                                                 <template v-for="team in $page.props.user.all_teams">
@@ -101,15 +101,15 @@
                                     <template #content>
                                         <!-- Account Management -->
                                         <div class="block px-4 py-2 text-xs text-gray-400">
-                                            {{ $t('Manage Account') }}
+                                            Manage Account
                                         </div>
 
                                         <jet-dropdown-link :href="route('profile.show')">
-                                            {{ $t('Profile') }}
+                                            Profile
                                         </jet-dropdown-link>
 
                                         <jet-dropdown-link :href="route('api-tokens.index')" v-if="$page.props.jetstream.hasApiFeatures">
-                                            {{ $t('API Tokens') }}
+                                            API Tokens
                                         </jet-dropdown-link>
 
                                         <div class="border-t border-gray-100"></div>
@@ -117,7 +117,7 @@
                                         <!-- Authentication -->
                                         <form @submit.prevent="logout">
                                             <jet-dropdown-link as="button">
-                                                {{ $t('Logout') }}
+                                                Logout
                                             </jet-dropdown-link>
                                         </form>
                                     </template>
@@ -141,7 +141,7 @@
                 <div :class="{'block': showingNavigationDropdown, 'hidden': ! showingNavigationDropdown}" class="sm:hidden">
                     <div class="pt-2 pb-3 space-y-1">
                         <jet-responsive-nav-link :href="route('dashboard')" :active="route().current('dashboard')">
-                            {{ $t('Dashboard') }}
+                            Dashboard
                         </jet-responsive-nav-link>
                     </div>
 
@@ -160,17 +160,17 @@
 
                         <div class="mt-3 space-y-1">
                             <jet-responsive-nav-link :href="route('profile.show')" :active="route().current('profile.show')">
-                                {{ $t('Profile') }}
+                                Profile
                             </jet-responsive-nav-link>
 
                             <jet-responsive-nav-link :href="route('api-tokens.index')" :active="route().current('api-tokens.index')" v-if="$page.props.jetstream.hasApiFeatures">
-                                {{ $t('API Tokens') }}
+                                API Tokens
                             </jet-responsive-nav-link>
 
                             <!-- Authentication -->
                             <form method="POST" @submit.prevent="logout">
                                 <jet-responsive-nav-link as="button">
-                                    {{ $t('Logout') }}
+                                    Logout
                                 </jet-responsive-nav-link>
                             </form>
 
@@ -179,23 +179,23 @@
                                 <div class="border-t border-gray-200"></div>
 
                                 <div class="block px-4 py-2 text-xs text-gray-400">
-                                    {{ $t('Manage Team') }}
+                                    Manage Team
                                 </div>
 
                                 <!-- Team Settings -->
                                 <jet-responsive-nav-link :href="route('teams.show', $page.props.user.current_team)" :active="route().current('teams.show')">
-                                    {{ $t('Team Settings') }}
+                                    Team Settings
                                 </jet-responsive-nav-link>
 
                                 <jet-responsive-nav-link :href="route('teams.create')" :active="route().current('teams.create')">
-                                    {{ $t('Create New Team') }}
+                                    Create New Team
                                 </jet-responsive-nav-link>
 
                                 <div class="border-t border-gray-200"></div>
 
                                 <!-- Team Switcher -->
                                 <div class="block px-4 py-2 text-xs text-gray-400">
-                                    {{ $t('Switch Teams') }}
+                                    Switch Teams
                                 </div>
 
                                 <template v-for="team in $page.props.user.all_teams">

--- a/stubs/inertia/resources/js/Pages/API/ApiTokenManager.vue
+++ b/stubs/inertia/resources/js/Pages/API/ApiTokenManager.vue
@@ -3,24 +3,24 @@
         <!-- Generate API Token -->
         <jet-form-section @submitted="createApiToken">
             <template #title>
-                {{ $t('Create API Token') }}
+                Create API Token
             </template>
 
             <template #description>
-                {{ $t('API tokens allow third-party services to authenticate with our application on your behalf.') }}
+                API tokens allow third-party services to authenticate with our application on your behalf.
             </template>
 
             <template #form>
                 <!-- Token Name -->
                 <div class="col-span-6 sm:col-span-4">
-                    <jet-label for="name" :value="$t('Name')" />
+                    <jet-label for="name" value="Name" />
                     <jet-input id="name" type="text" class="mt-1 block w-full" v-model="createApiTokenForm.name" autofocus />
                     <jet-input-error :message="createApiTokenForm.error('name')" class="mt-2" />
                 </div>
 
                 <!-- Token Permissions -->
                 <div class="col-span-6" v-if="availablePermissions.length > 0">
-                    <jet-label for="permissions" :value="$t('Permissions')" />
+                    <jet-label for="permissions" value="Permissions" />
 
                     <div class="mt-2 grid grid-cols-1 md:grid-cols-2 gap-4">
                         <div v-for="permission in availablePermissions" :key="permission">
@@ -35,11 +35,11 @@
 
             <template #actions>
                 <jet-action-message :on="createApiTokenForm.recentlySuccessful" class="mr-3">
-                    {{ $t('Created.') }}
+                    Created.
                 </jet-action-message>
 
                 <jet-button :class="{ 'opacity-25': createApiTokenForm.processing }" :disabled="createApiTokenForm.processing">
-                    {{ $t('Create') }}
+                    Create
                 </jet-button>
             </template>
         </jet-form-section>
@@ -51,11 +51,11 @@
             <div class="mt-10 sm:mt-0">
                 <jet-action-section>
                     <template #title>
-                        {{ $t('Manage API Tokens') }}
+                        Manage API Tokens
                     </template>
 
                     <template #description>
-                        {{ $t('You may delete any of your existing tokens if they are no longer needed.') }}
+                        You may delete any of your existing tokens if they are no longer needed.
                     </template>
 
                     <!-- API Token List -->
@@ -68,17 +68,17 @@
 
                                 <div class="flex items-center">
                                     <div class="text-sm text-gray-400" v-if="token.last_used_at">
-                                        {{ $t('Last used {last_used}', { 'last_used': fromNow(token.last_used_at) }) }}
+                                        Last used {{ fromNow(token.last_used_at) }}
                                     </div>
 
                                     <button class="cursor-pointer ml-6 text-sm text-gray-400 underline"
                                                 @click="manageApiTokenPermissions(token)"
                                                 v-if="availablePermissions.length > 0">
-                                        {{ $t('Permissions') }}
+                                        Permissions
                                     </button>
 
                                     <button class="cursor-pointer ml-6 text-sm text-red-500" @click="confirmApiTokenDeletion(token)">
-                                        {{ $t('Delete') }}
+                                        Delete
                                     </button>
                                 </div>
                             </div>
@@ -91,12 +91,12 @@
         <!-- Token Value Modal -->
         <jet-dialog-modal :show="displayingToken" @close="displayingToken = false">
             <template #title>
-                {{ $t('API Token') }}
+                API Token
             </template>
 
             <template #content>
                 <div>
-                    {{ $t('Please copy your new API token. For your security, it won\'t be shown again.') }}
+                    Please copy your new API token. For your security, it won't be shown again.
                 </div>
 
                 <div class="mt-4 bg-gray-100 px-4 py-2 rounded font-mono text-sm text-gray-500" v-if="$page.props.jetstream.flash.token">
@@ -106,7 +106,7 @@
 
             <template #footer>
                 <jet-secondary-button @click.native="displayingToken = false">
-                    {{ $t('Close') }}
+                    Close
                 </jet-secondary-button>
             </template>
         </jet-dialog-modal>
@@ -114,7 +114,7 @@
         <!-- API Token Permissions Modal -->
         <jet-dialog-modal :show="managingPermissionsFor" @close="managingPermissionsFor = null">
             <template #title>
-                {{ $t('API Token Permissions') }}
+                API Token Permissions
             </template>
 
             <template #content>
@@ -130,11 +130,11 @@
 
             <template #footer>
                 <jet-secondary-button @click.native="managingPermissionsFor = null">
-                    {{ $t('Nevermind') }}
+                    Nevermind
                 </jet-secondary-button>
 
                 <jet-button class="ml-2" @click.native="updateApiToken" :class="{ 'opacity-25': updateApiTokenForm.processing }" :disabled="updateApiTokenForm.processing">
-                    {{ $t('Save') }}
+                    Save
                 </jet-button>
             </template>
         </jet-dialog-modal>
@@ -142,20 +142,20 @@
         <!-- Delete Token Confirmation Modal -->
         <jet-confirmation-modal :show="apiTokenBeingDeleted" @close="apiTokenBeingDeleted = null">
             <template #title>
-                {{ $t('Delete API Token') }}
+                Delete API Token
             </template>
 
             <template #content>
-                {{ $t('Are you sure you would like to delete this API token?') }}
+                Are you sure you would like to delete this API token?
             </template>
 
             <template #footer>
                 <jet-secondary-button @click.native="apiTokenBeingDeleted = null">
-                    {{ $t('Nevermind') }}
+                    Nevermind
                 </jet-secondary-button>
 
                 <jet-danger-button class="ml-2" @click.native="deleteApiToken" :class="{ 'opacity-25': deleteApiTokenForm.processing }" :disabled="deleteApiTokenForm.processing">
-                    {{ $t('Delete') }}
+                    Delete
                 </jet-danger-button>
             </template>
         </jet-confirmation-modal>

--- a/stubs/inertia/resources/js/Pages/API/Index.vue
+++ b/stubs/inertia/resources/js/Pages/API/Index.vue
@@ -2,7 +2,7 @@
     <app-layout>
         <template #header>
             <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-                {{ $t('API Tokens') }}
+                API Tokens
             </h2>
         </template>
 

--- a/stubs/inertia/resources/js/Pages/Auth/ConfirmPassword.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/ConfirmPassword.vue
@@ -5,20 +5,20 @@
         </template>
 
         <div class="mb-4 text-sm text-gray-600">
-            {{ $t('This is a secure area of the application. Please confirm your password before continuing.') }}
+            This is a secure area of the application. Please confirm your password before continuing.
         </div>
 
         <jet-validation-errors class="mb-4" />
 
         <form @submit.prevent="submit">
             <div>
-                <jet-label for="password" :value="$t('Password')" />
+                <jet-label for="password" value="Password" />
                 <jet-input id="password" type="password" class="mt-1 block w-full" v-model="form.password" required autocomplete="current-password" autofocus />
             </div>
 
             <div class="flex justify-end mt-4">
                 <jet-button class="ml-4" :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
-                    {{ $t('Confirm') }}
+                    Confirm
                 </jet-button>
             </div>
         </form>

--- a/stubs/inertia/resources/js/Pages/Auth/ForgotPassword.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/ForgotPassword.vue
@@ -5,7 +5,7 @@
         </template>
 
         <div class="mb-4 text-sm text-gray-600">
-            {{ $t('Forgot your password? No problem. Just let us know your email address and we will email you a password reset link that will allow you to choose a new one.') }}
+            Forgot your password? No problem. Just let us know your email address and we will email you a password reset link that will allow you to choose a new one.
         </div>
 
         <div v-if="status" class="mb-4 font-medium text-sm text-green-600">
@@ -16,13 +16,13 @@
 
         <form @submit.prevent="submit">
             <div>
-                <jet-label for="email" :value="$t('Email')" />
+                <jet-label for="email" value="Email" />
                 <jet-input id="email" type="email" class="mt-1 block w-full" v-model="form.email" required autofocus />
             </div>
 
             <div class="flex items-center justify-end mt-4">
                 <jet-button :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
-                    {{ $t('Email Password Reset Link') }}
+                    Email Password Reset Link
                 </jet-button>
             </div>
         </form>

--- a/stubs/inertia/resources/js/Pages/Auth/Login.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/Login.vue
@@ -12,29 +12,29 @@
 
         <form @submit.prevent="submit">
             <div>
-                <jet-label for="email" :value="$t('Email')" />
+                <jet-label for="email" value="Email" />
                 <jet-input id="email" type="email" class="mt-1 block w-full" v-model="form.email" required autofocus />
             </div>
 
             <div class="mt-4">
-                <jet-label for="password" :value="$t('Password')" />
+                <jet-label for="password" value="Password" />
                 <jet-input id="password" type="password" class="mt-1 block w-full" v-model="form.password" required autocomplete="current-password" />
             </div>
 
             <div class="block mt-4">
                 <label class="flex items-center">
                     <jet-checkbox  name="remember" v-model="remember"/>
-                    <span class="ml-2 text-sm text-gray-600">{{ $t('Remember me') }}</span>
+                    <span class="ml-2 text-sm text-gray-600">Remember me</span>
                 </label>
             </div>
 
             <div class="flex items-center justify-end mt-4">
                 <inertia-link v-if="canResetPassword" :href="route('password.request')" class="underline text-sm text-gray-600 hover:text-gray-900">
-                    {{ $t('Forgot your password?') }}
+                    Forgot your password?
                 </inertia-link>
 
                 <jet-button class="ml-4" :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
-                    {{ $t('Login') }}
+                    Login
                 </jet-button>
             </div>
         </form>

--- a/stubs/inertia/resources/js/Pages/Auth/Register.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/Register.vue
@@ -8,22 +8,22 @@
 
         <form @submit.prevent="submit">
             <div>
-                <jet-label for="name" :value="$t('Name')" />
+                <jet-label for="name" value="Name" />
                 <jet-input id="name" type="text" class="mt-1 block w-full" v-model="form.name" required autofocus autocomplete="name" />
             </div>
 
             <div class="mt-4">
-                <jet-label for="email" :value="$t('Email')" />
+                <jet-label for="email" value="Email" />
                 <jet-input id="email" type="email" class="mt-1 block w-full" v-model="form.email" required />
             </div>
 
             <div class="mt-4">
-                <jet-label for="password" :value="$t('Password')" />
+                <jet-label for="password" value="Password" />
                 <jet-input id="password" type="password" class="mt-1 block w-full" v-model="form.password" required autocomplete="new-password" />
             </div>
 
             <div class="mt-4">
-                <jet-label for="password_confirmation" :value="$t('Confirm Password')" />
+                <jet-label for="password_confirmation" value="Confirm Password" />
                 <jet-input id="password_confirmation" type="password" class="mt-1 block w-full" v-model="form.password_confirmation" required autocomplete="new-password" />
             </div>
 
@@ -32,26 +32,20 @@
                     <div class="flex items-center">
                         <jet-checkbox name="terms" id="terms" v-model="form.terms"/>
 
-                        <i18n path="I agree to the {terms_of_service} and {privacy_policy}" tag="div" class="ml-2">
-                            <template #terms_of_service>
-                                <a target="_blank" :href="route('terms.show')" class="underline text-sm text-gray-600 hover:text-gray-900">{{ $t('Terms of Service') }}</a>
-                            </template>
-
-                            <template #privacy_policy>
-                                <a target="_blank" :href="route('policy.show')" class="underline text-sm text-gray-600 hover:text-gray-900">{{ $t('Privacy Policy') }}</a>
-                            </template>
-                        </i18n>
+                        <div>
+                            I agree to the <inertia-link target="_blank" :href="route('terms.show')" class="underline text-sm text-gray-600 hover:text-gray-900">Terms of Service</inertia-link> and <inertia-link target="_blank" :href="route('policy.show')" class="underline text-sm text-gray-600 hover:text-gray-900">Privacy Policy</inertia-link>
+                        </div>
                     </div>
                 </jet-label>
             </div>
 
             <div class="flex items-center justify-end mt-4">
                 <inertia-link :href="route('login')" class="underline text-sm text-gray-600 hover:text-gray-900">
-                    {{ $t('Already registered?') }}
+                    Already registered?
                 </inertia-link>
 
                 <jet-button class="ml-4" :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
-                    {{ $t('Register') }}
+                    Register
                 </jet-button>
             </div>
         </form>

--- a/stubs/inertia/resources/js/Pages/Auth/ResetPassword.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/ResetPassword.vue
@@ -8,23 +8,23 @@
 
         <form @submit.prevent="submit">
             <div>
-                <jet-label for="email" :value="$t('Email')" />
+                <jet-label for="email" value="Email" />
                 <jet-input id="email" type="email" class="mt-1 block w-full" v-model="form.email" required autofocus />
             </div>
 
             <div class="mt-4">
-                <jet-label for="password" :value="$t('Password')" />
+                <jet-label for="password" value="Password" />
                 <jet-input id="password" type="password" class="mt-1 block w-full" v-model="form.password" required autocomplete="new-password" />
             </div>
 
             <div class="mt-4">
-                <jet-label for="password_confirmation" :value="$t('Confirm Password')" />
+                <jet-label for="password_confirmation" value="Confirm Password" />
                 <jet-input id="password_confirmation" type="password" class="mt-1 block w-full" v-model="form.password_confirmation" required autocomplete="new-password" />
             </div>
 
             <div class="flex items-center justify-end mt-4">
                 <jet-button :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
-                    {{ $t('Reset Password') }}
+                    Reset Password
                 </jet-button>
             </div>
         </form>

--- a/stubs/inertia/resources/js/Pages/Auth/TwoFactorChallenge.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/TwoFactorChallenge.vue
@@ -6,11 +6,11 @@
 
         <div class="mb-4 text-sm text-gray-600">
             <template v-if="! recovery">
-                {{ $t('Please confirm access to your account by entering the authentication code provided by your authenticator application.') }}
+                Please confirm access to your account by entering the authentication code provided by your authenticator application.
             </template>
 
             <template v-else>
-                {{ $t('Please confirm access to your account by entering one of your emergency recovery codes.') }}
+                Please confirm access to your account by entering one of your emergency recovery codes.
             </template>
         </div>
 
@@ -18,28 +18,28 @@
 
         <form @submit.prevent="submit">
             <div v-if="! recovery">
-                <jet-label for="code" :value="$t('Code')" />
+                <jet-label for="code" value="Code" />
                 <jet-input ref="code" id="code" type="text" inputmode="numeric" class="mt-1 block w-full" v-model="form.code" autofocus autocomplete="one-time-code" />
             </div>
 
             <div v-else>
-                <jet-label for="recovery_code" :value="$t('Recovery Code')" />
+                <jet-label for="recovery_code" value="Recovery Code" />
                 <jet-input ref="recovery_code" id="recovery_code" type="text" class="mt-1 block w-full" v-model="form.recovery_code" autocomplete="one-time-code" />
             </div>
 
             <div class="flex items-center justify-end mt-4">
                 <button type="button" class="text-sm text-gray-600 hover:text-gray-900 underline cursor-pointer" @click.prevent="toggleRecovery">
                     <template v-if="! recovery">
-                        {{ $t('Use a recovery code') }}
+                        Use a recovery code
                     </template>
 
                     <template v-else>
-                        {{ $t('Use an authentication code') }}
+                        Use an authentication code
                     </template>
                 </button>
 
                 <jet-button class="ml-4" :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
-                    {{ $t('Login') }}
+                    Login
                 </jet-button>
             </div>
         </form>

--- a/stubs/inertia/resources/js/Pages/Auth/VerifyEmail.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/VerifyEmail.vue
@@ -5,20 +5,20 @@
         </template>
 
         <div class="mb-4 text-sm text-gray-600">
-            {{ $t('Thanks for signing up! Before getting started, could you verify your email address by clicking on the link we just emailed to you? If you didn\'t receive the email, we will gladly send you another.') }}'
+            Thanks for signing up! Before getting started, could you verify your email address by clicking on the link we just emailed to you? If you didn't receive the email, we will gladly send you another.
         </div>
 
         <div class="mb-4 font-medium text-sm text-green-600" v-if="verificationLinkSent" >
-            {{ $t('A new verification link has been sent to the email address you provided during registration.') }}
+            A new verification link has been sent to the email address you provided during registration.
         </div>
 
         <form @submit.prevent="submit">
             <div class="mt-4 flex items-center justify-between">
                 <jet-button :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
-                    {{ $t('Resend Verification Email') }}
+                    Resend Verification Email
                 </jet-button>
 
-                <inertia-link :href="route('logout')" method="post" class="underline text-sm text-gray-600 hover:text-gray-900">{{ $t('Logout') }}</inertia-link>
+                <inertia-link :href="route('logout')" method="post" class="underline text-sm text-gray-600 hover:text-gray-900">Logout</inertia-link>
             </div>
         </form>
     </jet-authentication-card>

--- a/stubs/inertia/resources/js/Pages/Dashboard.vue
+++ b/stubs/inertia/resources/js/Pages/Dashboard.vue
@@ -2,7 +2,7 @@
     <app-layout>
         <template #header>
             <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-                {{ $t('Dashboard') }}
+                Dashboard
             </h2>
         </template>
 

--- a/stubs/inertia/resources/js/Pages/Profile/DeleteUserForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/DeleteUserForm.vue
@@ -1,36 +1,35 @@
 <template>
     <jet-action-section>
         <template #title>
-            {{ $t('Delete Account') }}
+            Delete Account
         </template>
 
         <template #description>
-            {{ $t('Permanently delete your account.') }}
+            Permanently delete your account.
         </template>
 
         <template #content>
             <div class="max-w-xl text-sm text-gray-600">
-                {{ $t('Once your account is deleted, all of its resources and data will be permanently deleted. Before deleting your account, please download any data or information that you wish to retain.') }}
+                Once your account is deleted, all of its resources and data will be permanently deleted. Before deleting your account, please download any data or information that you wish to retain.
             </div>
 
             <div class="mt-5">
                 <jet-danger-button @click.native="confirmUserDeletion">
-                    {{ $t('Delete Account') }}
+                    Delete Account
                 </jet-danger-button>
             </div>
 
             <!-- Delete Account Confirmation Modal -->
             <jet-dialog-modal :show="confirmingUserDeletion" @close="confirmingUserDeletion = false">
                 <template #title>
-                    {{ $t('Delete Account') }}
+                    Delete Account
                 </template>
 
                 <template #content>
-                    {{ $t('Are you sure you want to delete your account? Once your account is deleted, all of its resources and data will be permanently deleted. Please enter your password to confirm you would like to permanently delete your account.') }}
+                    Are you sure you want to delete your account? Once your account is deleted, all of its resources and data will be permanently deleted. Please enter your password to confirm you would like to permanently delete your account.
 
                     <div class="mt-4">
-                        <jet-input type="password" class="mt-1 block w-3/4"
-                                    :placeholder="$t('Password')"
+                        <jet-input type="password" class="mt-1 block w-3/4" placeholder="Password"
                                     ref="password"
                                     v-model="form.password"
                                     @keyup.enter.native="deleteUser" />
@@ -41,13 +40,11 @@
 
                 <template #footer>
                     <jet-secondary-button @click.native="confirmingUserDeletion = false">
-                        {{ $t('Nevermind') }}
+                        Nevermind
                     </jet-secondary-button>
 
-                    <jet-danger-button class="ml-2"
-                                       @click.native="deleteUser"
-                                       :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
-                        {{ $t('Delete Account') }}
+                    <jet-danger-button class="ml-2" @click.native="deleteUser" :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
+                        Delete Account
                     </jet-danger-button>
                 </template>
             </jet-dialog-modal>

--- a/stubs/inertia/resources/js/Pages/Profile/LogoutOtherBrowserSessionsForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/LogoutOtherBrowserSessionsForm.vue
@@ -1,16 +1,16 @@
 <template>
     <jet-action-section>
         <template #title>
-            {{ $t('Browser Sessions') }}
+            Browser Sessions
         </template>
 
         <template #description>
-            {{ $t('Manage and logout your active sessions on other browsers and devices.') }}
+            Manage and logout your active sessions on other browsers and devices.
         </template>
 
         <template #content>
             <div class="max-w-xl text-sm text-gray-600">
-                {{ $t('If necessary, you may logout of all of your other browser sessions across all of your devices. Some of your recent sessions are listed below; however, this list may not be exhaustive. If you feel your account has been compromised, you should also update your password.') }}
+                If necessary, you may logout of all of your other browser sessions across all of your devices. Some of your recent sessions are listed below; however, this list may not be exhaustive. If you feel your account has been compromised, you should also update your password.
             </div>
 
             <!-- Other Browser Sessions -->
@@ -35,8 +35,8 @@
                             <div class="text-xs text-gray-500">
                                 {{ session.ip_address }},
 
-                                <span class="text-green-500 font-semibold" v-if="session.is_current_device">{{ $t('This device') }}</span>
-                                <span v-else>{{ $t('Last active {last_active}', { 'last_active': session.last_active }) }}</span>
+                                <span class="text-green-500 font-semibold" v-if="session.is_current_device">This device</span>
+                                <span v-else>Last active {{ session.last_active }}</span>
                             </div>
                         </div>
                     </div>
@@ -45,26 +45,25 @@
 
             <div class="flex items-center mt-5">
                 <jet-button @click.native="confirmLogout">
-                    {{ $t('Logout Other Browser Sessions') }}
+                    Logout Other Browser Sessions
                 </jet-button>
 
                 <jet-action-message :on="form.recentlySuccessful" class="ml-3">
-                    {{ $t('Done.') }}
+                    Done.
                 </jet-action-message>
             </div>
 
             <!-- Logout Other Devices Confirmation Modal -->
             <jet-dialog-modal :show="confirmingLogout" @close="confirmingLogout = false">
                 <template #title>
-                    {{ $t('Logout Other Browser Sessions') }}
+                    Logout Other Browser Sessions
                 </template>
 
                 <template #content>
-                    {{ $t('Please enter your password to confirm you would like to logout of your other browser sessions across all of your devices.') }}
+                    Please enter your password to confirm you would like to logout of your other browser sessions across all of your devices.
 
                     <div class="mt-4">
-                        <jet-input type="password" class="mt-1 block w-3/4"
-                                    :placeholder="$t('Password')"
+                        <jet-input type="password" class="mt-1 block w-3/4" placeholder="Password"
                                     ref="password"
                                     v-model="form.password"
                                     @keyup.enter.native="logoutOtherBrowserSessions" />
@@ -75,14 +74,11 @@
 
                 <template #footer>
                     <jet-secondary-button @click.native="confirmingLogout = false">
-                        {{ $t('Nevermind') }}
+                        Nevermind
                     </jet-secondary-button>
 
-                    <jet-button class="ml-2"
-                                :class="{ 'opacity-25': form.processing }"
-                                @click.native="logoutOtherBrowserSessions"
-                                :disabled="form.processing">
-                        {{ $t('Logout Other Browser Sessions') }}
+                    <jet-button class="ml-2" @click.native="logoutOtherBrowserSessions" :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
+                        Logout Other Browser Sessions
                     </jet-button>
                 </template>
             </jet-dialog-modal>

--- a/stubs/inertia/resources/js/Pages/Profile/Show.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/Show.vue
@@ -2,7 +2,7 @@
     <app-layout>
         <template #header>
             <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-                {{ $t('Profile') }}
+                Profile
             </h2>
         </template>
 

--- a/stubs/inertia/resources/js/Pages/Profile/TwoFactorAuthenticationForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/TwoFactorAuthenticationForm.vue
@@ -1,25 +1,25 @@
 <template>
     <jet-action-section>
         <template #title>
-            {{ $t('Two Factor Authentication') }}
+            Two Factor Authentication
         </template>
 
         <template #description>
-            {{ $t('Add additional security to your account using two factor authentication.') }}
+            Add additional security to your account using two factor authentication.
         </template>
 
         <template #content>
             <h3 class="text-lg font-medium text-gray-900" v-if="twoFactorEnabled">
-                {{ $t('You have enabled two factor authentication.') }}
+                You have enabled two factor authentication.
             </h3>
 
             <h3 class="text-lg font-medium text-gray-900" v-else>
-                {{ $t('You have not enabled two factor authentication.') }}
+                You have not enabled two factor authentication.
             </h3>
 
             <div class="mt-3 max-w-xl text-sm text-gray-600">
                 <p>
-                    {{ $t('When two factor authentication is enabled, you will be prompted for a secure, random token during authentication. You may retrieve this token from your phone\'s Google Authenticator application.') }}
+                    When two factor authentication is enabled, you will be prompted for a secure, random token during authentication. You may retrieve this token from your phone's Google Authenticator application.
                 </p>
             </div>
 
@@ -27,7 +27,7 @@
                 <div v-if="qrCode">
                     <div class="mt-4 max-w-xl text-sm text-gray-600">
                         <p class="font-semibold">
-                            {{ $t('Two factor authentication is now enabled. Scan the following QR code using your phone\'s authenticator application.') }}
+                            Two factor authentication is now enabled. Scan the following QR code using your phone's authenticator application.
                         </p>
                     </div>
 
@@ -38,7 +38,7 @@
                 <div v-if="recoveryCodes.length > 0">
                     <div class="mt-4 max-w-xl text-sm text-gray-600">
                         <p class="font-semibold">
-                            {{ $t('Store these recovery codes in a secure password manager. They can be used to recover access to your account if your two factor authentication device is lost.') }}
+                            Store these recovery codes in a secure password manager. They can be used to recover access to your account if your two factor authentication device is lost.
                         </p>
                     </div>
 
@@ -54,27 +54,30 @@
                 <div v-if="! twoFactorEnabled">
                     <jet-confirms-password @confirmed="enableTwoFactorAuthentication">
                         <jet-button type="button" :class="{ 'opacity-25': enabling }" :disabled="enabling">
-                            {{ $t('Enable') }}
+                            Enable
                         </jet-button>
                     </jet-confirms-password>
                 </div>
 
                 <div v-else>
                     <jet-confirms-password @confirmed="regenerateRecoveryCodes">
-                        <jet-secondary-button class="mr-3" v-if="recoveryCodes.length > 0">
-                            {{ $t('Regenerate Recovery Codes') }}
+                        <jet-secondary-button class="mr-3"
+                                        v-if="recoveryCodes.length > 0">
+                            Regenerate Recovery Codes
                         </jet-secondary-button>
                     </jet-confirms-password>
 
                     <jet-confirms-password @confirmed="showRecoveryCodes">
                         <jet-secondary-button class="mr-3" v-if="recoveryCodes.length == 0">
-                            {{ $t('Show Recovery Codes') }}
+                            Show Recovery Codes
                         </jet-secondary-button>
                     </jet-confirms-password>
 
                     <jet-confirms-password @confirmed="disableTwoFactorAuthentication">
-                        <jet-danger-button :class="{ 'opacity-25': disabling }" :disabled="disabling">
-                            {{ $t('Disable') }}
+                        <jet-danger-button
+                                        :class="{ 'opacity-25': disabling }"
+                                        :disabled="disabling">
+                            Disable
                         </jet-danger-button>
                     </jet-confirms-password>
                 </div>

--- a/stubs/inertia/resources/js/Pages/Profile/UpdatePasswordForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/UpdatePasswordForm.vue
@@ -1,28 +1,28 @@
 <template>
     <jet-form-section @submitted="updatePassword">
         <template #title>
-            {{ $t('Update Password') }}
+            Update Password
         </template>
 
         <template #description>
-            {{ $t('Ensure your account is using a long, random password to stay secure.') }}
+            Ensure your account is using a long, random password to stay secure.
         </template>
 
         <template #form>
             <div class="col-span-6 sm:col-span-4">
-                <jet-label for="current_password" :value="$t('Current Password')" />
+                <jet-label for="current_password" value="Current Password" />
                 <jet-input id="current_password" type="password" class="mt-1 block w-full" v-model="form.current_password" ref="current_password" autocomplete="current-password" />
                 <jet-input-error :message="form.error('current_password')" class="mt-2" />
             </div>
 
             <div class="col-span-6 sm:col-span-4">
-                <jet-label for="password" :value="$t('New Password')" />
+                <jet-label for="password" value="New Password" />
                 <jet-input id="password" type="password" class="mt-1 block w-full" v-model="form.password" autocomplete="new-password" />
                 <jet-input-error :message="form.error('password')" class="mt-2" />
             </div>
 
             <div class="col-span-6 sm:col-span-4">
-                <jet-label for="password_confirmation" :value="$t('Confirm Password')" />
+                <jet-label for="password_confirmation" value="Confirm Password" />
                 <jet-input id="password_confirmation" type="password" class="mt-1 block w-full" v-model="form.password_confirmation" autocomplete="new-password" />
                 <jet-input-error :message="form.error('password_confirmation')" class="mt-2" />
             </div>
@@ -30,11 +30,11 @@
 
         <template #actions>
             <jet-action-message :on="form.recentlySuccessful" class="mr-3">
-                {{ $t('Saved.') }}
+                Saved.
             </jet-action-message>
 
             <jet-button :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
-                {{ $t('Save') }}
+                Save
             </jet-button>
         </template>
     </jet-form-section>

--- a/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
@@ -1,11 +1,11 @@
 <template>
     <jet-form-section @submitted="updateProfileInformation">
         <template #title>
-            {{ $t('Profile Information') }}
+            Profile Information
         </template>
 
         <template #description>
-            {{ $t('Update your account\'s profile information and email address.') }}
+            Update your account's profile information and email address.
         </template>
 
         <template #form>
@@ -16,7 +16,7 @@
                             ref="photo"
                             @change="updatePhotoPreview">
 
-                <jet-label for="photo" :value="$t('Photo')" />
+                <jet-label for="photo" value="Photo" />
 
                 <!-- Current Profile Photo -->
                 <div class="mt-2" v-show="! photoPreview">
@@ -31,11 +31,11 @@
                 </div>
 
                 <jet-secondary-button class="mt-2 mr-2" type="button" @click.native.prevent="selectNewPhoto">
-                    {{ $t('Select A New Photo') }}
+                    Select A New Photo
                 </jet-secondary-button>
 
                 <jet-secondary-button type="button" class="mt-2" @click.native.prevent="deletePhoto" v-if="user.profile_photo_path">
-                    {{ $t('Remove Photo') }}
+                    Remove Photo
                 </jet-secondary-button>
 
                 <jet-input-error :message="form.error('photo')" class="mt-2" />
@@ -43,14 +43,14 @@
 
             <!-- Name -->
             <div class="col-span-6 sm:col-span-4">
-                <jet-label for="name" :value="$t('Name')" />
+                <jet-label for="name" value="Name" />
                 <jet-input id="name" type="text" class="mt-1 block w-full" v-model="form.name" autocomplete="name" />
                 <jet-input-error :message="form.error('name')" class="mt-2" />
             </div>
 
             <!-- Email -->
             <div class="col-span-6 sm:col-span-4">
-                <jet-label for="email" :value="$t('Email')" />
+                <jet-label for="email" value="Email" />
                 <jet-input id="email" type="email" class="mt-1 block w-full" v-model="form.email" />
                 <jet-input-error :message="form.error('email')" class="mt-2" />
             </div>
@@ -58,11 +58,11 @@
 
         <template #actions>
             <jet-action-message :on="form.recentlySuccessful" class="mr-3">
-                {{ $t('Saved.') }}
+                Saved.
             </jet-action-message>
 
             <jet-button :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
-                {{ $t('Save') }}
+                Save
             </jet-button>
         </template>
     </jet-form-section>

--- a/stubs/inertia/resources/js/Pages/Teams/Create.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/Create.vue
@@ -2,7 +2,7 @@
     <app-layout>
         <template #header>
             <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-                {{ $t('Create Team') }}
+                Create Team
             </h2>
         </template>
 

--- a/stubs/inertia/resources/js/Pages/Teams/CreateTeamForm.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/CreateTeamForm.vue
@@ -1,16 +1,16 @@
 <template>
     <jet-form-section @submitted="createTeam">
         <template #title>
-            {{ $t('Team Details') }}
+            Team Details
         </template>
 
         <template #description>
-            {{ $t('Create a new team to collaborate with others on projects.') }}
+            Create a new team to collaborate with others on projects.
         </template>
 
         <template #form>
             <div class="col-span-6">
-                <jet-label :value="$t('Team Owner')" />
+                <jet-label value="Team Owner" />
 
                 <div class="flex items-center mt-2">
                     <img class="w-12 h-12 rounded-full object-cover" :src="$page.props.user.profile_photo_url" :alt="$page.props.user.name">
@@ -23,7 +23,7 @@
             </div>
 
             <div class="col-span-6 sm:col-span-4">
-                <jet-label for="name" :value="$t('Team Name')" />
+                <jet-label for="name" value="Team Name" />
                 <jet-input id="name" type="text" class="mt-1 block w-full" v-model="form.name" autofocus />
                 <jet-input-error :message="form.error('name')" class="mt-2" />
             </div>
@@ -31,7 +31,7 @@
 
         <template #actions>
             <jet-button :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
-                {{ $t('Create') }}
+                Create
             </jet-button>
         </template>
     </jet-form-section>

--- a/stubs/inertia/resources/js/Pages/Teams/DeleteTeamForm.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/DeleteTeamForm.vue
@@ -1,41 +1,41 @@
 <template>
     <jet-action-section>
         <template #title>
-            {{ $t('Delete Team') }}
+            Delete Team
         </template>
 
         <template #description>
-            {{ $t('Permanently delete this team.') }}
+            Permanently delete this team.
         </template>
 
         <template #content>
             <div class="max-w-xl text-sm text-gray-600">
-                {{ $t('Once a team is deleted, all of its resources and data will be permanently deleted. Before deleting this team, please download any data or information regarding this team that you wish to retain.') }}
+                Once a team is deleted, all of its resources and data will be permanently deleted. Before deleting this team, please download any data or information regarding this team that you wish to retain.
             </div>
 
             <div class="mt-5">
                 <jet-danger-button @click.native="confirmTeamDeletion">
-                    {{ $t('Delete Team') }}
+                    Delete Team
                 </jet-danger-button>
             </div>
 
             <!-- Delete Team Confirmation Modal -->
             <jet-confirmation-modal :show="confirmingTeamDeletion" @close="confirmingTeamDeletion = false">
                 <template #title>
-                    {{ $t('Delete Team') }}
+                    Delete Team
                 </template>
 
                 <template #content>
-                    {{ $t('Are you sure you want to delete this team? Once a team is deleted, all of its resources and data will be permanently deleted.') }}
+                    Are you sure you want to delete this team? Once a team is deleted, all of its resources and data will be permanently deleted.
                 </template>
 
                 <template #footer>
                     <jet-secondary-button @click.native="confirmingTeamDeletion = false">
-                        {{ $t('Nevermind') }}
+                        Nevermind
                     </jet-secondary-button>
 
                     <jet-danger-button class="ml-2" @click.native="deleteTeam" :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
-                        {{ $t('Delete Team') }}
+                        Delete Team
                     </jet-danger-button>
                 </template>
             </jet-confirmation-modal>

--- a/stubs/inertia/resources/js/Pages/Teams/Show.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/Show.vue
@@ -2,7 +2,7 @@
     <app-layout>
         <template #header>
             <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-                {{ $t('Team Settings') }}
+                Team Settings
             </h2>
         </template>
 

--- a/stubs/inertia/resources/js/Pages/Teams/TeamMemberManager.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/TeamMemberManager.vue
@@ -6,30 +6,30 @@
             <!-- Add Team Member -->
             <jet-form-section @submitted="addTeamMember">
                 <template #title>
-                    {{ $t('Add Team Member') }}
+                    Add Team Member
                 </template>
 
                 <template #description>
-                    {{ $t('Add a new team member to your team, allowing them to collaborate with you.') }}
+                    Add a new team member to your team, allowing them to collaborate with you.
                 </template>
 
                 <template #form>
                     <div class="col-span-6">
                         <div class="max-w-xl text-sm text-gray-600">
-                            {{ $t('Please provide the email address of the person you would like to add to this team.') }}
+                            Please provide the email address of the person you would like to add to this team.
                         </div>
                     </div>
 
                     <!-- Member Email -->
                     <div class="col-span-6 sm:col-span-4">
-                        <jet-label for="email" :value="$t('Email')" />
+                        <jet-label for="email" value="Email" />
                         <jet-input id="email" type="text" class="mt-1 block w-full" v-model="addTeamMemberForm.email" />
                         <jet-input-error :message="addTeamMemberForm.error('email')" class="mt-2" />
                     </div>
 
                     <!-- Role -->
                     <div class="col-span-6 lg:col-span-4" v-if="availableRoles.length > 0">
-                        <jet-label for="roles" :value="$t('Role')" />
+                        <jet-label for="roles" value="Role" />
                         <jet-input-error :message="addTeamMemberForm.error('role')" class="mt-2" />
 
                         <div class="relative z-0 mt-1 border border-gray-200 rounded-lg cursor-pointer">
@@ -60,11 +60,11 @@
 
                 <template #actions>
                     <jet-action-message :on="addTeamMemberForm.recentlySuccessful" class="mr-3">
-                        {{ $t('Added.') }}
+                        Added.
                     </jet-action-message>
 
                     <jet-button :class="{ 'opacity-25': addTeamMemberForm.processing }" :disabled="addTeamMemberForm.processing">
-                        {{ $t('Add') }}
+                        Add
                     </jet-button>
                 </template>
             </jet-form-section>
@@ -76,11 +76,11 @@
             <!-- Team Member Invitations -->
             <jet-action-section class="mt-10 sm:mt-0">
                 <template #title>
-                    {{ $t('Pending Team Invitations') }}
+                    Pending Team Invitations
                 </template>
 
                 <template #description>
-                    {{ $t('These people have been invited to your team and have been sent an invitation email. They may join the team by accepting the email invitation.') }}
+                    These people have been invited to your team and have been sent an invitation email. They may join the team by accepting the email invitation.
                 </template>
 
                 <!-- Pending Team Member Invitation List -->
@@ -94,7 +94,7 @@
                                 <button class="cursor-pointer ml-6 text-sm text-red-500 focus:outline-none"
                                                     @click="cancelTeamInvitation(invitation)"
                                                     v-if="userPermissions.canRemoveTeamMembers">
-                                    {{ $t('Cancel') }}
+                                    Cancel
                                 </button>
                             </div>
                         </div>
@@ -109,11 +109,11 @@
             <!-- Manage Team Members -->
             <jet-action-section class="mt-10 sm:mt-0">
                 <template #title>
-                    {{ $t('Team Members') }}
+                    Team Members
                 </template>
 
                 <template #description>
-                    {{ $t('All of the people that are part of this team.') }}
+                    All of the people that are part of this team.
                 </template>
 
                 <!-- Team Member List -->
@@ -141,14 +141,14 @@
                                 <button class="cursor-pointer ml-6 text-sm text-red-500"
                                                     @click="confirmLeavingTeam"
                                                     v-if="$page.props.user.id === user.id">
-                                    {{ $t('Leave') }}
+                                    Leave
                                 </button>
 
                                 <!-- Remove Team Member -->
                                 <button class="cursor-pointer ml-6 text-sm text-red-500"
                                                     @click="confirmTeamMemberRemoval(user)"
                                                     v-if="userPermissions.canRemoveTeamMembers">
-                                    {{ $t('Remove') }}
+                                    Remove
                                 </button>
                             </div>
                         </div>
@@ -160,7 +160,7 @@
         <!-- Role Management Modal -->
         <jet-dialog-modal :show="currentlyManagingRole" @close="currentlyManagingRole = false">
             <template #title>
-                {{ $t('Manage Role') }}
+                Manage Role
             </template>
 
             <template #content>
@@ -193,13 +193,11 @@
 
             <template #footer>
                 <jet-secondary-button @click.native="currentlyManagingRole = false">
-                    {{ $t('Nevermind') }}
+                    Nevermind
                 </jet-secondary-button>
 
-                <jet-button class="ml-2"
-                            :class="{ 'opacity-25': updateRoleForm.processing }" :disabled="updateRoleForm.processing"
-                            @click.native="updateRole">
-                    {{ $t('Save') }}
+                <jet-button class="ml-2" @click.native="updateRole" :class="{ 'opacity-25': updateRoleForm.processing }" :disabled="updateRoleForm.processing">
+                    Save
                 </jet-button>
             </template>
         </jet-dialog-modal>
@@ -207,20 +205,20 @@
         <!-- Leave Team Confirmation Modal -->
         <jet-confirmation-modal :show="confirmingLeavingTeam" @close="confirmingLeavingTeam = false">
             <template #title>
-                {{ $t('Leave Team') }}
+                Leave Team
             </template>
 
             <template #content>
-                {{ $t('Are you sure you would like to leave this team?') }}
+                Are you sure you would like to leave this team?
             </template>
 
             <template #footer>
                 <jet-secondary-button @click.native="confirmingLeavingTeam = false">
-                    {{ $t('Nevermind') }}
+                    Nevermind
                 </jet-secondary-button>
 
                 <jet-danger-button class="ml-2" @click.native="leaveTeam" :class="{ 'opacity-25': leaveTeamForm.processing }" :disabled="leaveTeamForm.processing">
-                    {{ $t('Leave') }}
+                    Leave
                 </jet-danger-button>
             </template>
         </jet-confirmation-modal>
@@ -228,23 +226,20 @@
         <!-- Remove Team Member Confirmation Modal -->
         <jet-confirmation-modal :show="teamMemberBeingRemoved" @close="teamMemberBeingRemoved = null">
             <template #title>
-                {{ $t('Remove Team Member') }}
+                Remove Team Member
             </template>
 
             <template #content>
-                {{ $t('Are you sure you would like to remove this person from the team?') }}
+                Are you sure you would like to remove this person from the team?
             </template>
 
             <template #footer>
                 <jet-secondary-button @click.native="teamMemberBeingRemoved = null">
-                    {{ $t('Nevermind') }}
+                    Nevermind
                 </jet-secondary-button>
 
-                <jet-danger-button class="ml-2"
-                                :class="{ 'opacity-25': removeTeamMemberForm.processing }"
-                                @click.native="removeTeamMember"
-                                :disabled="removeTeamMemberForm.processing">
-                    {{ $t('Remove') }}
+                <jet-danger-button class="ml-2" @click.native="removeTeamMember" :class="{ 'opacity-25': removeTeamMemberForm.processing }" :disabled="removeTeamMemberForm.processing">
+                    Remove
                 </jet-danger-button>
             </template>
         </jet-confirmation-modal>

--- a/stubs/inertia/resources/js/Pages/Teams/UpdateTeamNameForm.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/UpdateTeamNameForm.vue
@@ -1,17 +1,17 @@
 <template>
     <jet-form-section @submitted="updateTeamName">
         <template #title>
-            {{ $t('Team Name') }}
+            Team Name
         </template>
 
         <template #description>
-            {{ $t('The team\'s name and owner information.') }}
+            The team's name and owner information.
         </template>
 
         <template #form>
             <!-- Team Owner Information -->
             <div class="col-span-6">
-                <jet-label :value="$t('Team Owner')" />
+                <jet-label value="Team Owner" />
 
                 <div class="flex items-center mt-2">
                     <img class="w-12 h-12 rounded-full object-cover" :src="team.owner.profile_photo_url" :alt="team.owner.name">
@@ -25,7 +25,7 @@
 
             <!-- Team Name -->
             <div class="col-span-6 sm:col-span-4">
-                <jet-label for="name" :value="$t('Team Name')" />
+                <jet-label for="name" value="Team Name" />
 
                 <jet-input id="name"
                             type="text"
@@ -39,11 +39,11 @@
 
         <template #actions v-if="permissions.canUpdateTeam">
             <jet-action-message :on="form.recentlySuccessful" class="mr-3">
-                {{ $t('Saved.') }}
+                Saved.
             </jet-action-message>
 
             <jet-button :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
-                {{ $t('Save') }}
+                Save
             </jet-button>
         </template>
     </jet-form-section>

--- a/stubs/inertia/resources/js/app.js
+++ b/stubs/inertia/resources/js/app.js
@@ -2,50 +2,24 @@ require('./bootstrap');
 
 require('moment');
 
-// Import modules...
 import Vue from 'vue';
+
 import { InertiaApp, plugin as InertiaPlugin } from '@inertiajs/inertia-vue';
 import { InertiaForm } from 'laravel-jetstream';
 import PortalVue from 'portal-vue';
-import VueI18n from 'vue-i18n';
 
-// Configure Vue...
 Vue.mixin({ methods: { route } });
-
 Vue.use(InertiaPlugin);
 Vue.use(InertiaForm);
 Vue.use(PortalVue);
-Vue.use(VueI18n);
 
-// Configure Vue internationalization...
 const app = document.getElementById('app');
 
-const initialPage = JSON.parse(app.dataset.page);
-
-const i18n = new VueI18n({
-    locale: initialPage.props.jetstream.locale,
-    fallbackLocale: initialPage.props.jetstream.fallbackLocale,
-    formatFallbackMessages: true,
-    silentTranslationWarn: true,
-    silentFallbackWarn: true,
-});
-
-// Create the Vue application instance...
 new Vue({
-    i18n,
-
-    created() {
-        this.$inertia.on('success', (event) => {
-            const locale = event.detail.page.props.jetstream?.locale || i18n.locale;
-
-            document.documentElement.lang = i18n.locale = locale;
-        });
-    },
-
     render: (h) =>
         h(InertiaApp, {
             props: {
-                initialPage,
+                initialPage: JSON.parse(app.dataset.page),
                 resolveComponent: (name) => require(`./Pages/${name}`).default,
             },
         }),

--- a/stubs/inertia/webpack.config.js
+++ b/stubs/inertia/webpack.config.js
@@ -1,15 +1,6 @@
 const path = require('path');
 
 module.exports = {
-    module: {
-        rules: [
-            {
-                resourceQuery: /blockType=i18n/,
-                type: 'javascript/auto',
-                loader: '@intlify/vue-i18n-loader',
-            },
-        ],
-    },
     resolve: {
         alias: {
             '@': path.resolve('resources/js'),


### PR DESCRIPTION
This PR reverts the internationalization changes that were introduced to `2.x` earlier this year, for multiple reasons:
- Lots of people don't use translations in their apps at all, as they are not targeting an international audience.
- The implementation has a lot of surface area, and it's configuration makes a 'clean install' look overly complex.
- Third-party translation services might not support/use vue i18n, forcing you to re-do the integration anyway.
- Implementing Vue i18n yourself does not take too much time.