### PR TITLE
[2.x] Inertia: Remove moment.js dependency

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -273,7 +273,6 @@ EOF;
                 '@tailwindcss/forms' => '^0.2.1',
                 '@tailwindcss/typography' => '^0.3.0',
                 'laravel-jetstream' => '^1.0.0',
-                'moment' => '^2.26.0',
                 'portal-vue' => '^2.1.7',
                 'postcss-import' => '^12.0.1',
                 'tailwindcss' => 'npm:@tailwindcss/postcss7-compat@^2.0.1',

--- a/src/Http/Controllers/Inertia/ApiTokenController.php
+++ b/src/Http/Controllers/Inertia/ApiTokenController.php
@@ -20,7 +20,7 @@ class ApiTokenController extends Controller
         return Jetstream::inertia()->render($request, 'API/Index', [
             'tokens' => $request->user()->tokens->map(function ($token) {
                 return $token->toArray() + [
-                    'last_used_ago' => optional($token->last_used_at)->diffForHumans()
+                    'last_used_ago' => optional($token->last_used_at)->diffForHumans(),
                 ];
             }),
             'availablePermissions' => Jetstream::$permissions,

--- a/src/Http/Controllers/Inertia/ApiTokenController.php
+++ b/src/Http/Controllers/Inertia/ApiTokenController.php
@@ -18,7 +18,11 @@ class ApiTokenController extends Controller
     public function index(Request $request)
     {
         return Jetstream::inertia()->render($request, 'API/Index', [
-            'tokens' => $request->user()->tokens,
+            'tokens' => $request->user()->tokens->map(function ($token) {
+                return $token->toArray() + [
+                    'last_used_ago' => optional($token->last_used_at)->diffForHumans()
+                ];
+            }),
             'availablePermissions' => Jetstream::$permissions,
             'defaultPermissions' => Jetstream::$defaultPermissions,
         ]);

--- a/stubs/inertia/resources/js/Pages/API/ApiTokenManager.vue
+++ b/stubs/inertia/resources/js/Pages/API/ApiTokenManager.vue
@@ -68,7 +68,7 @@
 
                                 <div class="flex items-center">
                                     <div class="text-sm text-gray-400" v-if="token.last_used_ago">
-                                        Last used {{ token.last_used_ago }}
+                                        {{ $t('Last used {last_used}', { 'last_used': token.last_used_ago }) }}
                                     </div>
 
                                     <button class="cursor-pointer ml-6 text-sm text-gray-400 underline"

--- a/stubs/inertia/resources/js/Pages/API/ApiTokenManager.vue
+++ b/stubs/inertia/resources/js/Pages/API/ApiTokenManager.vue
@@ -67,8 +67,8 @@
                                 </div>
 
                                 <div class="flex items-center">
-                                    <div class="text-sm text-gray-400" v-if="token.last_used_at">
-                                        {{ $t('Last used {last_used}', { 'last_used': fromNow(token.last_used_at) }) }}
+                                    <div class="text-sm text-gray-400" v-if="token.last_used_ago">
+                                        Last used {{ token.last_used_ago }}
                                     </div>
 
                                     <button class="cursor-pointer ml-6 text-sm text-gray-400 underline"
@@ -265,10 +265,6 @@
                         this.apiTokenBeingDeleted = null
                     }
                 })
-            },
-
-            fromNow(timestamp) {
-                return moment(timestamp).local().fromNow()
             },
         },
     }

--- a/stubs/inertia/resources/js/Pages/API/ApiTokenManager.vue
+++ b/stubs/inertia/resources/js/Pages/API/ApiTokenManager.vue
@@ -67,7 +67,7 @@
                                 </div>
 
                                 <div class="flex items-center">
-                                    <div class="text-sm text-gray-400" v-if="token.last_used_at">
+                                    <div class="text-sm text-gray-400" v-if="token.last_used_ago">
                                         Last used {{ fromNow(token.last_used_ago) }}
                                     </div>
 

--- a/stubs/inertia/resources/js/app.js
+++ b/stubs/inertia/resources/js/app.js
@@ -1,7 +1,5 @@
 require('./bootstrap');
 
-require('moment');
-
 // Import modules...
 import Vue from 'vue';
 import { InertiaApp, plugin as InertiaPlugin } from '@inertiajs/inertia-vue';


### PR DESCRIPTION
While cleaning up the `app.js`, I noticed that the `moment` library was included, but was only being used once.

Because Inertia gets it's state from the back-end, we can instead let Carbon do this conversion for us and pass it through to the front-end and remove the (fairly large) `moment` dependency entirely.