### PR TITLE
[2.x] Upgrade Inertia

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -262,7 +262,7 @@ EOF;
     protected function installInertiaStack()
     {
         // Install Inertia...
-        $this->requireComposerPackages('inertiajs/inertia-laravel:^0.3', 'laravel/sanctum:^2.6', 'tightenco/ziggy:^1.0');
+        $this->requireComposerPackages('inertiajs/inertia-laravel:^0.3.5', 'laravel/sanctum:^2.6', 'tightenco/ziggy:^1.0');
 
         // Install NPM packages...
         $this->updateNodePackages(function ($packages) {

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -267,8 +267,8 @@ EOF;
         // Install NPM packages...
         $this->updateNodePackages(function ($packages) {
             return [
-                '@inertiajs/inertia' => '^0.4.0',
-                '@inertiajs/inertia-vue' => '^0.3.0',
+                '@inertiajs/inertia' => '^0.8.0',
+                '@inertiajs/inertia-vue' => '^0.5.0',
                 '@tailwindcss/forms' => '^0.2.1',
                 '@tailwindcss/typography' => '^0.3.0',
                 'portal-vue' => '^2.1.7',

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -267,8 +267,8 @@ EOF;
         // Install NPM packages...
         $this->updateNodePackages(function ($packages) {
             return [
-                '@inertiajs/inertia' => '^0.4.0',
-                '@inertiajs/inertia-vue' => '^0.3.0',
+                '@inertiajs/inertia' => '^0.8.0',
+                '@inertiajs/inertia-vue' => '^0.5.0',
                 '@intlify/vue-i18n-loader' => '^1.0.0',
                 '@tailwindcss/forms' => '^0.2.1',
                 '@tailwindcss/typography' => '^0.3.0',

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -268,7 +268,7 @@ EOF;
         $this->updateNodePackages(function ($packages) {
             return [
                 '@inertiajs/inertia' => '^0.8.0',
-                '@inertiajs/inertia-vue' => '^0.5.0',
+                '@inertiajs/inertia-vue' => '^0.5.2',
                 '@tailwindcss/forms' => '^0.2.1',
                 '@tailwindcss/typography' => '^0.3.0',
                 'portal-vue' => '^2.1.7',

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -272,7 +272,6 @@ EOF;
                 '@intlify/vue-i18n-loader' => '^1.0.0',
                 '@tailwindcss/forms' => '^0.2.1',
                 '@tailwindcss/typography' => '^0.3.0',
-                'laravel-jetstream' => '^1.0.0',
                 'moment' => '^2.26.0',
                 'portal-vue' => '^2.1.7',
                 'postcss-import' => '^12.0.1',

--- a/src/Http/Controllers/Inertia/ApiTokenController.php
+++ b/src/Http/Controllers/Inertia/ApiTokenController.php
@@ -36,11 +36,9 @@ class ApiTokenController extends Controller
      */
     public function store(Request $request)
     {
-        Validator::make([
-            'name' => $request->name,
-        ], [
-            'name' => ['required', 'string', 'max:255'],
-        ])->validateWithBag('createApiToken');
+        $request->validate([
+            'name' => ['required', 'string', 'max:255']
+        ]);
 
         $token = $request->user()->createToken(
             $request->name, Jetstream::validPermissions($request->input('permissions', []))
@@ -60,6 +58,11 @@ class ApiTokenController extends Controller
      */
     public function update(Request $request, $tokenId)
     {
+        $request->validate([
+            'permissions' => 'array',
+            'permissions.*' => 'string'
+        ]);
+
         $token = $request->user()->tokens()->where('id', $tokenId)->firstOrFail();
 
         $token->forceFill([

--- a/src/Http/Controllers/Inertia/ApiTokenController.php
+++ b/src/Http/Controllers/Inertia/ApiTokenController.php
@@ -37,11 +37,12 @@ class ApiTokenController extends Controller
     public function store(Request $request)
     {
         $request->validate([
-            'name' => ['required', 'string', 'max:255']
+            'name' => ['required', 'string', 'max:255'],
         ]);
 
         $token = $request->user()->createToken(
-            $request->name, Jetstream::validPermissions($request->input('permissions', []))
+            $request->name,
+            Jetstream::validPermissions($request->input('permissions', []))
         );
 
         return back()->with('flash', [
@@ -60,7 +61,7 @@ class ApiTokenController extends Controller
     {
         $request->validate([
             'permissions' => 'array',
-            'permissions.*' => 'string'
+            'permissions.*' => 'string',
         ]);
 
         $token = $request->user()->tokens()->where('id', $tokenId)->firstOrFail();

--- a/src/Http/Controllers/Inertia/CurrentUserController.php
+++ b/src/Http/Controllers/Inertia/CurrentUserController.php
@@ -21,11 +21,9 @@ class CurrentUserController extends Controller
      */
     public function destroy(Request $request, StatefulGuard $auth)
     {
-        if (! Hash::check($request->password, $request->user()->password)) {
-            throw ValidationException::withMessages([
-                'password' => [__('This password does not match our records.')],
-            ])->errorBag('deleteUser');
-        }
+        $request->validate([
+            'password' => 'password',
+        ]);
 
         app(DeletesUsers::class)->delete($request->user()->fresh());
 

--- a/src/Http/Controllers/Inertia/OtherBrowserSessionsController.php
+++ b/src/Http/Controllers/Inertia/OtherBrowserSessionsController.php
@@ -20,11 +20,9 @@ class OtherBrowserSessionsController extends Controller
      */
     public function destroy(Request $request, StatefulGuard $guard)
     {
-        if (! Hash::check($request->password, $request->user()->password)) {
-            throw ValidationException::withMessages([
-                'password' => [__('This password does not match our records.')],
-            ])->errorBag('logoutOtherBrowserSessions');
-        }
+        $request->validate([
+            'password' => 'password',
+        ]);
 
         $guard->logoutOtherDevices($request->password);
 

--- a/src/Http/Middleware/ShareInertiaData.php
+++ b/src/Http/Middleware/ShareInertiaData.php
@@ -51,12 +51,7 @@ class ShareInertiaData
                 ]), [
                     'two_factor_enabled' => ! is_null($request->user()->two_factor_secret),
                 ]);
-            },
-            'errorBags' => function () {
-                return collect(optional(Session::get('errors'))->getBags() ?: [])->mapWithKeys(function ($bag, $key) {
-                    return [$key => $bag->messages()];
-                })->all();
-            },
+            }
         ]));
 
         return $next($request);

--- a/src/Http/Middleware/ShareInertiaData.php
+++ b/src/Http/Middleware/ShareInertiaData.php
@@ -3,8 +3,6 @@
 namespace Laravel\Jetstream\Http\Middleware;
 
 use Illuminate\Support\Facades\Gate;
-use Illuminate\Support\Facades\Route;
-use Illuminate\Support\Facades\Session;
 use Inertia\Inertia;
 use Laravel\Fortify\Features;
 use Laravel\Jetstream\Jetstream;
@@ -51,7 +49,7 @@ class ShareInertiaData
                 ]), [
                     'two_factor_enabled' => ! is_null($request->user()->two_factor_secret),
                 ]);
-            }
+            },
         ]));
 
         return $next($request);

--- a/stubs/inertia/resources/js/Jetstream/ConfirmsPassword.vue
+++ b/stubs/inertia/resources/js/Jetstream/ConfirmsPassword.vue
@@ -23,7 +23,7 @@
             </template>
 
             <template #footer>
-                <jet-secondary-button @click.native="confirmingPassword = false">
+                <jet-secondary-button @click.native="closeModal">
                     Nevermind
                 </jet-secondary-button>
 
@@ -74,6 +74,10 @@
         },
 
         methods: {
+            closeModal() {
+                this.confirmingPassword = false
+                this.form.password = '';
+            },
             startConfirmingPassword() {
                 this.form.error = '';
 
@@ -82,11 +86,8 @@
                         this.$emit('confirmed');
                     } else {
                         this.confirmingPassword = true;
-                        this.form.password = '';
 
-                        setTimeout(() => {
-                            this.$refs.password.focus()
-                        }, 250)
+                        setTimeout(() => this.$refs.password.focus(), 250)
                     }
                 })
             },

--- a/stubs/inertia/resources/js/Jetstream/ConfirmsPassword.vue
+++ b/stubs/inertia/resources/js/Jetstream/ConfirmsPassword.vue
@@ -79,6 +79,7 @@
                 this.form.password = '';
                 this.form.error = '';
             },
+
             startConfirmingPassword() {
                 axios.get(route('password.confirmation')).then(response => {
                     if (response.data.confirmed) {

--- a/stubs/inertia/resources/js/Jetstream/ConfirmsPassword.vue
+++ b/stubs/inertia/resources/js/Jetstream/ConfirmsPassword.vue
@@ -4,7 +4,7 @@
             <slot />
         </span>
 
-        <jet-dialog-modal :show="confirmingPassword" @close="confirmingPassword = false">
+        <jet-dialog-modal :show="confirmingPassword" @close="closeModal">
             <template #title>
                 {{ title }}
             </template>
@@ -77,10 +77,9 @@
             closeModal() {
                 this.confirmingPassword = false
                 this.form.password = '';
+                this.form.error = '';
             },
             startConfirmingPassword() {
-                this.form.error = '';
-
                 axios.get(route('password.confirmation')).then(response => {
                     if (response.data.confirmed) {
                         this.$emit('confirmed');
@@ -97,12 +96,9 @@
 
                 axios.post(route('password.confirm'), {
                     password: this.form.password,
-                }).then(response => {
-                    this.confirmingPassword = false;
-                    this.form.password = '';
-                    this.form.error = '';
+                }).then(() => {
                     this.form.processing = false;
-
+                    this.closeModal()
                     this.$nextTick(() => this.$emit('confirmed'));
                 }).catch(error => {
                     this.form.processing = false;

--- a/stubs/inertia/resources/js/Jetstream/ConfirmsPassword.vue
+++ b/stubs/inertia/resources/js/Jetstream/ConfirmsPassword.vue
@@ -66,13 +66,10 @@
         data() {
             return {
                 confirmingPassword: false,
-
-                form: this.$inertia.form({
+                form: {
                     password: '',
                     error: '',
-                }, {
-                    bag: 'confirmPassword',
-                })
+                },
             }
         },
 

--- a/stubs/inertia/resources/js/Jetstream/ConfirmsPassword.vue
+++ b/stubs/inertia/resources/js/Jetstream/ConfirmsPassword.vue
@@ -103,6 +103,7 @@
                 }).catch(error => {
                     this.form.processing = false;
                     this.form.error = error.response.data.errors.password[0];
+                    this.$refs.password.focus()
                 });
             }
         }

--- a/stubs/inertia/resources/js/Jetstream/ValidationErrors.vue
+++ b/stubs/inertia/resources/js/Jetstream/ValidationErrors.vue
@@ -3,32 +3,21 @@
         <div class="font-medium text-red-600">Whoops! Something went wrong.</div>
 
         <ul class="mt-3 list-disc list-inside text-sm text-red-600">
-            <li v-for="(error, key) in flattenedErrors" :key="key">{{ error }}</li>
+            <li v-for="(error, key) in errors" :key="key">{{ error }}</li>
         </ul>
     </div>
 </template>
 
 <script>
     export default {
-        props: {
-            bag: {
-                type: String,
-                default: 'default',
-            },
-        },
-
         computed: {
-            errorBag() {
-                return this.$page.props.errorBags[this.bag] || {}
+            errors() {
+                return this.$page.props.errors
             },
 
             hasErrors() {
-                return Object.keys(this.errorBag).length > 0;
+                return Object.keys(this.errors).length > 0;
             },
-
-            flattenedErrors() {
-                return Object.keys(this.errorBag).reduce((carry, key) => carry.concat(this.errorBag[key]), [])
-            }
         }
     }
 </script>

--- a/stubs/inertia/resources/js/Pages/API/ApiTokenManager.vue
+++ b/stubs/inertia/resources/js/Pages/API/ApiTokenManager.vue
@@ -230,7 +230,6 @@
                     onSuccess: () => {
                         this.apiTokenRecentlyCreated = true
                         this.displayingToken = true
-
                         this.createApiTokenForm.reset()
                     }
                 })

--- a/stubs/inertia/resources/js/Pages/API/ApiTokenManager.vue
+++ b/stubs/inertia/resources/js/Pages/API/ApiTokenManager.vue
@@ -34,7 +34,7 @@
             </template>
 
             <template #actions>
-                <jet-action-message :on="apiTokenRecentlyCreated" class="mr-3">
+                <jet-action-message :on="createApiTokenForm.recentlySuccessful" class="mr-3">
                     Created.
                 </jet-action-message>
 
@@ -214,7 +214,6 @@
 
                 deleteApiTokenForm: this.$inertia.form(),
 
-                apiTokenRecentlyCreated: false,
                 displayingToken: false,
                 managingPermissionsFor: null,
                 apiTokenBeingDeleted: null,
@@ -225,9 +224,7 @@
             createApiToken() {
                 this.createApiTokenForm.post(route('api-tokens.store'), {
                     preserveScroll: true,
-                    before: () => (this.apiTokenRecentlyCreated = false),
                     onSuccess: () => {
-                        this.apiTokenRecentlyCreated = true
                         this.displayingToken = true
                         this.createApiTokenForm.reset()
                     }

--- a/stubs/inertia/resources/js/Pages/API/ApiTokenManager.vue
+++ b/stubs/inertia/resources/js/Pages/API/ApiTokenManager.vue
@@ -34,7 +34,7 @@
             </template>
 
             <template #actions>
-                <jet-action-message :on="createApiTokenFormRecentlySuccessful" class="mr-3">
+                <jet-action-message :on="apiTokenRecentlyCreated" class="mr-3">
                     Created.
                 </jet-action-message>
 
@@ -214,7 +214,7 @@
 
                 deleteApiTokenForm: this.$inertia.form(),
 
-                createApiTokenFormRecentlySuccessful: false,
+                apiTokenRecentlyCreated: false,
                 displayingToken: false,
                 managingPermissionsFor: null,
                 apiTokenBeingDeleted: null,
@@ -226,9 +226,9 @@
                 this.createApiTokenForm.post(route('api-tokens.store'), {
                     errorBag: 'createApiToken',
                     preserveScroll: true,
-                    before: () => (this.createApiTokenFormRecentlySuccessful = false),
+                    before: () => (this.apiTokenRecentlyCreated = false),
                     onSuccess: () => {
-                        this.createApiTokenFormRecentlySuccessful = true
+                        this.apiTokenRecentlyCreated = true
                         this.displayingToken = true
 
                         this.createApiTokenForm.reset()

--- a/stubs/inertia/resources/js/Pages/API/ApiTokenManager.vue
+++ b/stubs/inertia/resources/js/Pages/API/ApiTokenManager.vue
@@ -224,7 +224,6 @@
         methods: {
             createApiToken() {
                 this.createApiTokenForm.post(route('api-tokens.store'), {
-                    errorBag: 'createApiToken',
                     preserveScroll: true,
                     before: () => (this.apiTokenRecentlyCreated = false),
                     onSuccess: () => {
@@ -243,7 +242,6 @@
 
             updateApiToken() {
                 this.updateApiTokenForm.put(route('api-tokens.update', this.managingPermissionsFor), {
-                    errorBag: 'updateApiToken',
                     preserveScroll: true,
                     preserveState: true,
                     onSuccess: () => {

--- a/stubs/inertia/resources/js/Pages/API/ApiTokenManager.vue
+++ b/stubs/inertia/resources/js/Pages/API/ApiTokenManager.vue
@@ -241,9 +241,7 @@
                 this.updateApiTokenForm.put(route('api-tokens.update', this.managingPermissionsFor), {
                     preserveScroll: true,
                     preserveState: true,
-                    onSuccess: () => {
-                        this.managingPermissionsFor = null
-                    }
+                    onSuccess: () => (this.managingPermissionsFor = null),
                 })
             },
 
@@ -255,9 +253,7 @@
                 this.deleteApiTokenForm.delete(route('api-tokens.destroy', this.apiTokenBeingDeleted), {
                     preserveScroll: true,
                     preserveState: true,
-                    onSuccess: () => {
-                        this.apiTokenBeingDeleted = null
-                    }
+                    onSuccess: () => (this.apiTokenBeingDeleted = null),
                 })
             },
         },

--- a/stubs/inertia/resources/js/Pages/Auth/ConfirmPassword.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/ConfirmPassword.vue
@@ -54,7 +54,7 @@
         methods: {
             submit() {
                 this.form.post(this.route('password.confirm'), {
-                    onFinish: () => this.form.reset('password'),
+                    onFinish: () => this.form.reset(),
                 })
             }
         }

--- a/stubs/inertia/resources/js/Pages/Auth/ConfirmPassword.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/ConfirmPassword.vue
@@ -54,7 +54,7 @@
         methods: {
             submit() {
                 this.form.post(this.route('password.confirm'), {
-                    onFinish: () => this.form.reset('password')
+                    onFinish: () => this.form.reset('password'),
                 })
             }
         }

--- a/stubs/inertia/resources/js/Pages/Auth/ConfirmPassword.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/ConfirmPassword.vue
@@ -53,7 +53,9 @@
 
         methods: {
             submit() {
-                this.form.post(this.route('password.confirm'))
+                this.form.post(this.route('password.confirm'), {
+                    onFinish: () => this.form.reset('password')
+                })
             }
         }
     }

--- a/stubs/inertia/resources/js/Pages/Auth/Login.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/Login.vue
@@ -83,7 +83,9 @@
                         ... data,
                         remember: this.form.remember ? 'on' : ''
                     }))
-                    .post(this.route('login'))
+                    .post(this.route('login'), {
+                        onFinish: () => this.form.reset('password')
+                    })
             }
         }
     }

--- a/stubs/inertia/resources/js/Pages/Auth/Login.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/Login.vue
@@ -72,16 +72,18 @@
                     email: '',
                     password: '',
                     remember: false
-                }).transform(data => ({
-                    ... data,
-                    remember: this.form.remember ? 'on' : ''
-                }))
+                })
             }
         },
 
         methods: {
             submit() {
-                this.form.post(this.route('login'))
+                this.form
+                    .transform(data => ({
+                        ... data,
+                        remember: this.form.remember ? 'on' : ''
+                    }))
+                    .post(this.route('login'))
             }
         }
     }

--- a/stubs/inertia/resources/js/Pages/Auth/Login.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/Login.vue
@@ -23,7 +23,7 @@
 
             <div class="block mt-4">
                 <label class="flex items-center">
-                    <jet-checkbox  name="remember" v-model="remember"/>
+                    <jet-checkbox name="remember" v-model="form.remember" />
                     <span class="ml-2 text-sm text-gray-600">Remember me</span>
                 </label>
             </div>
@@ -68,28 +68,20 @@
 
         data() {
             return {
-                remember: false,
                 form: this.$inertia.form({
                     email: '',
                     password: '',
                     remember: ''
-                })
-            }
-        },
-
-        watch: {
-            remember(value) {
-                this.form.remember = value ? 'on' : ''
+                }).transform(data => ({
+                    ... data,
+                    remember: this.form.remember ? 'on' : ''
+                }))
             }
         },
 
         methods: {
             submit() {
-                this.form.post(this.route('login'), {
-                    onSuccess: () => {
-                        this.remember = false
-                    }
-                })
+                this.form.post(this.route('login'))
             }
         }
     }

--- a/stubs/inertia/resources/js/Pages/Auth/Login.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/Login.vue
@@ -71,7 +71,7 @@
                 form: this.$inertia.form({
                     email: '',
                     password: '',
-                    remember: ''
+                    remember: false
                 }).transform(data => ({
                     ... data,
                     remember: this.form.remember ? 'on' : ''

--- a/stubs/inertia/resources/js/Pages/Auth/Login.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/Login.vue
@@ -84,7 +84,7 @@
                         remember: this.form.remember ? 'on' : ''
                     }))
                     .post(this.route('login'), {
-                        onFinish: () => this.form.reset('password')
+                        onFinish: () => this.form.reset('password'),
                     })
             }
         }

--- a/stubs/inertia/resources/js/Pages/Auth/Register.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/Register.vue
@@ -30,10 +30,10 @@
             <div class="mt-4" v-if="$page.props.jetstream.hasTermsAndPrivacyPolicyFeature">
                 <jet-label for="terms">
                     <div class="flex items-center">
-                        <jet-checkbox name="terms" id="terms" v-model="form.terms"/>
+                        <jet-checkbox name="terms" id="terms" v-model="form.terms" />
 
-                        <div>
-                            I agree to the <inertia-link target="_blank" :href="route('terms.show')" class="underline text-sm text-gray-600 hover:text-gray-900">Terms of Service</inertia-link> and <inertia-link target="_blank" :href="route('policy.show')" class="underline text-sm text-gray-600 hover:text-gray-900">Privacy Policy</inertia-link>
+                        <div class="ml-2">
+                            I agree to the <a target="_blank" :href="route('terms.show')" class="underline text-sm text-gray-600 hover:text-gray-900">Terms of Service</a> and <a target="_blank" :href="route('policy.show')" class="underline text-sm text-gray-600 hover:text-gray-900">Privacy Policy</a>
                         </div>
                     </div>
                 </jet-label>
@@ -79,7 +79,7 @@
                     email: '',
                     password: '',
                     password_confirmation: '',
-                    terms: null,
+                    terms: false,
                 })
             }
         },
@@ -87,10 +87,7 @@
         methods: {
             submit() {
                 this.form.post(this.route('register'), {
-                    onSuccess: () => {
-                        this.form.password = ''
-                        this.form.password_confirmation = ''
-                    }
+                    onFinish: () => this.form.reset('password', 'password_confirmation'),
                 })
             }
         }

--- a/stubs/inertia/resources/js/Pages/Auth/ResetPassword.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/ResetPassword.vue
@@ -68,10 +68,7 @@
         methods: {
             submit() {
                 this.form.post(this.route('password.update'), {
-                    onSuccess: () => {
-                        this.form.password = ''
-                        this.form.password_confirmation = ''
-                    }
+                    onFinish: () => this.form.reset('password', 'password_confirmation'),
                 })
             }
         }

--- a/stubs/inertia/resources/js/Pages/Auth/VerifyEmail.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/VerifyEmail.vue
@@ -18,7 +18,7 @@
                     Resend Verification Email
                 </jet-button>
 
-                <inertia-link :href="route('logout')" method="post" class="underline text-sm text-gray-600 hover:text-gray-900">Logout</inertia-link>
+                <inertia-link :href="route('logout')" method="post" as="button" class="underline text-sm text-gray-600 hover:text-gray-900">Logout</inertia-link>
             </div>
         </form>
     </jet-authentication-card>

--- a/stubs/inertia/resources/js/Pages/Profile/DeleteUserForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/DeleteUserForm.vue
@@ -85,6 +85,7 @@
                 this.confirmingUserDeletion = false
                 this.form.reset()
             },
+
             confirmUserDeletion() {
                 this.confirmingUserDeletion = true;
 

--- a/stubs/inertia/resources/js/Pages/Profile/DeleteUserForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/DeleteUserForm.vue
@@ -34,7 +34,7 @@
                                     v-model="form.password"
                                     @keyup.enter.native="deleteUser" />
 
-                        <jet-input-error :message="form.error('password')" class="mt-2" />
+                        <jet-input-error :message="form.errors.password" class="mt-2" />
                     </div>
                 </template>
 
@@ -75,10 +75,7 @@
                 confirmingUserDeletion: false,
 
                 form: this.$inertia.form({
-                    '_method': 'DELETE',
                     password: '',
-                }, {
-                    bag: 'deleteUser'
                 })
             }
         },
@@ -95,13 +92,10 @@
             },
 
             deleteUser() {
-                this.form.post(route('current-user.destroy'), {
+                this.form.delete(route('current-user.destroy'), {
+                    errorBag: 'deleteUser',
                     preserveScroll: true,
-                    onSuccess: () => {
-                        if (! this.form.hasErrors()) {
-                            this.confirmingUserDeletion = false;
-                        }
-                    }
+                    onSuccess: () => (this.confirmingUserDeletion = false)
                 })
             },
         },

--- a/stubs/inertia/resources/js/Pages/Profile/DeleteUserForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/DeleteUserForm.vue
@@ -95,6 +95,7 @@
                 this.form.delete(route('current-user.destroy'), {
                     preserveScroll: true,
                     onSuccess: () => this.closeModal(),
+                    onError: () => this.$refs.password.focus(),
                     onFinish: () => this.form.reset(),
                 })
             },

--- a/stubs/inertia/resources/js/Pages/Profile/DeleteUserForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/DeleteUserForm.vue
@@ -94,7 +94,8 @@
             deleteUser() {
                 this.form.delete(route('current-user.destroy'), {
                     preserveScroll: true,
-                    onSuccess: () => (this.confirmingUserDeletion = false)
+                    onSuccess: () => (this.confirmingUserDeletion = false),
+                    onFinish: () => this.form.reset('password'),
                 })
             },
         },

--- a/stubs/inertia/resources/js/Pages/Profile/DeleteUserForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/DeleteUserForm.vue
@@ -39,7 +39,7 @@
                 </template>
 
                 <template #footer>
-                    <jet-secondary-button @click.native="confirmingUserDeletion = false">
+                    <jet-secondary-button @click.native="closeModal">
                         Nevermind
                     </jet-secondary-button>
 
@@ -81,21 +81,21 @@
         },
 
         methods: {
+            closeModal() {
+                this.confirmingUserDeletion = false
+                this.form.reset()
+            },
             confirmUserDeletion() {
-                this.form.password = '';
-
                 this.confirmingUserDeletion = true;
 
-                setTimeout(() => {
-                    this.$refs.password.focus()
-                }, 250)
+                setTimeout(() => this.$refs.password.focus(), 250)
             },
 
             deleteUser() {
                 this.form.delete(route('current-user.destroy'), {
                     preserveScroll: true,
                     onSuccess: () => (this.confirmingUserDeletion = false),
-                    onFinish: () => this.form.reset('password'),
+                    onFinish: () => this.form.reset(),
                 })
             },
         },

--- a/stubs/inertia/resources/js/Pages/Profile/DeleteUserForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/DeleteUserForm.vue
@@ -93,7 +93,6 @@
 
             deleteUser() {
                 this.form.delete(route('current-user.destroy'), {
-                    errorBag: 'deleteUser',
                     preserveScroll: true,
                     onSuccess: () => (this.confirmingUserDeletion = false)
                 })

--- a/stubs/inertia/resources/js/Pages/Profile/DeleteUserForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/DeleteUserForm.vue
@@ -20,7 +20,7 @@
             </div>
 
             <!-- Delete Account Confirmation Modal -->
-            <jet-dialog-modal :show="confirmingUserDeletion" @close="confirmingUserDeletion = false">
+            <jet-dialog-modal :show="confirmingUserDeletion" @close="closeModal">
                 <template #title>
                     Delete Account
                 </template>
@@ -94,7 +94,7 @@
             deleteUser() {
                 this.form.delete(route('current-user.destroy'), {
                     preserveScroll: true,
-                    onSuccess: () => (this.confirmingUserDeletion = false),
+                    onSuccess: () => this.closeModal(),
                     onFinish: () => this.form.reset(),
                 })
             },

--- a/stubs/inertia/resources/js/Pages/Profile/LogoutOtherBrowserSessionsForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/LogoutOtherBrowserSessionsForm.vue
@@ -73,7 +73,7 @@
                 </template>
 
                 <template #footer>
-                    <jet-secondary-button @click.native="confirmingLogout = false">
+                    <jet-secondary-button @click.native="closeModal">
                         Nevermind
                     </jet-secondary-button>
 
@@ -119,21 +119,21 @@
         },
 
         methods: {
+            closeModal() {
+                this.confirmingLogout = false
+                this.form.reset()
+            },
             confirmLogout() {
-                this.form.password = ''
-
                 this.confirmingLogout = true
 
-                setTimeout(() => {
-                    this.$refs.password.focus()
-                }, 250)
+                setTimeout(() => this.$refs.password.focus(), 250)
             },
 
             logoutOtherBrowserSessions() {
                 this.form.delete(route('other-browser-sessions.destroy'), {
                     preserveScroll: true,
                     onSuccess: () => (this.confirmingLogout = false),
-                    onFinish: () => this.form.reset('password'),
+                    onFinish: () => this.form.reset(),
                 })
             },
         },

--- a/stubs/inertia/resources/js/Pages/Profile/LogoutOtherBrowserSessionsForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/LogoutOtherBrowserSessionsForm.vue
@@ -48,7 +48,7 @@
                     Logout Other Browser Sessions
                 </jet-button>
 
-                <jet-action-message :on="form.recentlySuccessful" class="ml-3">
+                <jet-action-message :on="formRecentlySuccessful" class="ml-3">
                     Done.
                 </jet-action-message>
             </div>
@@ -68,7 +68,7 @@
                                     v-model="form.password"
                                     @keyup.enter.native="logoutOtherBrowserSessions" />
 
-                        <jet-input-error :message="form.error('password')" class="mt-2" />
+                        <jet-input-error :message="form.errors.password" class="mt-2" />
                     </div>
                 </template>
 
@@ -111,12 +111,10 @@
         data() {
             return {
                 confirmingLogout: false,
+                formRecentlySuccessful: false,
 
                 form: this.$inertia.form({
-                    '_method': 'DELETE',
                     password: '',
-                }, {
-                    bag: 'logoutOtherBrowserSessions'
                 })
             }
         },
@@ -133,12 +131,13 @@
             },
 
             logoutOtherBrowserSessions() {
-                this.form.post(route('other-browser-sessions.destroy'), {
+                this.form.delete(route('other-browser-sessions.destroy'), {
+                    errorBag: 'logoutOtherBrowserSessions',
                     preserveScroll: true,
+                    before: () => (this.formRecentlySuccessful = false),
                     onSuccess: () => {
-                        if (! this.form.hasErrors()) {
-                            this.confirmingLogout = false
-                        }
+                        this.formRecentlySuccessful = true
+                        this.confirmingLogout = false
                     }
                 })
             },

--- a/stubs/inertia/resources/js/Pages/Profile/LogoutOtherBrowserSessionsForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/LogoutOtherBrowserSessionsForm.vue
@@ -54,7 +54,7 @@
             </div>
 
             <!-- Logout Other Devices Confirmation Modal -->
-            <jet-dialog-modal :show="confirmingLogout" @close="confirmingLogout = false">
+            <jet-dialog-modal :show="confirmingLogout" @close="closeModal">
                 <template #title>
                     Logout Other Browser Sessions
                 </template>
@@ -132,7 +132,7 @@
             logoutOtherBrowserSessions() {
                 this.form.delete(route('other-browser-sessions.destroy'), {
                     preserveScroll: true,
-                    onSuccess: () => (this.confirmingLogout = false),
+                    onSuccess: () => this.closeModal(),
                     onFinish: () => this.form.reset(),
                 })
             },

--- a/stubs/inertia/resources/js/Pages/Profile/LogoutOtherBrowserSessionsForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/LogoutOtherBrowserSessionsForm.vue
@@ -48,7 +48,7 @@
                     Logout Other Browser Sessions
                 </jet-button>
 
-                <jet-action-message :on="formRecentlySuccessful" class="ml-3">
+                <jet-action-message :on="successfulLogoutOtherBrowserSessions" class="ml-3">
                     Done.
                 </jet-action-message>
             </div>
@@ -111,7 +111,7 @@
         data() {
             return {
                 confirmingLogout: false,
-                formRecentlySuccessful: false,
+                successfulLogoutOtherBrowserSessions: false,
 
                 form: this.$inertia.form({
                     password: '',
@@ -134,9 +134,9 @@
                 this.form.delete(route('other-browser-sessions.destroy'), {
                     errorBag: 'logoutOtherBrowserSessions',
                     preserveScroll: true,
-                    before: () => (this.formRecentlySuccessful = false),
+                    before: () => (this.successfulLogoutOtherBrowserSessions = false),
                     onSuccess: () => {
-                        this.formRecentlySuccessful = true
+                        this.successfulLogoutOtherBrowserSessions = true
                         this.confirmingLogout = false
                     }
                 })

--- a/stubs/inertia/resources/js/Pages/Profile/LogoutOtherBrowserSessionsForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/LogoutOtherBrowserSessionsForm.vue
@@ -48,7 +48,7 @@
                     Logout Other Browser Sessions
                 </jet-button>
 
-                <jet-action-message :on="successfulLogoutOtherBrowserSessions" class="ml-3">
+                <jet-action-message :on="form.recentlySuccessful" class="ml-3">
                     Done.
                 </jet-action-message>
             </div>
@@ -111,7 +111,6 @@
         data() {
             return {
                 confirmingLogout: false,
-                successfulLogoutOtherBrowserSessions: false,
 
                 form: this.$inertia.form({
                     password: '',
@@ -133,11 +132,8 @@
             logoutOtherBrowserSessions() {
                 this.form.delete(route('other-browser-sessions.destroy'), {
                     preserveScroll: true,
-                    before: () => (this.successfulLogoutOtherBrowserSessions = false),
-                    onSuccess: () => {
-                        this.successfulLogoutOtherBrowserSessions = true
-                        this.confirmingLogout = false
-                    }
+                    onSuccess: () => (this.confirmingLogout = false),
+                    onFinish: () => this.form.reset('password'),
                 })
             },
         },

--- a/stubs/inertia/resources/js/Pages/Profile/LogoutOtherBrowserSessionsForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/LogoutOtherBrowserSessionsForm.vue
@@ -123,6 +123,7 @@
                 this.confirmingLogout = false
                 this.form.reset()
             },
+
             confirmLogout() {
                 this.confirmingLogout = true
 

--- a/stubs/inertia/resources/js/Pages/Profile/LogoutOtherBrowserSessionsForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/LogoutOtherBrowserSessionsForm.vue
@@ -132,7 +132,6 @@
 
             logoutOtherBrowserSessions() {
                 this.form.delete(route('other-browser-sessions.destroy'), {
-                    errorBag: 'logoutOtherBrowserSessions',
                     preserveScroll: true,
                     before: () => (this.successfulLogoutOtherBrowserSessions = false),
                     onSuccess: () => {

--- a/stubs/inertia/resources/js/Pages/Profile/LogoutOtherBrowserSessionsForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/LogoutOtherBrowserSessionsForm.vue
@@ -133,6 +133,7 @@
                 this.form.delete(route('other-browser-sessions.destroy'), {
                     preserveScroll: true,
                     onSuccess: () => this.closeModal(),
+                    onError: () => this.$refs.password.focus(),
                     onFinish: () => this.form.reset(),
                 })
             },

--- a/stubs/inertia/resources/js/Pages/Profile/TwoFactorAuthenticationForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/TwoFactorAuthenticationForm.vue
@@ -68,7 +68,7 @@
                     </jet-confirms-password>
 
                     <jet-confirms-password @confirmed="showRecoveryCodes">
-                        <jet-secondary-button class="mr-3" v-if="recoveryCodes.length == 0">
+                        <jet-secondary-button class="mr-3" v-if="recoveryCodes.length === 0">
                             Show Recovery Codes
                         </jet-secondary-button>
                     </jet-confirms-password>

--- a/stubs/inertia/resources/js/Pages/Profile/TwoFactorAuthenticationForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/TwoFactorAuthenticationForm.vue
@@ -122,9 +122,7 @@
                         this.showQrCode(),
                         this.showRecoveryCodes(),
                     ]),
-                    onFinish: () => {
-                        this.enabling = false
-                    }
+                    onFinish: () => (this.enabling = false),
                 })
             },
 
@@ -154,9 +152,7 @@
 
                 this.$inertia.delete('/user/two-factor-authentication', {}, {
                     preserveScroll: true,
-                    onSuccess: () => {
-                        this.disabling = false
-                    }
+                    onSuccess: () => (this.disabling = false),
                 })
             },
         },

--- a/stubs/inertia/resources/js/Pages/Profile/TwoFactorAuthenticationForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/TwoFactorAuthenticationForm.vue
@@ -152,7 +152,7 @@
             disableTwoFactorAuthentication() {
                 this.disabling = true
 
-                this.$inertia.delete('/user/two-factor-authentication', {
+                this.$inertia.delete('/user/two-factor-authentication', {}, {
                     preserveScroll: true,
                     onSuccess: () => {
                         this.disabling = false

--- a/stubs/inertia/resources/js/Pages/Profile/UpdatePasswordForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/UpdatePasswordForm.vue
@@ -17,7 +17,7 @@
 
             <div class="col-span-6 sm:col-span-4">
                 <jet-label for="password" value="New Password" />
-                <jet-input id="password" type="password" class="mt-1 block w-full" v-model="form.password" autocomplete="new-password" />
+                <jet-input id="password" type="password" class="mt-1 block w-full" v-model="form.password" ref="password" autocomplete="new-password" />
                 <jet-input-error :message="form.errors.password" class="mt-2" />
             </div>
 
@@ -29,7 +29,7 @@
         </template>
 
         <template #actions>
-            <jet-action-message :on="successfullyUpdatedPassword" class="mr-3">
+            <jet-action-message :on="form.recentlySuccessful" class="mr-3">
                 Saved.
             </jet-action-message>
 
@@ -60,7 +60,6 @@
 
         data() {
             return {
-                successfullyUpdatedPassword: false,
                 form: this.$inertia.form({
                     current_password: '',
                     password: '',
@@ -74,11 +73,18 @@
                 this.form.put(route('user-password.update'), {
                     errorBag: 'updatePassword',
                     preserveScroll: true,
-                    before: () => (this.successfullyUpdatedPassword = false),
-                    onSuccess: () => {
-                        this.successfullyUpdatedPassword = true
-                        this.$refs.current_password.focus()
-                    },
+                    onSuccess: () => this.form.reset(),
+                    onError: () => {
+                        if (this.form.errors.password) {
+                            this.form.reset('password', 'password_confirmation')
+                            this.$refs.password.focus()
+                        }
+
+                        if (this.form.errors.current_password) {
+                            this.form.reset('current_password')
+                            this.$refs.current_password.focus()
+                        }
+                    }
                 })
             },
         },

--- a/stubs/inertia/resources/js/Pages/Profile/UpdatePasswordForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/UpdatePasswordForm.vue
@@ -12,24 +12,24 @@
             <div class="col-span-6 sm:col-span-4">
                 <jet-label for="current_password" value="Current Password" />
                 <jet-input id="current_password" type="password" class="mt-1 block w-full" v-model="form.current_password" ref="current_password" autocomplete="current-password" />
-                <jet-input-error :message="form.error('current_password')" class="mt-2" />
+                <jet-input-error :message="form.errors.current_password" class="mt-2" />
             </div>
 
             <div class="col-span-6 sm:col-span-4">
                 <jet-label for="password" value="New Password" />
                 <jet-input id="password" type="password" class="mt-1 block w-full" v-model="form.password" autocomplete="new-password" />
-                <jet-input-error :message="form.error('password')" class="mt-2" />
+                <jet-input-error :message="form.errors.password" class="mt-2" />
             </div>
 
             <div class="col-span-6 sm:col-span-4">
                 <jet-label for="password_confirmation" value="Confirm Password" />
                 <jet-input id="password_confirmation" type="password" class="mt-1 block w-full" v-model="form.password_confirmation" autocomplete="new-password" />
-                <jet-input-error :message="form.error('password_confirmation')" class="mt-2" />
+                <jet-input-error :message="form.errors.password_confirmation" class="mt-2" />
             </div>
         </template>
 
         <template #actions>
-            <jet-action-message :on="form.recentlySuccessful" class="mr-3">
+            <jet-action-message :on="formRecentlySuccessful" class="mr-3">
                 Saved.
             </jet-action-message>
 
@@ -60,12 +60,11 @@
 
         data() {
             return {
+                formRecentlySuccessful: false,
                 form: this.$inertia.form({
                     current_password: '',
                     password: '',
                     password_confirmation: '',
-                }, {
-                    bag: 'updatePassword',
                 }),
             }
         },
@@ -73,10 +72,13 @@
         methods: {
             updatePassword() {
                 this.form.put(route('user-password.update'), {
+                    errorBag: 'updatePassword',
                     preserveScroll: true,
+                    before: () => (this.formRecentlySuccessful = false),
                     onSuccess: () => {
+                        this.formRecentlySuccessful = true
                         this.$refs.current_password.focus()
-                    }
+                    },
                 })
             },
         },

--- a/stubs/inertia/resources/js/Pages/Profile/UpdatePasswordForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/UpdatePasswordForm.vue
@@ -29,7 +29,7 @@
         </template>
 
         <template #actions>
-            <jet-action-message :on="formRecentlySuccessful" class="mr-3">
+            <jet-action-message :on="successfullyUpdatedPassword" class="mr-3">
                 Saved.
             </jet-action-message>
 
@@ -60,7 +60,7 @@
 
         data() {
             return {
-                formRecentlySuccessful: false,
+                successfullyUpdatedPassword: false,
                 form: this.$inertia.form({
                     current_password: '',
                     password: '',
@@ -74,9 +74,9 @@
                 this.form.put(route('user-password.update'), {
                     errorBag: 'updatePassword',
                     preserveScroll: true,
-                    before: () => (this.formRecentlySuccessful = false),
+                    before: () => (this.successfullyUpdatedPassword = false),
                     onSuccess: () => {
-                        this.formRecentlySuccessful = true
+                        this.successfullyUpdatedPassword = true
                         this.$refs.current_password.focus()
                     },
                 })

--- a/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
@@ -38,21 +38,21 @@
                     Remove Photo
                 </jet-secondary-button>
 
-                <jet-input-error :message="form.error('photo')" class="mt-2" />
+                <jet-input-error :message="form.errors.photo" class="mt-2" />
             </div>
 
             <!-- Name -->
             <div class="col-span-6 sm:col-span-4">
                 <jet-label for="name" value="Name" />
                 <jet-input id="name" type="text" class="mt-1 block w-full" v-model="form.name" autocomplete="name" />
-                <jet-input-error :message="form.error('name')" class="mt-2" />
+                <jet-input-error :message="form.errors.name" class="mt-2" />
             </div>
 
             <!-- Email -->
             <div class="col-span-6 sm:col-span-4">
                 <jet-label for="email" value="Email" />
                 <jet-input id="email" type="email" class="mt-1 block w-full" v-model="form.email" />
-                <jet-input-error :message="form.error('email')" class="mt-2" />
+                <jet-input-error :message="form.errors.email" class="mt-2" />
             </div>
         </template>
 
@@ -93,13 +93,10 @@
         data() {
             return {
                 form: this.$inertia.form({
-                    '_method': 'PUT',
+                    _method: 'PUT',
                     name: this.user.name,
                     email: this.user.email,
                     photo: null,
-                }, {
-                    bag: 'updateProfileInformation',
-                    resetOnSuccess: false,
                 }),
 
                 photoPreview: null,
@@ -113,6 +110,7 @@
                 }
 
                 this.form.post(route('user-profile-information.update'), {
+                    errorBag: 'updateProfileInformation',
                     preserveScroll: true
                 });
             },

--- a/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
@@ -130,7 +130,7 @@
             },
 
             deletePhoto() {
-                this.$inertia.delete(route('current-user-photo.destroy'), {
+                this.$inertia.delete(route('current-user-photo.destroy'), {}, {
                     preserveScroll: true,
                     onSuccess: () => {
                         this.photoPreview = null

--- a/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
@@ -132,9 +132,7 @@
             deletePhoto() {
                 this.$inertia.delete(route('current-user-photo.destroy'), {}, {
                     preserveScroll: true,
-                    onSuccess: () => {
-                        this.photoPreview = null
-                    }
+                    onSuccess: () => (this.photoPreview = null),
                 });
             },
         },

--- a/stubs/inertia/resources/js/Pages/Teams/CreateTeamForm.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/CreateTeamForm.vue
@@ -25,7 +25,7 @@
             <div class="col-span-6 sm:col-span-4">
                 <jet-label for="name" value="Team Name" />
                 <jet-input id="name" type="text" class="mt-1 block w-full" v-model="form.name" autofocus />
-                <jet-input-error :message="form.error('name')" class="mt-2" />
+                <jet-input-error :message="form.errors.name" class="mt-2" />
             </div>
         </template>
 
@@ -59,9 +59,6 @@
             return {
                 form: this.$inertia.form({
                     name: '',
-                }, {
-                    bag: 'createTeam',
-                    resetOnSuccess: false,
                 })
             }
         },
@@ -69,6 +66,7 @@
         methods: {
             createTeam() {
                 this.form.post(route('teams.store'), {
+                    errorBag: 'createTeam',
                     preserveScroll: true
                 });
             },

--- a/stubs/inertia/resources/js/Pages/Teams/DeleteTeamForm.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/DeleteTeamForm.vue
@@ -66,11 +66,7 @@
                 confirmingTeamDeletion: false,
                 deleting: false,
 
-                form: this.$inertia.form({
-                    //
-                }, {
-                    bag: 'deleteTeam'
-                })
+                form: this.$inertia.form()
             }
         },
 
@@ -81,6 +77,7 @@
 
             deleteTeam() {
                 this.form.delete(route('teams.destroy', this.team), {
+                    errorBag: 'deleteTeam',
                     preserveScroll: true
                 });
             },

--- a/stubs/inertia/resources/js/Pages/Teams/DeleteTeamForm.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/DeleteTeamForm.vue
@@ -77,8 +77,7 @@
 
             deleteTeam() {
                 this.form.delete(route('teams.destroy', this.team), {
-                    errorBag: 'deleteTeam',
-                    preserveScroll: true
+                    errorBag: 'deleteTeam'
                 });
             },
         },

--- a/stubs/inertia/resources/js/Pages/Teams/TeamMemberManager.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/TeamMemberManager.vue
@@ -308,9 +308,7 @@
                 this.addTeamMemberForm.post(route('team-members.store', this.team), {
                     errorBag: 'addTeamMember',
                     preserveScroll: true,
-                    onSuccess: () => {
-                        this.addTeamMemberForm.reset()
-                    },
+                    onSuccess: () => this.addTeamMemberForm.reset(),
                 });
             },
 

--- a/stubs/inertia/resources/js/Pages/Teams/TeamMemberManager.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/TeamMemberManager.vue
@@ -318,7 +318,7 @@
             },
 
             cancelTeamInvitation(invitation) {
-                this.$inertia.delete(route('team-invitations.destroy', invitation), {
+                this.$inertia.delete(route('team-invitations.destroy', invitation), {}, {
                     preserveScroll: true
                 });
             },

--- a/stubs/inertia/resources/js/Pages/Teams/TeamMemberManager.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/TeamMemberManager.vue
@@ -59,7 +59,7 @@
                 </template>
 
                 <template #actions>
-                    <jet-action-message :on="successfullyAddedTeamMember" class="mr-3">
+                    <jet-action-message :on="addTeamMemberForm.recentlySuccessful" class="mr-3">
                         Added.
                     </jet-action-message>
 
@@ -284,7 +284,6 @@
 
         data() {
             return {
-                successfullyAddedTeamMember: false,
                 addTeamMemberForm: this.$inertia.form({
                     email: '',
                     role: null,
@@ -309,9 +308,7 @@
                 this.addTeamMemberForm.post(route('team-members.store', this.team), {
                     errorBag: 'addTeamMember',
                     preserveScroll: true,
-                    before: () => (this.successfullyAddedTeamMember = false),
                     onSuccess: () => {
-                        this.successfullyAddedTeamMember = true
                         this.addTeamMemberForm.reset()
                     },
                 });

--- a/stubs/inertia/resources/js/Pages/Teams/TeamMemberManager.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/TeamMemberManager.vue
@@ -24,13 +24,13 @@
                     <div class="col-span-6 sm:col-span-4">
                         <jet-label for="email" value="Email" />
                         <jet-input id="email" type="text" class="mt-1 block w-full" v-model="addTeamMemberForm.email" />
-                        <jet-input-error :message="addTeamMemberForm.error('email')" class="mt-2" />
+                        <jet-input-error :message="addTeamMemberForm.errors.email" class="mt-2" />
                     </div>
 
                     <!-- Role -->
                     <div class="col-span-6 lg:col-span-4" v-if="availableRoles.length > 0">
                         <jet-label for="roles" value="Role" />
-                        <jet-input-error :message="addTeamMemberForm.error('role')" class="mt-2" />
+                        <jet-input-error :message="addTeamMemberForm.errors.role" class="mt-2" />
 
                         <div class="relative z-0 mt-1 border border-gray-200 rounded-lg cursor-pointer">
                             <button type="button" class="relative px-4 py-3 inline-flex w-full rounded-lg focus:z-10 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue"
@@ -59,7 +59,7 @@
                 </template>
 
                 <template #actions>
-                    <jet-action-message :on="addTeamMemberForm.recentlySuccessful" class="mr-3">
+                    <jet-action-message :on="addTeamMemberFormRecentlySuccessful" class="mr-3">
                         Added.
                     </jet-action-message>
 
@@ -167,18 +167,18 @@
                 <div v-if="managingRoleFor">
                     <div class="relative z-0 mt-1 border border-gray-200 rounded-lg cursor-pointer">
                         <button type="button" class="relative px-4 py-3 inline-flex w-full rounded-lg focus:z-10 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue"
-                                        :class="{'border-t border-gray-200 rounded-t-none': i > 0, 'rounded-b-none': i != Object.keys(availableRoles).length - 1}"
+                                        :class="{'border-t border-gray-200 rounded-t-none': i > 0, 'rounded-b-none': i !== Object.keys(availableRoles).length - 1}"
                                         @click="updateRoleForm.role = role.key"
                                         v-for="(role, i) in availableRoles"
                                         :key="role.key">
-                            <div :class="{'opacity-50': updateRoleForm.role && updateRoleForm.role != role.key}">
+                            <div :class="{'opacity-50': updateRoleForm.role && updateRoleForm.role !== role.key}">
                                 <!-- Role Name -->
                                 <div class="flex items-center">
-                                    <div class="text-sm text-gray-600" :class="{'font-semibold': updateRoleForm.role == role.key}">
+                                    <div class="text-sm text-gray-600" :class="{'font-semibold': updateRoleForm.role === role.key}">
                                         {{ role.name }}
                                     </div>
 
-                                    <svg v-if="updateRoleForm.role == role.key" class="ml-2 h-5 w-5 text-green-400" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" stroke="currentColor" viewBox="0 0 24 24"><path d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+                                    <svg v-if="updateRoleForm.role === role.key" class="ml-2 h-5 w-5 text-green-400" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" stroke="currentColor" viewBox="0 0 24 24"><path d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
                                 </div>
 
                                 <!-- Role Description -->
@@ -284,32 +284,18 @@
 
         data() {
             return {
+                addTeamMemberFormRecentlySuccessful: false,
                 addTeamMemberForm: this.$inertia.form({
                     email: '',
                     role: null,
-                }, {
-                    bag: 'addTeamMember',
-                    resetOnSuccess: true,
                 }),
 
                 updateRoleForm: this.$inertia.form({
                     role: null,
-                }, {
-                    bag: 'updateRole',
-                    resetOnSuccess: false,
                 }),
 
-                leaveTeamForm: this.$inertia.form({
-                    //
-                }, {
-                    bag: 'leaveTeam',
-                }),
-
-                removeTeamMemberForm: this.$inertia.form({
-                    //
-                }, {
-                    bag: 'removeTeamMember',
-                }),
+                leaveTeamForm: this.$inertia.form(),
+                removeTeamMemberForm: this.$inertia.form(),
 
                 currentlyManagingRole: false,
                 managingRoleFor: null,
@@ -321,7 +307,13 @@
         methods: {
             addTeamMember() {
                 this.addTeamMemberForm.post(route('team-members.store', this.team), {
-                    preserveScroll: true
+                    errorBag: 'addTeamMember',
+                    preserveScroll: true,
+                    before: () => (this.addTeamMemberFormRecentlySuccessful = false),
+                    onSuccess: () => {
+                        this.addTeamMemberFormRecentlySuccessful = true
+                        this.addTeamMemberForm.reset()
+                    },
                 });
             },
 
@@ -339,10 +331,9 @@
 
             updateRole() {
                 this.updateRoleForm.put(route('team-members.update', [this.team, this.managingRoleFor]), {
+                    errorBag: 'updateRole',
                     preserveScroll: true,
-                    onSuccess: () => {
-                        this.currentlyManagingRole = false
-                    }
+                    onSuccess: () => (this.currentlyManagingRole = false),
                 })
             },
 
@@ -351,7 +342,9 @@
             },
 
             leaveTeam() {
-                this.leaveTeamForm.delete(route('team-members.destroy', [this.team, this.$page.props.user]))
+                this.leaveTeamForm.delete(route('team-members.destroy', [this.team, this.$page.props.user]), {
+                    errorBag: 'leaveTeam',
+                })
             },
 
             confirmTeamMemberRemoval(teamMember) {
@@ -360,16 +353,15 @@
 
             removeTeamMember() {
                 this.removeTeamMemberForm.delete(route('team-members.destroy', [this.team, this.teamMemberBeingRemoved]), {
+                    errorBag: 'removeTeamMember',
                     preserveScroll: true,
                     preserveState: true,
-                    onSuccess: () => {
-                        this.teamMemberBeingRemoved = null
-                    }
+                    onSuccess: () => (this.teamMemberBeingRemoved = null),
                 })
             },
 
             displayableRole(role) {
-                return this.availableRoles.find(r => r.key == role).name
+                return this.availableRoles.find(r => r.key === role).name
             },
         },
     }

--- a/stubs/inertia/resources/js/Pages/Teams/TeamMemberManager.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/TeamMemberManager.vue
@@ -59,7 +59,7 @@
                 </template>
 
                 <template #actions>
-                    <jet-action-message :on="addTeamMemberFormRecentlySuccessful" class="mr-3">
+                    <jet-action-message :on="successfullyAddedTeamMember" class="mr-3">
                         Added.
                     </jet-action-message>
 
@@ -284,7 +284,7 @@
 
         data() {
             return {
-                addTeamMemberFormRecentlySuccessful: false,
+                successfullyAddedTeamMember: false,
                 addTeamMemberForm: this.$inertia.form({
                     email: '',
                     role: null,
@@ -309,9 +309,9 @@
                 this.addTeamMemberForm.post(route('team-members.store', this.team), {
                     errorBag: 'addTeamMember',
                     preserveScroll: true,
-                    before: () => (this.addTeamMemberFormRecentlySuccessful = false),
+                    before: () => (this.successfullyAddedTeamMember = false),
                     onSuccess: () => {
-                        this.addTeamMemberFormRecentlySuccessful = true
+                        this.successfullyAddedTeamMember = true
                         this.addTeamMemberForm.reset()
                     },
                 });

--- a/stubs/inertia/resources/js/Pages/Teams/TeamMemberManager.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/TeamMemberManager.vue
@@ -331,7 +331,6 @@
 
             updateRole() {
                 this.updateRoleForm.put(route('team-members.update', [this.team, this.managingRoleFor]), {
-                    errorBag: 'updateRole',
                     preserveScroll: true,
                     onSuccess: () => (this.currentlyManagingRole = false),
                 })
@@ -342,9 +341,7 @@
             },
 
             leaveTeam() {
-                this.leaveTeamForm.delete(route('team-members.destroy', [this.team, this.$page.props.user]), {
-                    errorBag: 'leaveTeam',
-                })
+                this.leaveTeamForm.delete(route('team-members.destroy', [this.team, this.$page.props.user]))
             },
 
             confirmTeamMemberRemoval(teamMember) {

--- a/stubs/inertia/resources/js/Pages/Teams/UpdateTeamNameForm.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/UpdateTeamNameForm.vue
@@ -33,7 +33,7 @@
                             v-model="form.name"
                             :disabled="! permissions.canUpdateTeam" />
 
-                <jet-input-error :message="form.error('name')" class="mt-2" />
+                <jet-input-error :message="form.errors.name" class="mt-2" />
             </div>
         </template>
 
@@ -73,9 +73,6 @@
             return {
                 form: this.$inertia.form({
                     name: this.team.name,
-                }, {
-                    bag: 'updateTeamName',
-                    resetOnSuccess: false,
                 })
             }
         },
@@ -83,6 +80,7 @@
         methods: {
             updateTeamName() {
                 this.form.put(route('teams.update', this.team), {
+                    errorBag: 'updateTeamName',
                     preserveScroll: true
                 });
             },

--- a/stubs/inertia/resources/js/app.js
+++ b/stubs/inertia/resources/js/app.js
@@ -4,7 +4,7 @@ require('moment');
 
 // Import modules...
 import Vue from 'vue';
-import { InertiaApp, plugin as InertiaPlugin } from '@inertiajs/inertia-vue';
+import { App as InertiaApp, plugin as InertiaPlugin } from '@inertiajs/inertia-vue';
 import { InertiaForm } from 'laravel-jetstream';
 import PortalVue from 'portal-vue';
 import VueI18n from 'vue-i18n';

--- a/stubs/inertia/resources/js/app.js
+++ b/stubs/inertia/resources/js/app.js
@@ -5,7 +5,6 @@ require('moment');
 // Import modules...
 import Vue from 'vue';
 import { App as InertiaApp, plugin as InertiaPlugin } from '@inertiajs/inertia-vue';
-import { InertiaForm } from 'laravel-jetstream';
 import PortalVue from 'portal-vue';
 import VueI18n from 'vue-i18n';
 
@@ -13,7 +12,6 @@ import VueI18n from 'vue-i18n';
 Vue.mixin({ methods: { route } });
 
 Vue.use(InertiaPlugin);
-Vue.use(InertiaForm);
 Vue.use(PortalVue);
 Vue.use(VueI18n);
 


### PR DESCRIPTION
This PR upgrades Jetstream to support and make use of the features shipped with `@inertiajs/inertia-vue` version `0.5.0`.

Specifically, it migrates away from [`jetstream-js`](https://github.com/laravel/jetstream-js) in favor of Inertia's own form helper, removes explicit 'error bag' definitions where possible, and also fixes a couple other minor issues found during this migration.