### PR TITLE
Add @can check to mobile menu

### DIFF
--- a/stubs/livewire/resources/views/navigation-dropdown.blade.php
+++ b/stubs/livewire/resources/views/navigation-dropdown.blade.php
@@ -171,9 +171,11 @@
                         {{ __('Team Settings') }}
                     </x-jet-responsive-nav-link>
 
+                    @can('create', Laravel\Jetstream\Jetstream::newTeamModel())
                     <x-jet-responsive-nav-link href="{{ route('teams.create') }}" :active="request()->routeIs('teams.create')">
                         {{ __('Create New Team') }}
                     </x-jet-responsive-nav-link>
+                    @endcan
 
                     <div class="border-t border-gray-200"></div>
 


### PR DESCRIPTION
Adds `@can` check to the mobile menu.

This check is present on the desktop menu:

https://github.com/stancl/jetstream/blob/5c09ad50e4371610ebbc336aa0b6f9a3d5c8eccf/stubs/livewire/resources/views/navigation-dropdown.blade.php#L71-L75

The current behavior on mobile is that user is shown a link in the menu, he can visit the "create team" site, and only when he submits the form he gets a 403.