### PR TITLE
[1.x] Avoids eqeqeq errors in eslint

### DIFF
--- a/stubs/inertia/resources/js/Jetstream/Dropdown.vue
+++ b/stubs/inertia/resources/js/Jetstream/Dropdown.vue
@@ -70,9 +70,9 @@
             },
 
             alignmentClasses() {
-                if (this.align == 'left') {
+                if (this.align === 'left') {
                     return 'origin-top-left left-0'
-                } else if (this.align == 'right') {
+                } else if (this.align === 'right') {
                     return 'origin-top-right right-0'
                 } else {
                     return 'origin-top'


### PR DESCRIPTION
Avoid using '==' when possible and when compared to user input.
This fixes 'eqeqeq' error in eslint : https://eslint.org/docs/rules/eqeqeq

This fix is harmless and can be applied to 2.x

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

If you change the behavior of the Inertia stack you're expected to update the Livewire stack as well and vica versa.
-->
