### PR TITLE
Automatically select API token when it's created

### DIFF
--- a/src/Http/Livewire/ApiTokenManager.php
+++ b/src/Http/Livewire/ApiTokenManager.php
@@ -117,6 +117,8 @@ class ApiTokenManager extends Component
         $this->displayingToken = true;
 
         $this->plainTextToken = explode('|', $token->plainTextToken, 2)[1];
+
+        $this->dispatchBrowserEvent('showing-token-modal');
     }
 
     /**

--- a/stubs/livewire/resources/views/api/api-token-manager.blade.php
+++ b/stubs/livewire/resources/views/api/api-token-manager.blade.php
@@ -105,8 +105,8 @@
             </div>
 
             <x-jet-input
-                x-ref="plaintextToken" @keydown.prevent="" @showing-token-modal.window="setTimeout(() => $refs.plaintextToken.select(), 250)"
-                type="text" :value="$plainTextToken" class="mt-4 bg-gray-100 px-4 py-2 rounded font-mono text-sm text-gray-500 w-full"
+                x-ref="plaintextToken" @showing-token-modal.window="setTimeout(() => $refs.plaintextToken.select(), 250)"
+                type="text" readonly :value="$plainTextToken" class="mt-4 bg-gray-100 px-4 py-2 rounded font-mono text-sm text-gray-500 w-full"
                 autofocus autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"
             />
         </x-slot>

--- a/stubs/livewire/resources/views/api/api-token-manager.blade.php
+++ b/stubs/livewire/resources/views/api/api-token-manager.blade.php
@@ -104,9 +104,11 @@
                 {{ __('Please copy your new API token. For your security, it won\'t be shown again.') }}
             </div>
 
-            <div class="mt-4 bg-gray-100 px-4 py-2 rounded font-mono text-sm text-gray-500">
-                {{ $plainTextToken }}
-            </div>
+            <x-jet-input
+                x-ref="plaintextToken" @keydown.prevent="" @showing-token-modal.window="setTimeout(() => $refs.plaintextToken.select(), 250)"
+                type="text" :value="$plainTextToken" class="mt-4 bg-gray-100 px-4 py-2 rounded font-mono text-sm text-gray-500 w-full"
+                autofocus autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"
+            />
         </x-slot>
 
         <x-slot name="footer">


### PR DESCRIPTION
The user can now just CTRL+C.

<img width="699" alt="Screen Shot 2021-01-05 at 21 40 33" src="https://user-images.githubusercontent.com/33033094/103696573-e0361580-4f9e-11eb-908e-6ecc57ddf6b4.png">

Let me know if the template needs any changes.