### PR TITLE
Add --local-composer flag to the install command

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -16,7 +16,8 @@ class InstallCommand extends Command
      * @var string
      */
     protected $signature = 'jetstream:install {stack : The development stack that should be installed}
-                                              {--teams : Indicates if team support should be installed}';
+                                              {--teams : Indicates if team support should be installed}
+                                              {--local-composer : Indicates that the local composer.phar should be use instead of the gobal composer}';
 
     /**
      * The console command description.
@@ -515,8 +516,12 @@ EOF;
      */
     protected function requireComposerPackages($packages)
     {
+        if ($this->option('local-composer')) {
+            $command = ['php', 'composer.phar', 'require'];
+        }
+
         $command = array_merge(
-            ['composer', 'require'],
+            $command ?? ['composer', 'require'],
             is_array($packages) ? $packages : func_get_args()
         );
 

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -17,7 +17,7 @@ class InstallCommand extends Command
      */
     protected $signature = 'jetstream:install {stack : The development stack that should be installed}
                                               {--teams : Indicates if team support should be installed}
-                                              {--local-composer : Indicates that the local composer.phar should be use instead of the gobal composer}';
+                                              {--local-composer : Indicates that the local composer.phar binary should be used to require packages instead of the global composer binary}';
 
     /**
      * The console command description.


### PR DESCRIPTION
Using this flag will use the local composer.phar binary installed at the base path instead of the global composer binary command.

This is useful for systems where composer is not installed globally.

Flag Usage:
```
php artisan jetstream:install livewire --local-composer

php artisan jetstream:install livewire --teams --local-composer
```

Executes e.g. `php composer.phar require livewire/livewire:^2.0 laravel/sanctum:^2.6` 
instead of `composer require livewire/livewire:^2.0 laravel/sanctum:^2.6`

Not sure about the command flag description though. 
Happy for suggestions.
