### PR TITLE
[2.x] Fix registration test

### DIFF
--- a/stubs/tests/RegistrationTest.php
+++ b/stubs/tests/RegistrationTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Providers\RouteServiceProvider;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Jetstream\Jetstream;
 use Tests\TestCase;
 
 class RegistrationTest extends TestCase
@@ -24,6 +25,7 @@ class RegistrationTest extends TestCase
             'email' => 'test@example.com',
             'password' => 'password',
             'password_confirmation' => 'password',
+            'terms' => Jetstream::hasTermsAndPrivacyPolicyFeature() ? true : null,
         ]);
 
         $this->assertAuthenticated();


### PR DESCRIPTION
Currently when Terms and Privacy feature is enabled the `test_new_users_can_register` fails because Jetstream will require the accepted `terms`.

The field could be passed either way, but I opted for verifying if the feature is enabled to be more explicit.