### PR TITLE
[2.x] Improve registration test

### DIFF
--- a/stubs/tests/RegistrationTest.php
+++ b/stubs/tests/RegistrationTest.php
@@ -17,13 +17,31 @@ class RegistrationTest extends TestCase
         $response->assertStatus(200);
     }
 
-    public function test_new_users_can_register()
+    public function test_new_users_can_register_with_terms_disabled()
     {
+        $this->app['config']->set('jetstream.features', []);
+
         $response = $this->post('/register', [
             'name' => 'Test User',
             'email' => 'test@example.com',
             'password' => 'password',
             'password_confirmation' => 'password',
+        ]);
+
+        $this->assertAuthenticated();
+        $response->assertRedirect(RouteServiceProvider::HOME);
+    }
+
+    public function test_new_users_can_register_with_terms_enabled()
+    {
+        $this->app['config']->set('jetstream.features', ['terms']);
+
+        $response = $this->post('/register', [
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+            'password' => 'password',
+            'password_confirmation' => 'password',
+            'terms' => true,
         ]);
 
         $this->assertAuthenticated();


### PR DESCRIPTION
Previous PR's (#549 #593) have been attempted to fix this test as it currently fails for developers when their application's `jetstream.features` config contains the`terms` feature.

This PR improves and updates the current test by ensuring the terms feature is not in the `jetstream.features` config.

An additional test has been added to test registration with terms enabled.