### PR TITLE
[2.x] Allow publishing of missing Inertia files

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -91,7 +91,11 @@ Rename the `resources/views/navigation-dropdown.blade.php` file to `navigation-m
 
 #### Authentication Views
 
-In order for Jetstream 2.x to continue to render your Blade based authentication views, you should add the following code to the `boot` method of your application's `JetstreamServiceProvider` class:
+In  order to use the new Vue based authentication, you will first need to publish a few assets. To do so, run the following command:
+
+    php artisan vendor:publish --tag=jetstream-v2-inertia-files
+
+If you wish to to continue to render your Blade based authentication views in Jetstream 2.x, you should add the following code to the `boot` method of your application's `JetstreamServiceProvider` class:
 
 ```php
 use Illuminate\Support\Facades\Route;

--- a/src/JetstreamServiceProvider.php
+++ b/src/JetstreamServiceProvider.php
@@ -166,6 +166,14 @@ class JetstreamServiceProvider extends ServiceProvider
         ], 'jetstream-views');
 
         $this->publishes([
+            __DIR__.'/../stubs/inertia/resources/js/Pages/Auth' => resource_path('js/Pages/Auth'),
+            __DIR__.'/../stubs/inertia/resources/js/Jetstream/AuthenticationCard.vue' => resource_path('js/Jetstream/AuthenticationCard.vue'),
+            __DIR__.'/../stubs/inertia/resources/js/Jetstream/AuthenticationCardLogo.vue' => resource_path('js/Jetstream/AuthenticationCardLogo.vue'),
+            __DIR__.'/../stubs/inertia/resources/js/Jetstream/Checkbox.vue' => resource_path('js/Jetstream/Checkbox.vue'),
+            __DIR__.'/../stubs/inertia/resources/js/Jetstream/ValidationErrors.vue' => resource_path('js/Jetstream/ValidationErrors.vue'),
+        ], 'jetstream-v2-inertia-files');
+
+        $this->publishes([
             __DIR__.'/../database/migrations/2014_10_12_000000_create_users_table.php' => database_path('migrations/2014_10_12_000000_create_users_table.php'),
         ], 'jetstream-migrations');
 


### PR DESCRIPTION
This PR adds a new `jetstream-v2-inertia-files` tag to the service provider, allowing developers using the Inertia stack, looking to upgrade from 1.x to 2.x, to migrate their authentication views over to Vue.

```sh
php artisan vendor:publish --tag=jetstream-v2-inertia-files
```