### PR TITLE
[2.x] Make button text in team invitation email translatable

### DIFF
--- a/resources/views/mail/team-invitation.blade.php
+++ b/resources/views/mail/team-invitation.blade.php
@@ -4,13 +4,13 @@
 {{ __('If you do not have an account, you may create one by clicking the button below. After creating an account, you may click the invitation acceptance button in this email to accept the team invitation:') }}
 
 @component('mail::button', ['url' => route('register')])
-Create Account
+{{ __('Create Account') }}
 @endcomponent
 
 {{ __('If you already have an account, you may accept this invitation by clicking the button below:') }}
 
 @component('mail::button', ['url' => $acceptUrl])
-Accept Invitation
+{{ __('Accept Invitation') }}
 @endcomponent
 
 {{ __('If you did not expect to receive an invitation to this team, you may discard this email.') }}


### PR DESCRIPTION
Made the text on the buttons in the team invitation email translatable.