### PR TITLE
[2.x] Add --composer option to the install command

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -16,7 +16,8 @@ class InstallCommand extends Command
      * @var string
      */
     protected $signature = 'jetstream:install {stack : The development stack that should be installed}
-                                              {--teams : Indicates if team support should be installed}';
+                                              {--teams : Indicates if team support should be installed}
+                                              {--local-composer : Indicates that the local composer.phar should be use instead of the gobal composer}';
 
     /**
      * The console command description.
@@ -515,8 +516,12 @@ EOF;
      */
     protected function requireComposerPackages($packages)
     {
+        if ($this->option('local-composer')) {
+            $command = ['php', 'composer.phar', 'require'];
+        }
+
         $command = array_merge(
-            ['composer', 'require'],
+            $command ?? ['composer', 'require'],
             is_array($packages) ? $packages : func_get_args()
         );
 

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -17,7 +17,7 @@ class InstallCommand extends Command
      */
     protected $signature = 'jetstream:install {stack : The development stack that should be installed}
                                               {--teams : Indicates if team support should be installed}
-                                              {--local-composer : Indicates that the local composer.phar binary should be used to require packages instead of the global composer binary}';
+                                              {--composer=global : Absolute path to the composer binary which should be used to require packages}';
 
     /**
      * The console command description.
@@ -516,8 +516,9 @@ EOF;
      */
     protected function requireComposerPackages($packages)
     {
-        if ($this->option('local-composer')) {
-            $command = ['php', 'composer.phar', 'require'];
+        $composer = $this->option('composer');
+        if ($composer !== 'global') {
+            $command = ['php', $composer, 'require'];
         }
 
         $command = array_merge(

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -17,7 +17,7 @@ class InstallCommand extends Command
      */
     protected $signature = 'jetstream:install {stack : The development stack that should be installed}
                                               {--teams : Indicates if team support should be installed}
-                                              {--local-composer : Indicates that the local composer.phar should be use instead of the gobal composer}';
+                                              {--local-composer : Indicates that the local composer.phar binary should be used to require packages instead of the global composer binary}';
 
     /**
      * The console command description.


### PR DESCRIPTION
Adds the optional `--composer` option to the install command. This option may receive a path pointing to a specific composer binary. As proposed in PR #588.

```
php artisan jetstream:install livewire --composer=composer.phar

php artisan jetstream:install livewire --teams --composer=composer.phar
```

This is useful for systems where no global composer binary is installed.