### PR TITLE
Fix RegistrationTest, account for case with terms feature on

### DIFF
--- a/stubs/tests/RegistrationTest.php
+++ b/stubs/tests/RegistrationTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Providers\RouteServiceProvider;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Jetstream\Jetstream;
 use Tests\TestCase;
 
 class RegistrationTest extends TestCase
@@ -24,6 +25,7 @@ class RegistrationTest extends TestCase
             'email' => 'test@example.com',
             'password' => 'password',
             'password_confirmation' => 'password',
+            'terms' => Jetstream::hasTermsAndPrivacyPolicyFeature() ? 'on' : null,
         ]);
 
         $this->assertAuthenticated();


### PR DESCRIPTION
If you turn on the `Features::termsAndPrivacyPolicy()` feature in Jetstream, the `RegistrationTest` doesn't account for this case and will fail. Fixed by passing through the `terms` field if the feature is on.
