### PR TITLE
[2.x] Update UPGRADE.md to include new InviteTeamMember action

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -81,6 +81,18 @@ class CreateTeamInvitationsTable extends Migration
 }
 ```
 
+#### Invite Team Member Action
+
+You should place the new [InviteTeamMember](https://github.com/laravel/jetstream/blob/2.x/stubs/app/Actions/Jetstream/InviteTeamMember.php) action within your application's `app/Actions/Jetstream` directory.
+
+In addition, you should register this action with Jetstream by adding the following code to the `boot` method of your application's `JetstreamServiceProvider`:
+
+```php
+use App\Actions\Jetstream\InviteTeamMember;
+
+Jetstream::inviteTeamMembersUsing(InviteTeamMember::class);
+```
+
 ### Livewire Stack
 
 #### Navigation Menu


### PR DESCRIPTION
Adds a section to the upgrade docs detailing how to add the new InviteTeamMember action.

The migration and model were already included but the details of adding the action was missing.
