### PR TITLE
[2.x] Change current team of user when creating a new additional team

### DIFF
--- a/stubs/app/Actions/Jetstream/CreateTeam.php
+++ b/stubs/app/Actions/Jetstream/CreateTeam.php
@@ -32,9 +32,7 @@ class CreateTeam implements CreatesTeams
             'personal_team' => false,
         ]);
 
-        $user->forceFill([
-            'current_team_id' => $team->id,
-        ])->save();
+        $user->switchTeam($team);
 
         return $team;
     }

--- a/stubs/app/Actions/Jetstream/CreateTeam.php
+++ b/stubs/app/Actions/Jetstream/CreateTeam.php
@@ -33,7 +33,7 @@ class CreateTeam implements CreatesTeams
         ]);
 
         $user->forceFill([
-            'current_team_id' => $team->id
+            'current_team_id' => $team->id,
         ])->save();
 
         return $team;

--- a/stubs/app/Actions/Jetstream/CreateTeam.php
+++ b/stubs/app/Actions/Jetstream/CreateTeam.php
@@ -32,10 +32,9 @@ class CreateTeam implements CreatesTeams
             'personal_team' => false,
         ]);
 
-        $user->forceFill({
+        $user->forceFill([
             'current_team_id' => $team->id
-        })->save();
-        $user->save();
+        ])->save();
 
         return $team;
     }

--- a/stubs/app/Actions/Jetstream/CreateTeam.php
+++ b/stubs/app/Actions/Jetstream/CreateTeam.php
@@ -27,9 +27,14 @@ class CreateTeam implements CreatesTeams
 
         AddingTeam::dispatch($user);
 
-        return $user->ownedTeams()->create([
+        $team = $user->ownedTeams()->create([
             'name' => $input['name'],
             'personal_team' => false,
         ]);
+
+        $user->current_team_id = $team->id;
+        $user->save();
+
+        return $team;
     }
 }

--- a/stubs/app/Actions/Jetstream/CreateTeam.php
+++ b/stubs/app/Actions/Jetstream/CreateTeam.php
@@ -32,7 +32,9 @@ class CreateTeam implements CreatesTeams
             'personal_team' => false,
         ]);
 
-        $user->current_team_id = $team->id;
+        $user->forceFill({
+            'current_team_id' => $team->id
+        })->save();
         $user->save();
 
         return $team;

--- a/tests/TeamBehaviorTest.php
+++ b/tests/TeamBehaviorTest.php
@@ -147,8 +147,6 @@ class TeamBehaviorTest extends OrchestraTestCase
 
         $anotherTeam = $action->create($user, ['name' => 'Test Team']);
 
-        $this->assertTrue($user->isCurrentTeam($personalTeam));
-
         $user->switchTeam($anotherTeam);
 
         $this->assertTrue($user->isCurrentTeam($anotherTeam));

--- a/tests/TeamBehaviorTest.php
+++ b/tests/TeamBehaviorTest.php
@@ -144,7 +144,7 @@ class TeamBehaviorTest extends OrchestraTestCase
         $personalTeam = $action->create($user, ['name' => 'Personal Team']);
 
         $personalTeam->forceFill(['personal_team' => true])->save();
-        
+
         $this->assertTrue($user->isCurrentTeam($personalTeam));
 
         $anotherTeam = $action->create($user, ['name' => 'Test Team']);

--- a/tests/TeamBehaviorTest.php
+++ b/tests/TeamBehaviorTest.php
@@ -144,10 +144,10 @@ class TeamBehaviorTest extends OrchestraTestCase
         $personalTeam = $action->create($user, ['name' => 'Personal Team']);
 
         $personalTeam->forceFill(['personal_team' => true])->save();
+        
+        $this->assertTrue($user->isCurrentTeam($personalTeam));
 
         $anotherTeam = $action->create($user, ['name' => 'Test Team']);
-
-        $user->switchTeam($anotherTeam);
 
         $this->assertTrue($user->isCurrentTeam($anotherTeam));
     }


### PR DESCRIPTION
Current behaviour is when a new team is created you are redirected back to the dashboard of the team that you were in before creating the new. In almost all cases a users next action would be directed against the new team.

This PR solves that problem by modifying the CreateTeam class and updating the current_team_id param on the user model of the user creating the team. This way when the user is redirected back they are acting in the context of the newly created team. 