### PR TITLE
Add team to verify email test

### DIFF
--- a/stubs/tests/EmailVerificationTest.php
+++ b/stubs/tests/EmailVerificationTest.php
@@ -21,7 +21,7 @@ class EmailVerificationTest extends TestCase
             return $this->markTestSkipped('Email verification not enabled.');
         }
 
-        $user = User::factory()->create([
+        $user = User::factory()->withPersonalTeam()->create([
             'email_verified_at' => null,
         ]);
 


### PR DESCRIPTION
The email verification test is missing the personal team:
```
Tests\Feature\Auth\EmailVerificationTest::test_email_verification_screen_can_be_rendered
ErrorException: Trying to get property 'user_id' of non-object
```
```
HasTeams.php:107
```