### PR TITLE
[2.x] Jetstream ignoring sessions from session connection in config

### DIFF
--- a/src/Http/Controllers/Inertia/OtherBrowserSessionsController.php
+++ b/src/Http/Controllers/Inertia/OtherBrowserSessionsController.php
@@ -43,7 +43,7 @@ class OtherBrowserSessionsController extends Controller
             return;
         }
 
-        DB::table(config('session.table', 'sessions'))
+        DB::connection(config('session.connection'))->table(config('session.table', 'sessions'))
             ->where('user_id', $request->user()->getAuthIdentifier())
             ->where('id', '!=', $request->session()->getId())
             ->delete();

--- a/src/Http/Controllers/Inertia/UserProfileController.php
+++ b/src/Http/Controllers/Inertia/UserProfileController.php
@@ -37,7 +37,7 @@ class UserProfileController extends Controller
         }
 
         return collect(
-            DB::table(config('session.table', 'sessions'))
+            DB::connection(config('session.connection'))->table(config('session.table', 'sessions'))
                     ->where('user_id', $request->user()->getAuthIdentifier())
                     ->orderBy('last_activity', 'desc')
                     ->get()

--- a/src/Http/Livewire/LogoutOtherBrowserSessionsForm.php
+++ b/src/Http/Livewire/LogoutOtherBrowserSessionsForm.php
@@ -77,7 +77,7 @@ class LogoutOtherBrowserSessionsForm extends Component
             return;
         }
 
-        DB::table(config('session.table', 'sessions'))
+        DB::connection(config('session.connection'))->table(config('session.table', 'sessions'))
             ->where('user_id', Auth::user()->getAuthIdentifier())
             ->where('id', '!=', request()->session()->getId())
             ->delete();
@@ -95,7 +95,7 @@ class LogoutOtherBrowserSessionsForm extends Component
         }
 
         return collect(
-            DB::table(config('session.table', 'sessions'))
+            DB::connection(config('session.connection'))->table(config('session.table', 'sessions'))
                     ->where('user_id', Auth::user()->getAuthIdentifier())
                     ->orderBy('last_activity', 'desc')
                     ->get()


### PR DESCRIPTION
When using sessions in a separate database connection, the sessions table is not found when querying or deleting sessions. This pull request takes the session.connection supplied in the config, so the session management for Jetstream can follow the users configs and/or .env values for session connection.

The changes has been made both for Inertia and Livewire stack. 

Should be no breaking changes as it uses the same way Laravel/framework gets the session connection in the session manager: https://github.com/laravel/framework/blob/28e0f61bba1cbc727383d183b7116eb723de7660/src/Illuminate/Session/SessionManager.php
line: 99