### PR TITLE
[2.x] Use Aliases feature of Laravel Mix

### DIFF
--- a/stubs/inertia/webpack.config.js
+++ b/stubs/inertia/webpack.config.js
@@ -1,9 +1,0 @@
-const path = require('path');
-
-module.exports = {
-    resolve: {
-        alias: {
-            '@': path.resolve('resources/js'),
-        },
-    },
-};

--- a/stubs/inertia/webpack.mix.js
+++ b/stubs/inertia/webpack.mix.js
@@ -1,4 +1,5 @@
 const mix = require('laravel-mix');
+const path = require('path');
 
 /*
  |--------------------------------------------------------------------------
@@ -17,7 +18,9 @@ mix.js('resources/js/app.js', 'public/js').vue()
         require('tailwindcss'),
         require('autoprefixer'),
     ])
-    .webpackConfig(require('./webpack.config'));
+    .alias({
+        '@': path.resolve('resources/js'),
+    });
 
 if (mix.inProduction()) {
     mix.version();


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

If you change the behavior of the Inertia stack you're expected to update the Livewire stack as well and vica versa.
-->

Laravel Mix 6.0 comes with [Webpack Aliases](https://laravel-mix.com/docs/6.0/aliases
) right baked in, thus removing the need for a separate `webpack.config.js` and one less config file to worry about.