### PR TITLE
Remove extra comma in str_replace method call

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -497,7 +497,7 @@ EOF;
             $modifiedMiddlewareGroup = str_replace(
                 $after.',',
                 $after.','.PHP_EOL.'            '.$name.',',
-                $middlewareGroup,
+                $middlewareGroup
             );
 
             file_put_contents(app_path('Http/Kernel.php'), str_replace(


### PR DESCRIPTION
Closes #634

This extra ',' caused a fatal error to occur on install.
Removing this resolves that issue.
