### PR TITLE
[2.x] Allow configuration of profile photo disk

### DIFF
--- a/src/HasProfilePhoto.php
+++ b/src/HasProfilePhoto.php
@@ -76,6 +76,6 @@ trait HasProfilePhoto
      */
     protected function profilePhotoDisk()
     {
-        return isset($_ENV['VAPOR_ARTIFACT_NAME']) ? 's3' : 'public';
+        return isset($_ENV['VAPOR_ARTIFACT_NAME']) ? 's3' : config('jetstream.profile_photo_disk', 'public');
     }
 }

--- a/tests/UpdateProfilePhotoTest.php
+++ b/tests/UpdateProfilePhotoTest.php
@@ -21,10 +21,10 @@ class UpdateProfilePhotoTest extends OrchestraTestCase
         $this->migrate();
 
         $user = User::forceCreate([
-                                      'name'     => 'Taylor Otwell',
-                                      'email'    => 'taylor@laravel.com',
-                                      'password' => 'secret',
-                                  ]);
+            'name'     => 'Taylor Otwell',
+            'email'    => 'taylor@laravel.com',
+            'password' => 'secret',
+        ]);
 
         Storage::fake('s3');
         Storage::fake('public');
@@ -42,10 +42,10 @@ class UpdateProfilePhotoTest extends OrchestraTestCase
         $_ENV['VAPOR_ARTIFACT_NAME'] = 'fake-artifact-name';
 
         $user = User::forceCreate([
-                                      'name'     => 'Taylor Otwell',
-                                      'email'    => 'taylor@laravel.com',
-                                      'password' => 'secret',
-                                  ]);
+            'name'     => 'Taylor Otwell',
+            'email'    => 'taylor@laravel.com',
+            'password' => 'secret',
+        ]);
 
         Storage::fake('s3');
         Storage::fake('public');
@@ -63,10 +63,10 @@ class UpdateProfilePhotoTest extends OrchestraTestCase
         config(['jetstream.profile_photo_disk' => 's3']);
 
         $user = User::forceCreate([
-                                      'name'     => 'Taylor Otwell',
-                                      'email'    => 'taylor@laravel.com',
-                                      'password' => 'secret',
-                                  ]);
+            'name'     => 'Taylor Otwell',
+            'email'    => 'taylor@laravel.com',
+            'password' => 'secret',
+        ]);
 
         Storage::fake('s3');
         Storage::fake('public');

--- a/tests/UpdateProfilePhotoTest.php
+++ b/tests/UpdateProfilePhotoTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Laravel\Jetstream\Tests;
+
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Laravel\Jetstream\Jetstream;
+use Laravel\Jetstream\Tests\Fixtures\User;
+
+class UpdateProfilePhotoTest extends OrchestraTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Jetstream::useUserModel(User::class);
+    }
+
+    public function test_profile_photo_uploads_to_public_by_default_non_vapor()
+    {
+        $this->migrate();
+
+        $user = User::forceCreate([
+                                      'name'     => 'Taylor Otwell',
+                                      'email'    => 'taylor@laravel.com',
+                                      'password' => 'secret',
+                                  ]);
+
+        Storage::fake('s3');
+        Storage::fake('public');
+
+        $user->updateProfilePhoto(UploadedFile::fake()->image('photo1.jpg'));
+
+        Storage::disk('s3')->assertMissing($user->profile_photo_path);
+        Storage::disk('public')->assertExists($user->profile_photo_path);
+    }
+
+    public function test_profile_photo_uploads_to_s3_by_default_vapor()
+    {
+        $this->migrate();
+
+        $_ENV['VAPOR_ARTIFACT_NAME'] = 'fake-artifact-name';
+
+        $user = User::forceCreate([
+                                      'name'     => 'Taylor Otwell',
+                                      'email'    => 'taylor@laravel.com',
+                                      'password' => 'secret',
+                                  ]);
+
+        Storage::fake('s3');
+        Storage::fake('public');
+
+        $user->updateProfilePhoto(UploadedFile::fake()->image('photo1.jpg'));
+
+        Storage::disk('s3')->assertExists($user->profile_photo_path);
+        Storage::disk('public')->assertMissing($user->profile_photo_path);
+    }
+
+    public function test_profile_photo_uploads_to_s3_if_specified_non_vapor()
+    {
+        $this->migrate();
+
+        config(['jetstream.profile_photo_disk' => 's3']);
+
+        $user = User::forceCreate([
+                                      'name'     => 'Taylor Otwell',
+                                      'email'    => 'taylor@laravel.com',
+                                      'password' => 'secret',
+                                  ]);
+
+        Storage::fake('s3');
+        Storage::fake('public');
+
+        $user->updateProfilePhoto(UploadedFile::fake()->image('photo1.jpg'));
+
+        Storage::disk('s3')->assertExists($user->profile_photo_path);
+        Storage::disk('public')->assertMissing($user->profile_photo_path);
+    }
+
+    protected function migrate()
+    {
+        $this->artisan('migrate', ['--database' => 'testbench'])->run();
+    }
+}


### PR DESCRIPTION
This change will allow the user to specify on which disk profile photos should be stored via the Jetstream config file.

Currently, the only disk that will be used is `public` (unless you add `VAPOR_ARTIFACT_NAME` to the `.env` file [sort of an override]).

I don't think it's uncommon for all images to be stored on S3 (or some other disk) for apps, so I think this could benefit a number of users.

Please let me know if anything can be improved. I didn't explicitly add the key to the config file so as to not clutter it.

Thanks!