### PR TITLE
[2.x] Fix overriding TeamInvitation model in application

### DIFF
--- a/src/Http/Controllers/TeamInvitationController.php
+++ b/src/Http/Controllers/TeamInvitationController.php
@@ -7,7 +7,7 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Gate;
 use Laravel\Jetstream\Contracts\AddsTeamMembers;
-use Laravel\Jetstream\TeamInvitation;
+use Laravel\Jetstream\Jetstream;
 
 class TeamInvitationController extends Controller
 {
@@ -15,11 +15,13 @@ class TeamInvitationController extends Controller
      * Accept a team invitation.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  \Laravel\Jetstream\TeamInvitation  $invitation
+     * @param  int  $invitation
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function accept(Request $request, TeamInvitation $invitation)
+    public function accept(Request $request, $invitationId)
     {
+        $invitation = Jetstream::newTeamInvitationModel()->findOrFail($invitationId);
+
         app(AddsTeamMembers::class)->add(
             $invitation->team->owner,
             $invitation->team,
@@ -38,11 +40,13 @@ class TeamInvitationController extends Controller
      * Cancel the given team invitation.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  \Laravel\Jetstream\TeamInvitation  $invitation
+     * @param  int  $invitationId
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function destroy(Request $request, TeamInvitation $invitation)
+    public function destroy(Request $request, $invitationId)
     {
+        $invitation = Jetstream::newTeamInvitationModel()->findOrFail($invitationId);
+
         if (! Gate::forUser($request->user())->check('removeTeamMember', $invitation->team)) {
             throw new AuthorizationException;
         }

--- a/src/Jetstream.php
+++ b/src/Jetstream.php
@@ -341,6 +341,18 @@ class Jetstream
     }
 
     /**
+     * Get a new instance of the team invitation model.
+     *
+     * @return mixed
+     */
+    public static function newTeamInvitationModel()
+    {
+        $model = static::teamInvitationModel();
+
+        return new $model;
+    }
+
+    /**
      * Specify the team invitation model that should be used by Jetstream.
      *
      * @param  string  $model

--- a/tests/TeamInvitationControllerTest.php
+++ b/tests/TeamInvitationControllerTest.php
@@ -41,6 +41,24 @@ class TeamInvitationControllerTest extends OrchestraTestCase
         $response->assertRedirect();
     }
 
+    public function test_team_member_invitations_can_be_cancelled()
+    {
+        Jetstream::role('admin', 'Admin', ['foo', 'bar']);
+        Jetstream::role('editor', 'Editor', ['baz', 'qux']);
+
+        $this->migrate();
+
+        $team = $this->createTeam();
+
+        $invitation = $team->teamInvitations()->create(['email' => 'invite@laravel.com', 'role' => 'admin']);
+
+        $url = URL::signedRoute('team-invitations.destroy', ['invitation' => $invitation]);
+
+        $response = $this->actingAs($team->owner)->delete($url);
+
+        $response->assertStatus(303);
+    }
+
     protected function createTeam()
     {
         $action = new CreateTeam;


### PR DESCRIPTION
Hi! If we'll change table name in own TeamInvitation model in Laravel project (child model, based on Laravel\Jetstream\TeamInvitation), we got error while trying to delete and/or accept invitations:

`Base table or view not found: 1146 Table 'team_invitations' doesn't exist.`

This pull allows to use project model instead jetstream model to perform these actions.