### PR TITLE
Skip DeleteAccountTest if feature is not enabled

### DIFF
--- a/stubs/tests/inertia/DeleteAccountTest.php
+++ b/stubs/tests/inertia/DeleteAccountTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Jetstream\Features;
 use Tests\TestCase;
 
 class DeleteAccountTest extends TestCase
@@ -12,6 +13,10 @@ class DeleteAccountTest extends TestCase
 
     public function test_user_accounts_can_be_deleted()
     {
+        if (! Features::hasAccountDeletionFeatures()) {
+            return $this->markTestSkipped('accountDeletion is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->create());
 
         $response = $this->delete('/user', [
@@ -23,6 +28,10 @@ class DeleteAccountTest extends TestCase
 
     public function test_correct_password_must_be_provided_before_account_can_be_deleted()
     {
+        if (! Features::hasAccountDeletionFeatures()) {
+            return $this->markTestSkipped('accountDeletion is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->create());
 
         $response = $this->delete('/user', [

--- a/stubs/tests/inertia/DeleteAccountTest.php
+++ b/stubs/tests/inertia/DeleteAccountTest.php
@@ -14,7 +14,7 @@ class DeleteAccountTest extends TestCase
     public function test_user_accounts_can_be_deleted()
     {
         if (! Features::hasAccountDeletionFeatures()) {
-            return $this->markTestSkipped('accountDeletion is not enabled.');
+            return $this->markTestSkipped('Account deletion is not enabled.');
         }
 
         $this->actingAs($user = User::factory()->create());
@@ -29,7 +29,7 @@ class DeleteAccountTest extends TestCase
     public function test_correct_password_must_be_provided_before_account_can_be_deleted()
     {
         if (! Features::hasAccountDeletionFeatures()) {
-            return $this->markTestSkipped('accountDeletion is not enabled.');
+            return $this->markTestSkipped('Account deletion is not enabled.');
         }
 
         $this->actingAs($user = User::factory()->create());

--- a/stubs/tests/livewire/DeleteAccountTest.php
+++ b/stubs/tests/livewire/DeleteAccountTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Http\Livewire\DeleteUserForm;
 use Livewire\Livewire;
 use Tests\TestCase;
@@ -14,6 +15,10 @@ class DeleteAccountTest extends TestCase
 
     public function test_user_accounts_can_be_deleted()
     {
+        if (! Features::hasAccountDeletionFeatures()) {
+            return $this->markTestSkipped('accountDeletion is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->create());
 
         $component = Livewire::test(DeleteUserForm::class)
@@ -25,6 +30,10 @@ class DeleteAccountTest extends TestCase
 
     public function test_correct_password_must_be_provided_before_account_can_be_deleted()
     {
+        if (! Features::hasAccountDeletionFeatures()) {
+            return $this->markTestSkipped('accountDeletion is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->create());
 
         Livewire::test(DeleteUserForm::class)

--- a/stubs/tests/livewire/DeleteAccountTest.php
+++ b/stubs/tests/livewire/DeleteAccountTest.php
@@ -16,7 +16,7 @@ class DeleteAccountTest extends TestCase
     public function test_user_accounts_can_be_deleted()
     {
         if (! Features::hasAccountDeletionFeatures()) {
-            return $this->markTestSkipped('accountDeletion is not enabled.');
+            return $this->markTestSkipped('Account deletion is not enabled.');
         }
 
         $this->actingAs($user = User::factory()->create());
@@ -31,7 +31,7 @@ class DeleteAccountTest extends TestCase
     public function test_correct_password_must_be_provided_before_account_can_be_deleted()
     {
         if (! Features::hasAccountDeletionFeatures()) {
-            return $this->markTestSkipped('accountDeletion is not enabled.');
+            return $this->markTestSkipped('Account deletion is not enabled.');
         }
 
         $this->actingAs($user = User::factory()->create());


### PR DESCRIPTION
The tests for `DeleteAccountTest` are always executed. Therefore tests fail when Account Deletion Features are disabled.

With this PR DeleteAccountTests are skipped when the feature is deactivated. 

<img width="472" alt="Screenshot 2021-01-18 at 16 39 07" src="https://user-images.githubusercontent.com/7462542/104935868-12d30b80-59ac-11eb-9d02-7ead6a224758.png">

