### PR TITLE
[2.x] Validation message for existing invitation

### DIFF
--- a/stubs/app/Actions/Jetstream/InviteTeamMember.php
+++ b/stubs/app/Actions/Jetstream/InviteTeamMember.php
@@ -52,7 +52,7 @@ class InviteTeamMember implements InvitesTeamMembers
             'email' => $email,
             'role' => $role,
         ], $this->rules(), [
-            'email.unique' => __('This user has already been invited to the team.'),
+            'email.unique' => __('This user has already has a pending invitation.'),
         ])->after(
             $this->ensureUserIsNotAlreadyOnTeam($team, $email)
         )->validateWithBag('addTeamMember');


### PR DESCRIPTION
When an email has already been invited but the same email address also gets invited to another team, but not yet accepted the past invitation, the error message implies that the email is already added to the current team. So the error message could be a bit confusing for the end-user. So I think it's better to inform the email address already has a pending invitation to avoid confusion.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

If you change the behavior of the Inertia stack you're expected to update the Livewire stack as well and vica versa.
-->
