### PR TITLE
Enabling Github Flavored Markdown for Terms and Privacy Policy

### DIFF
--- a/src/Http/Controllers/Inertia/PrivacyPolicyController.php
+++ b/src/Http/Controllers/Inertia/PrivacyPolicyController.php
@@ -7,6 +7,8 @@ use Illuminate\Routing\Controller;
 use Inertia\Inertia;
 use Laravel\Jetstream\Jetstream;
 use League\CommonMark\CommonMarkConverter;
+use League\CommonMark\Environment;
+use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
 
 class PrivacyPolicyController extends Controller
 {
@@ -20,8 +22,11 @@ class PrivacyPolicyController extends Controller
     {
         $policyFile = Jetstream::localizedMarkdownPath('policy.md');
 
+        $environment = Environment::createCommonMarkEnvironment();
+        $environment->addExtension(new GithubFlavoredMarkdownExtension());
+
         return Inertia::render('PrivacyPolicy', [
-            'policy' => (new CommonMarkConverter())->convertToHtml(file_get_contents($policyFile)),
+            'policy' => (new CommonMarkConverter([], $environment))->convertToHtml(file_get_contents($policyFile)),
         ]);
     }
 }

--- a/src/Http/Controllers/Inertia/TermsOfServiceController.php
+++ b/src/Http/Controllers/Inertia/TermsOfServiceController.php
@@ -7,6 +7,8 @@ use Illuminate\Routing\Controller;
 use Inertia\Inertia;
 use Laravel\Jetstream\Jetstream;
 use League\CommonMark\CommonMarkConverter;
+use League\CommonMark\Environment;
+use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
 
 class TermsOfServiceController extends Controller
 {
@@ -20,8 +22,11 @@ class TermsOfServiceController extends Controller
     {
         $termsFile = Jetstream::localizedMarkdownPath('terms.md');
 
+        $environment = Environment::createCommonMarkEnvironment();
+        $environment->addExtension(new GithubFlavoredMarkdownExtension());
+
         return Inertia::render('TermsOfService', [
-            'terms' => (new CommonMarkConverter())->convertToHtml(file_get_contents($termsFile)),
+            'terms' => (new CommonMarkConverter([], $environment))->convertToHtml(file_get_contents($termsFile)),
         ]);
     }
 }

--- a/src/Http/Controllers/Livewire/PrivacyPolicyController.php
+++ b/src/Http/Controllers/Livewire/PrivacyPolicyController.php
@@ -6,6 +6,8 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Laravel\Jetstream\Jetstream;
 use League\CommonMark\CommonMarkConverter;
+use League\CommonMark\Environment;
+use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
 
 class PrivacyPolicyController extends Controller
 {
@@ -19,8 +21,11 @@ class PrivacyPolicyController extends Controller
     {
         $policyFile = Jetstream::localizedMarkdownPath('policy.md');
 
+        $environment = Environment::createCommonMarkEnvironment();
+        $environment->addExtension(new GithubFlavoredMarkdownExtension());
+
         return view('policy', [
-            'policy' => (new CommonMarkConverter())->convertToHtml(file_get_contents($policyFile)),
+            'policy' => (new CommonMarkConverter([], $environment))->convertToHtml(file_get_contents($policyFile)),
         ]);
     }
 }

--- a/src/Http/Controllers/Livewire/TermsOfServiceController.php
+++ b/src/Http/Controllers/Livewire/TermsOfServiceController.php
@@ -6,6 +6,8 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Laravel\Jetstream\Jetstream;
 use League\CommonMark\CommonMarkConverter;
+use League\CommonMark\Environment;
+use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
 
 class TermsOfServiceController extends Controller
 {
@@ -19,8 +21,11 @@ class TermsOfServiceController extends Controller
     {
         $termsFile = Jetstream::localizedMarkdownPath('terms.md');
 
+        $environment = Environment::createCommonMarkEnvironment();
+        $environment->addExtension(new GithubFlavoredMarkdownExtension());
+
         return view('terms', [
-            'terms' => (new CommonMarkConverter())->convertToHtml(file_get_contents($termsFile)),
+            'terms' => (new CommonMarkConverter([], $environment))->convertToHtml(file_get_contents($termsFile)),
         ]);
     }
 }


### PR DESCRIPTION
This enables the GithubFlavoredMarkdownExtention for CommonMark. GFM is included in CommonMark and only has to be enabled to allow a list of markdown features:
- Autolinks
- Disallowed Raw HTML
- Strikethrough
- Tables
- Task Lists

**Reasoning for enabling this by default**
I feel like especially the Tables functionality is something that can benefit many users attempting to set up terms through Jetstream. These documents often include tables, and enabling this extension allows for printing them on the terms pages.  

