### PR TITLE
[2.x] Hide AppLayout header if no slot defined in Page component

### DIFF
--- a/stubs/inertia/resources/js/Layouts/AppLayout.vue
+++ b/stubs/inertia/resources/js/Layouts/AppLayout.vue
@@ -215,7 +215,7 @@
             </nav>
 
             <!-- Page Heading -->
-            <header class="bg-white shadow">
+            <header class="bg-white shadow" v-if="$slots.header">
                 <div class="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
                     <slot name="header"></slot>
                 </div>


### PR DESCRIPTION
On Jetstream Inertia when creating a Page component with no #header slot, the AppLayout display an empty unnecessary header instead of no header.

Before:
![Opera Snapshot_2021-01-24_133749_next-ci localhost](https://user-images.githubusercontent.com/2951704/105630427-6d0b1b00-5e49-11eb-9e9f-cf924309476e.png)

After:
![Opera Snapshot_2021-01-24_133921_next-ci localhost](https://user-images.githubusercontent.com/2951704/105630446-962bab80-5e49-11eb-8d8a-2a596dc44825.png)


