### PR TITLE
[2.x] Check for registration feature in test stub

### DIFF
--- a/stubs/tests/RegistrationTest.php
+++ b/stubs/tests/RegistrationTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Providers\RouteServiceProvider;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Fortify\Features;
 use Laravel\Jetstream\Jetstream;
 use Tests\TestCase;
 
@@ -13,6 +14,10 @@ class RegistrationTest extends TestCase
 
     public function test_registration_screen_can_be_rendered()
     {
+        if (! Features::enabled(Features::registration())) {
+            return $this->markTestSkipped('Account registration is not enabled.');
+        }
+
         $response = $this->get('/register');
 
         $response->assertStatus(200);
@@ -20,6 +25,10 @@ class RegistrationTest extends TestCase
 
     public function test_new_users_can_register()
     {
+        if (! Features::enabled(Features::registration())) {
+            return $this->markTestSkipped('Account registration is not enabled.');
+        }
+        
         $response = $this->post('/register', [
             'name' => 'Test User',
             'email' => 'test@example.com',

--- a/stubs/tests/RegistrationTest.php
+++ b/stubs/tests/RegistrationTest.php
@@ -28,7 +28,7 @@ class RegistrationTest extends TestCase
         if (! Features::enabled(Features::registration())) {
             return $this->markTestSkipped('Account registration is not enabled.');
         }
-        
+
         $response = $this->post('/register', [
             'name' => 'Test User',
             'email' => 'test@example.com',


### PR DESCRIPTION
Would you consider changes like this where the feature tests check that the relevant Fortify feature is enabled? 

This change would stop published tests from failing when users disable some of the features in Fortify.

To clean up the above code I could create a helper function called "hasAccountRegistrationFeatures" in the Fortify to follow the convention I've seen in the Jetstream repo

