### PR TITLE
Remove laravel-jestream package when upgrading

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -139,3 +139,23 @@ Fortify::confirmPasswordView(function () {
     return view('auth/confirm-password');
 });
 ```
+
+### Remove [laravel-jetstream](https://www.npmjs.com/package/laravel-jetstream) javascript package
+
+As of the Jetstream 2.0 release, this library is no longer necessary as all of its features have been incorporated into Inertia itself. 
+
+Remove the following from your `resources/js/app.js`:
+
+```
+import {InertiaForm} from 'laravel-jetstream';
+
+Vue.use(InertiaForm);
+
+````
+
+Remove the package from your `package.json`:
+
+
+`npm uninstall laravel-jetstream`
+or
+`yarn remove laravel-jetstream`

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -140,11 +140,9 @@ Fortify::confirmPasswordView(function () {
 });
 ```
 
-### Remove [laravel-jetstream](https://www.npmjs.com/package/laravel-jetstream) javascript package
+#### Remove [laravel-jetstream](https://www.npmjs.com/package/laravel-jetstream) NPM Package
 
-As of the Jetstream 2.0 release, this library is no longer necessary as all of its features have been incorporated into Inertia itself. 
-
-Remove the following from your `resources/js/app.js`:
+As of the Jetstream 2.0 release, this library is no longer necessary as all of its features have been incorporated into Inertia itself. You should remove the following from your `resources/js/app.js` file:
 
 ```
 import {InertiaForm} from 'laravel-jetstream';
@@ -153,9 +151,6 @@ Vue.use(InertiaForm);
 
 ````
 
-Remove the package from your `package.json`:
-
+Finally, you may remove the package:
 
 `npm uninstall laravel-jetstream`
-or
-`yarn remove laravel-jetstream`


### PR DESCRIPTION
When the package is left installed, it causes the following error to be thrown:

```
Uncaught (in promise) TypeError: this.inertiaPage().errorBags is undefined
```

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

If you change the behavior of the Inertia stack you're expected to update the Livewire stack as well and vica versa.
-->
