### PR TITLE
[2.x] Add profile_photo_disk config option

### DIFF
--- a/config/jetstream.php
+++ b/config/jetstream.php
@@ -49,17 +49,4 @@ return [
         Features::accountDeletion(),
     ],
 
-    /*
-    |--------------------------------------------------------------------------
-    | Profile Photo Disk
-    |--------------------------------------------------------------------------
-    |
-    | Here you may specify the default filesystem disk that should be used by
-    | Jetstream to store the profile photos.
-    | By default, the s3 disk will be used to store profile photos when your
-    | application is running within Laravel Vapor.
-    |
-    */
-
-    'profile_photo_disk' => 'public',
 ];

--- a/config/jetstream.php
+++ b/config/jetstream.php
@@ -49,4 +49,17 @@ return [
         Features::accountDeletion(),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Profile Photo Disk
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify the default filesystem disk that should be used by
+    | Jetstream to store the profile photos.
+    | By default, the s3 disk will be used to store profile photos when your
+    | application is running within Laravel Vapor.
+    |
+    */
+
+    'profile_photo_disk' => 'public',
 ];

--- a/src/HasProfilePhoto.php
+++ b/src/HasProfilePhoto.php
@@ -76,6 +76,6 @@ trait HasProfilePhoto
      */
     protected function profilePhotoDisk()
     {
-        return isset($_ENV['VAPOR_ARTIFACT_NAME']) ? 's3' : 'public';
+        return isset($_ENV['VAPOR_ARTIFACT_NAME']) ? 's3' : config('jetstream.profile_photo_disk');
     }
 }

--- a/src/HasProfilePhoto.php
+++ b/src/HasProfilePhoto.php
@@ -76,6 +76,6 @@ trait HasProfilePhoto
      */
     protected function profilePhotoDisk()
     {
-        return isset($_ENV['VAPOR_ARTIFACT_NAME']) ? 's3' : config('jetstream.profile_photo_disk');
+        return isset($_ENV['VAPOR_ARTIFACT_NAME']) ? 's3' : config('jetstream.profile_photo_disk', 'public');
     }
 }


### PR DESCRIPTION
Jetstream always uses `public` filesystem to store the profile photos if it's not running within Laravel Vapor.

In my case, I use Google Cloud Storage, so there is no way to tell Jetstream about that.

I know that I can modify the `filesystems.disks.public.driver` to point to GCS, but it'll break the dev. environment.

Therefore we should have the profile disk as a config, so we can change it to the appropriate value.
