### PR TITLE
Skip RegistrationTest if registration features not enabled

### DIFF
--- a/stubs/tests/RegistrationTest.php
+++ b/stubs/tests/RegistrationTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Providers\RouteServiceProvider;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Fortify\Features;
 use Laravel\Jetstream\Jetstream;
 use Tests\TestCase;
 
@@ -13,6 +14,10 @@ class RegistrationTest extends TestCase
 
     public function test_registration_screen_can_be_rendered()
     {
+        if (! Features::hasRegistrationFeatures() || ! config('fortify.views', true)) {
+            return $this->markTestSkipped('User registration support is not enabled.');
+        }
+
         $response = $this->get('/register');
 
         $response->assertStatus(200);
@@ -20,6 +25,10 @@ class RegistrationTest extends TestCase
 
     public function test_new_users_can_register()
     {
+        if (! Features::hasRegistrationFeatures()) {
+            return $this->markTestSkipped('User registration support is not enabled.');
+        }
+
         $response = $this->post('/register', [
             'name' => 'Test User',
             'email' => 'test@example.com',


### PR DESCRIPTION
Currently the RegistrationTests are still run when the feature is not enabled. This change adds check to skip those tests.
Requires [this pull ](https://github.com/laravel/fortify/pull/214) into Fortify