### PR TITLE
[2.x] add "prop" helper in inertia, so "$page.props.user.roles" can be "prop('user.roles')"

### DIFF
--- a/stubs/inertia/resources/js/app.js
+++ b/stubs/inertia/resources/js/app.js
@@ -5,13 +5,19 @@ import Vue from 'vue';
 import { App as InertiaApp, plugin as InertiaPlugin } from '@inertiajs/inertia-vue';
 import PortalVue from 'portal-vue';
 
-Vue.mixin({ methods: { route } });
+window.prop = (keys, defaultProp = null) => {
+    const prop = keys.split('.').reduce((object, key) => (object || {})[key], vueApp.$page.props);
+
+    return prop ?? defaultProp ?? null;
+};
+
+Vue.mixin({ methods: { route, prop } });
 Vue.use(InertiaPlugin);
 Vue.use(PortalVue);
 
 const app = document.getElementById('app');
 
-new Vue({
+window.vueApp = new Vue({
     render: (h) =>
         h(InertiaApp, {
             props: {


### PR DESCRIPTION
Instead of `$page.props...` this pull request adds a little helper `prop()` to get any props with behavior similar to `config()` in Laravel.

This helper also support dot notation: 
```
prop('user.roles')
```
and default value:
```
prop('user', 'guest')
```
Reasons: 
1. It's a cleaner way to access props.
2. avoid `Cannot read property "..." of undefined` errors when using `$page.props...`

Notes: 
1. In my projects I put it in helpers.js file, but here I put it in app.js until we find a better place.
2. I initialize a variable for vue app to use it in the helper.