### PR TITLE
[2.x] Fix create user for api

### DIFF
--- a/stubs/tests/livewire/ApiTokenPermissionsTest.php
+++ b/stubs/tests/livewire/ApiTokenPermissionsTest.php
@@ -19,8 +19,10 @@ class ApiTokenPermissionsTest extends TestCase
         if (! Features::hasApiFeatures()) {
             return $this->markTestSkipped('API support is not enabled.');
         }
-
-        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+        $user = Features::hasTeamFeatures()
+                                        ? User::factory()->withPersonalTeam()->create()
+                                        : User::factory()->create();
+        $this->actingAs($user);
 
         $token = $user->tokens()->create([
             'name' => 'Test Token',

--- a/stubs/tests/livewire/CreateApiTokenTest.php
+++ b/stubs/tests/livewire/CreateApiTokenTest.php
@@ -19,7 +19,10 @@ class CreateApiTokenTest extends TestCase
             return $this->markTestSkipped('API support is not enabled.');
         }
 
-        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+        $user = Features::hasTeamFeatures()
+                                        ? User::factory()->withPersonalTeam()->create()
+                                        : User::factory()->create();
+        $this->actingAs($user);
 
         Livewire::test(ApiTokenManager::class)
                     ->set(['createApiTokenForm' => [

--- a/stubs/tests/livewire/DeleteApiTokenTest.php
+++ b/stubs/tests/livewire/DeleteApiTokenTest.php
@@ -20,7 +20,10 @@ class DeleteApiTokenTest extends TestCase
             return $this->markTestSkipped('API support is not enabled.');
         }
 
-        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+        $user = Features::hasTeamFeatures()
+                                        ? User::factory()->withPersonalTeam()->create()
+                                        : User::factory()->create();
+        $this->actingAs($user);
 
         $token = $user->tokens()->create([
             'name' => 'Test Token',


### PR DESCRIPTION
I noticed that when I run tests. With the option team deactivates its generates an exception when creating the user.

        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
