### PR TITLE
[2.x] Fix permissions for team create routes

### DIFF
--- a/src/Http/Controllers/Inertia/TeamController.php
+++ b/src/Http/Controllers/Inertia/TeamController.php
@@ -28,9 +28,7 @@ class TeamController extends Controller
     {
         $team = Jetstream::newTeamModel()->findOrFail($teamId);
 
-        if (Gate::denies('view', $team)) {
-            abort(403);
-        }
+        Gate::authorize('view', $team);
 
         return Jetstream::inertia()->render($request, 'Teams/Show', [
             'team' => $team->load('owner', 'users', 'teamInvitations'),

--- a/src/Http/Controllers/Inertia/TeamController.php
+++ b/src/Http/Controllers/Inertia/TeamController.php
@@ -52,9 +52,7 @@ class TeamController extends Controller
      */
     public function create(Request $request)
     {
-        if (Gate::denies('create', Jetstream::newTeamModel())) {
-            abort(403);
-        }
+        Gate::authorize('create', Jetstream::newTeamModel());
 
         return Inertia::render('Teams/Create');
     }

--- a/src/Http/Controllers/Inertia/TeamController.php
+++ b/src/Http/Controllers/Inertia/TeamController.php
@@ -54,6 +54,10 @@ class TeamController extends Controller
      */
     public function create(Request $request)
     {
+        if (Gate::denies('create', Jetstream::newTeamModel())) {
+            abort(403);
+        }
+
         return Inertia::render('Teams/Create');
     }
 

--- a/src/Http/Controllers/Livewire/TeamController.php
+++ b/src/Http/Controllers/Livewire/TeamController.php
@@ -38,9 +38,7 @@ class TeamController extends Controller
      */
     public function create(Request $request)
     {
-        if (Gate::denies('create', Jetstream::newTeamModel())) {
-            abort(403);
-        }
+        Gate::authorize('create', Jetstream::newTeamModel());
 
         return view('teams.create', [
             'user' => $request->user(),

--- a/src/Http/Controllers/Livewire/TeamController.php
+++ b/src/Http/Controllers/Livewire/TeamController.php
@@ -38,6 +38,10 @@ class TeamController extends Controller
      */
     public function create(Request $request)
     {
+        if (Gate::denies('create', Jetstream::newTeamModel())) {
+            abort(403);
+        }
+
         return view('teams.create', [
             'user' => $request->user(),
         ]);


### PR DESCRIPTION
These routes are still accessible atm even if their policy returns false.

Fixes https://github.com/laravel/jetstream/issues/665