### PR TITLE
Code of Conduct Policy Acceptance

### DIFF
--- a/routes/inertia.php
+++ b/routes/inertia.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Route;
 use Laravel\Jetstream\Http\Controllers\CurrentTeamController;
 use Laravel\Jetstream\Http\Controllers\Inertia\ApiTokenController;
+use Laravel\Jetstream\Http\Controllers\Inertia\CodeOfConductController;
 use Laravel\Jetstream\Http\Controllers\Inertia\CurrentUserController;
 use Laravel\Jetstream\Http\Controllers\Inertia\OtherBrowserSessionsController;
 use Laravel\Jetstream\Http\Controllers\Inertia\PrivacyPolicyController;
@@ -16,6 +17,7 @@ use Laravel\Jetstream\Jetstream;
 
 Route::group(['middleware' => config('jetstream.middleware', ['web'])], function () {
     if (Jetstream::hasTermsAndPrivacyPolicyFeature()) {
+        Route::get('/conduct-policy', [CodeOfConductController::class, 'show'])->name('conduct.show');
         Route::get('/terms-of-service', [TermsOfServiceController::class, 'show'])->name('terms.show');
         Route::get('/privacy-policy', [PrivacyPolicyController::class, 'show'])->name('policy.show');
     }

--- a/routes/livewire.php
+++ b/routes/livewire.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Route;
 use Laravel\Jetstream\Http\Controllers\CurrentTeamController;
 use Laravel\Jetstream\Http\Controllers\Livewire\ApiTokenController;
+use Laravel\Jetstream\Http\Controllers\Livewire\CodeOfConductController;
 use Laravel\Jetstream\Http\Controllers\Livewire\PrivacyPolicyController;
 use Laravel\Jetstream\Http\Controllers\Livewire\TeamController;
 use Laravel\Jetstream\Http\Controllers\Livewire\TermsOfServiceController;
@@ -12,6 +13,7 @@ use Laravel\Jetstream\Jetstream;
 
 Route::group(['middleware' => config('jetstream.middleware', ['web'])], function () {
     if (Jetstream::hasTermsAndPrivacyPolicyFeature()) {
+        Route::get('/conduct-policy', [CodeOfConductController::class, 'show'])->name('conduct.show');
         Route::get('/terms-of-service', [TermsOfServiceController::class, 'show'])->name('terms.show');
         Route::get('/privacy-policy', [PrivacyPolicyController::class, 'show'])->name('policy.show');
     }

--- a/src/Http/Controllers/Inertia/CodeOfConductController.php
+++ b/src/Http/Controllers/Inertia/CodeOfConductController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Laravel\Jetstream\Http\Controllers\Inertia;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Inertia\Inertia;
+use Laravel\Jetstream\Jetstream;
+use League\CommonMark\CommonMarkConverter;
+use League\CommonMark\Environment;
+use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
+
+class CodeOfConductController extends Controller
+{
+    /**
+     * Show the conduct policy for the application.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Inertia\Response
+     */
+    public function show(Request $request)
+    {
+        $conductFile = Jetstream::localizedMarkdownPath('conduct.md');
+
+        $environment = Environment::createCommonMarkEnvironment();
+        $environment->addExtension(new GithubFlavoredMarkdownExtension());
+
+        return Inertia::render('ConductPolicy', [
+            'conduct' => (new CommonMarkConverter([], $environment))->convertToHtml(file_get_contents($conductFile)),
+        ]);
+    }
+}

--- a/src/Http/Controllers/Livewire/CodeOfConductController.php
+++ b/src/Http/Controllers/Livewire/CodeOfConductController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Laravel\Jetstream\Http\Controllers\Livewire;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Laravel\Jetstream\Jetstream;
+use League\CommonMark\CommonMarkConverter;
+use League\CommonMark\Environment;
+use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
+
+class CodeOfConductController extends Controller
+{
+    /**
+     * Show the privacy policy for the application.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\View\View
+     */
+    public function show(Request $request)
+    {
+        $conductFile = Jetstream::localizedMarkdownPath('conduct.md');
+
+        $environment = Environment::createCommonMarkEnvironment();
+        $environment->addExtension(new GithubFlavoredMarkdownExtension());
+
+        return view('conduct', [
+            'conduct' => (new CommonMarkConverter([], $environment))->convertToHtml(file_get_contents($conductFile)),
+        ]);
+    }
+}

--- a/stubs/inertia/resources/js/Pages/Auth/Register.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/Register.vue
@@ -33,7 +33,7 @@
                         <jet-checkbox name="terms" id="terms" v-model="form.terms" />
 
                         <div class="ml-2">
-                            I agree to the <a target="_blank" :href="route('terms.show')" class="underline text-sm text-gray-600 hover:text-gray-900">Terms of Service</a> and <a target="_blank" :href="route('policy.show')" class="underline text-sm text-gray-600 hover:text-gray-900">Privacy Policy</a>
+                            I agree to the <a target="_blank" :href="route('terms.show')" class="underline text-sm text-gray-600 hover:text-gray-900">Terms of Service</a>, <a target="_blank" :href="route('policy.show')" class="underline text-sm text-gray-600 hover:text-gray-900">Privacy Policy</a> and  <a target="_blank" :href="route('conduct.show')" class="underline text-sm text-gray-600 hover:text-gray-900">Conduct Policy</a>
                         </div>
                     </div>
                 </jet-label>

--- a/stubs/inertia/resources/js/Pages/CodeOfConduct.vue
+++ b/stubs/inertia/resources/js/Pages/CodeOfConduct.vue
@@ -1,0 +1,26 @@
+<template>
+    <div class="font-sans text-gray-900 antialiased">
+        <div class="pt-4 bg-gray-100">
+            <div class="min-h-screen flex flex-col items-center pt-6 sm:pt-0">
+                <div>
+                    <jet-authentication-card-logo />
+                </div>
+
+                <div v-html="conduct" class="w-full sm:max-w-2xl mt-6 p-6 bg-white shadow-md overflow-hidden sm:rounded-lg prose">
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script>
+import JetAuthenticationCardLogo from '@/Jetstream/AuthenticationCardLogo'
+
+export default {
+    props: ['conduct'],
+
+    components: {
+        JetAuthenticationCardLogo,
+    },
+}
+</script>

--- a/stubs/livewire/resources/views/auth/register.blade.php
+++ b/stubs/livewire/resources/views/auth/register.blade.php
@@ -36,9 +36,10 @@
                             <x-jet-checkbox name="terms" id="terms"/>
 
                             <div class="ml-2">
-                                {!! __('I agree to the :terms_of_service and :privacy_policy', [
+                                {!! __('I agree to the :terms_of_service, :privacy_policy and :conduct_policy', [
                                         'terms_of_service' => '<a target="_blank" href="'.route('terms.show').'" class="underline text-sm text-gray-600 hover:text-gray-900">'.__('Terms of Service').'</a>',
                                         'privacy_policy' => '<a target="_blank" href="'.route('policy.show').'" class="underline text-sm text-gray-600 hover:text-gray-900">'.__('Privacy Policy').'</a>',
+                                        'conduct_policy' => '<a target="_blank" href="'.route('conduct.show').'" class="underline text-sm text-gray-600 hover:text-gray-900">'.__('Conduct Policy').'</a>',
                                 ]) !!}
                             </div>
                         </div>

--- a/stubs/livewire/resources/views/conduct.blade.php
+++ b/stubs/livewire/resources/views/conduct.blade.php
@@ -1,0 +1,13 @@
+<x-guest-layout>
+    <div class="pt-4 bg-gray-100">
+        <div class="min-h-screen flex flex-col items-center pt-6 sm:pt-0">
+            <div>
+                <x-jet-authentication-card-logo />
+            </div>
+
+            <div class="w-full sm:max-w-2xl mt-6 p-6 bg-white shadow-md overflow-hidden sm:rounded-lg prose">
+                {!! $conduct !!}
+            </div>
+        </div>
+    </div>
+</x-guest-layout>

--- a/stubs/resources/markdown/conduct.md
+++ b/stubs/resources/markdown/conduct.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Edit this file to define the code of conduct for your application.


### PR DESCRIPTION
This PR introduces a Code of Conduct acceptance to the existing Terms of Use and Privacy Policy feature of Jetstream. 

This policy mimics the existing policies entirely and utilizes the same markdown process. 

No additional form fields are submitted and all tests follow the same feature tests that exist as this is integrated into the Features::termsAndPrivacyPolicy() configuration. I elected not to change the name, however it might be advisable to change the name to simply usagePolicies() to better capture potential future policies that might be required by developers.
