### PR TITLE
[2.x] Fix ownsTeam when applied to non-User model

### DIFF
--- a/src/HasTeams.php
+++ b/src/HasTeams.php
@@ -104,7 +104,7 @@ trait HasTeams
      */
     public function ownsTeam($team)
     {
-        return $this->id == $team->user_id;
+        return $this->id == $team->{$this->getForeignKey()};
     }
 
     /**


### PR DESCRIPTION
Hi,
due to the fact that Jetstream allows to bind this trait to any models (not only User), the foreign key shouldn't be hardcoded.

My use-case:
I'm building a game where an User can have many Character. Character belongs to Team, so my foreign key is `character_id`