### PR TITLE
[2.x] Allow UpdateTeamNameForm in Livewire to hydrate all Team attributes

### DIFF
--- a/src/Http/Livewire/UpdateTeamNameForm.php
+++ b/src/Http/Livewire/UpdateTeamNameForm.php
@@ -32,7 +32,7 @@ class UpdateTeamNameForm extends Component
     {
         $this->team = $team;
 
-        $this->state = ['name' => $team->name];
+        $this->state = $team->withoutRelations()->toArray();
     }
 
     /**


### PR DESCRIPTION
Hydrate UpdateTeamNameForm Livewire Component's state with complete team attributes instead of just name. Inertia already shares all team attributes.

This change will help the developer to 'show' attributes other than just name in Team Update Form in Livewire. Currently, the developer could update the team attribute to the database without this change. This change is so developers won't have to resort to registering custom Livewire components.
