### PR TITLE
[2.x] Add unverified state to UserFactory

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -33,6 +33,20 @@ class UserFactory extends Factory
     }
 
     /**
+     * Define the model's unverified state.
+     *
+     * @return \Illuminate\Database\Eloquent\Factories\Factory
+     */
+    public function unverified()
+    {
+        return $this->state(function (array $attributes) {
+            return [
+                'email_verified_at' => null,
+            ];
+        });
+    }
+
+    /**
      * Indicate that the user should have a personal team.
      *
      * @return $this


### PR DESCRIPTION
Just noticed that the ```jetstream:install``` artisan command overrides the default UserFactory from the standard Laravel installation. So, this PR brings over the unverified state that I contributed in laravel/laravel#5533 to Jetstream's UserFactory.