### PR TITLE
Replace Nevermind with Never Mind

### DIFF
--- a/resources/views/components/confirms-password.blade.php
+++ b/resources/views/components/confirms-password.blade.php
@@ -35,7 +35,7 @@
 
     <x-slot name="footer">
         <x-jet-secondary-button wire:click="stopConfirmingPassword" wire:loading.attr="disabled">
-            {{ __('Nevermind') }}
+            {{ __('Never Mind') }}
         </x-jet-secondary-button>
 
         <x-jet-button class="ml-2" dusk="confirm-password-button" wire:click="confirmPassword" wire:loading.attr="disabled">

--- a/stubs/inertia/resources/js/Jetstream/ConfirmsPassword.vue
+++ b/stubs/inertia/resources/js/Jetstream/ConfirmsPassword.vue
@@ -24,7 +24,7 @@
 
             <template #footer>
                 <jet-secondary-button @click.native="closeModal">
-                    Nevermind
+                    Never Mind
                 </jet-secondary-button>
 
                 <jet-button class="ml-2" @click.native="confirmPassword" :class="{ 'opacity-25': form.processing }" :disabled="form.processing">

--- a/stubs/inertia/resources/js/Pages/API/ApiTokenManager.vue
+++ b/stubs/inertia/resources/js/Pages/API/ApiTokenManager.vue
@@ -131,7 +131,7 @@
 
             <template #footer>
                 <jet-secondary-button @click.native="managingPermissionsFor = null">
-                    Nevermind
+                    Never Mind
                 </jet-secondary-button>
 
                 <jet-button class="ml-2" @click.native="updateApiToken" :class="{ 'opacity-25': updateApiTokenForm.processing }" :disabled="updateApiTokenForm.processing">
@@ -152,7 +152,7 @@
 
             <template #footer>
                 <jet-secondary-button @click.native="apiTokenBeingDeleted = null">
-                    Nevermind
+                    Never Mind
                 </jet-secondary-button>
 
                 <jet-danger-button class="ml-2" @click.native="deleteApiToken" :class="{ 'opacity-25': deleteApiTokenForm.processing }" :disabled="deleteApiTokenForm.processing">

--- a/stubs/inertia/resources/js/Pages/Profile/DeleteUserForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/DeleteUserForm.vue
@@ -40,7 +40,7 @@
 
                 <template #footer>
                     <jet-secondary-button @click.native="closeModal">
-                        Nevermind
+                        Never Mind
                     </jet-secondary-button>
 
                     <jet-danger-button class="ml-2" @click.native="deleteUser" :class="{ 'opacity-25': form.processing }" :disabled="form.processing">

--- a/stubs/inertia/resources/js/Pages/Profile/LogoutOtherBrowserSessionsForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/LogoutOtherBrowserSessionsForm.vue
@@ -74,7 +74,7 @@
 
                 <template #footer>
                     <jet-secondary-button @click.native="closeModal">
-                        Nevermind
+                        Never Mind
                     </jet-secondary-button>
 
                     <jet-button class="ml-2" @click.native="logoutOtherBrowserSessions" :class="{ 'opacity-25': form.processing }" :disabled="form.processing">

--- a/stubs/inertia/resources/js/Pages/Teams/DeleteTeamForm.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/DeleteTeamForm.vue
@@ -31,7 +31,7 @@
 
                 <template #footer>
                     <jet-secondary-button @click.native="confirmingTeamDeletion = false">
-                        Nevermind
+                        Never Mind
                     </jet-secondary-button>
 
                     <jet-danger-button class="ml-2" @click.native="deleteTeam" :class="{ 'opacity-25': form.processing }" :disabled="form.processing">

--- a/stubs/inertia/resources/js/Pages/Teams/TeamMemberManager.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/TeamMemberManager.vue
@@ -193,7 +193,7 @@
 
             <template #footer>
                 <jet-secondary-button @click.native="currentlyManagingRole = false">
-                    Nevermind
+                    Never Mind
                 </jet-secondary-button>
 
                 <jet-button class="ml-2" @click.native="updateRole" :class="{ 'opacity-25': updateRoleForm.processing }" :disabled="updateRoleForm.processing">
@@ -214,7 +214,7 @@
 
             <template #footer>
                 <jet-secondary-button @click.native="confirmingLeavingTeam = false">
-                    Nevermind
+                    Never Mind
                 </jet-secondary-button>
 
                 <jet-danger-button class="ml-2" @click.native="leaveTeam" :class="{ 'opacity-25': leaveTeamForm.processing }" :disabled="leaveTeamForm.processing">
@@ -235,7 +235,7 @@
 
             <template #footer>
                 <jet-secondary-button @click.native="teamMemberBeingRemoved = null">
-                    Nevermind
+                    Never Mind
                 </jet-secondary-button>
 
                 <jet-danger-button class="ml-2" @click.native="removeTeamMember" :class="{ 'opacity-25': removeTeamMemberForm.processing }" :disabled="removeTeamMemberForm.processing">

--- a/stubs/livewire/resources/views/api/api-token-manager.blade.php
+++ b/stubs/livewire/resources/views/api/api-token-manager.blade.php
@@ -137,7 +137,7 @@
 
         <x-slot name="footer">
             <x-jet-secondary-button wire:click="$set('managingApiTokenPermissions', false)" wire:loading.attr="disabled">
-                {{ __('Nevermind') }}
+                {{ __('Never Mind') }}
             </x-jet-secondary-button>
 
             <x-jet-button class="ml-2" wire:click="updateApiToken" wire:loading.attr="disabled">
@@ -158,7 +158,7 @@
 
         <x-slot name="footer">
             <x-jet-secondary-button wire:click="$toggle('confirmingApiTokenDeletion')" wire:loading.attr="disabled">
-                {{ __('Nevermind') }}
+                {{ __('Never Mind') }}
             </x-jet-secondary-button>
 
             <x-jet-danger-button class="ml-2" wire:click="deleteApiToken" wire:loading.attr="disabled">

--- a/stubs/livewire/resources/views/profile/delete-user-form.blade.php
+++ b/stubs/livewire/resources/views/profile/delete-user-form.blade.php
@@ -40,7 +40,7 @@
 
             <x-slot name="footer">
                 <x-jet-secondary-button wire:click="$toggle('confirmingUserDeletion')" wire:loading.attr="disabled">
-                    {{ __('Nevermind') }}
+                    {{ __('Never Mind') }}
                 </x-jet-secondary-button>
 
                 <x-jet-danger-button class="ml-2" wire:click="deleteUser" wire:loading.attr="disabled">

--- a/stubs/livewire/resources/views/profile/logout-other-browser-sessions-form.blade.php
+++ b/stubs/livewire/resources/views/profile/logout-other-browser-sessions-form.blade.php
@@ -83,7 +83,7 @@
 
             <x-slot name="footer">
                 <x-jet-secondary-button wire:click="$toggle('confirmingLogout')" wire:loading.attr="disabled">
-                    {{ __('Nevermind') }}
+                    {{ __('Never Mind') }}
                 </x-jet-secondary-button>
 
                 <x-jet-button class="ml-2"

--- a/stubs/livewire/resources/views/teams/delete-team-form.blade.php
+++ b/stubs/livewire/resources/views/teams/delete-team-form.blade.php
@@ -30,7 +30,7 @@
 
             <x-slot name="footer">
                 <x-jet-secondary-button wire:click="$toggle('confirmingTeamDeletion')" wire:loading.attr="disabled">
-                    {{ __('Nevermind') }}
+                    {{ __('Never Mind') }}
                 </x-jet-secondary-button>
 
                 <x-jet-danger-button class="ml-2" wire:click="deleteTeam" wire:loading.attr="disabled">

--- a/stubs/livewire/resources/views/teams/team-member-manager.blade.php
+++ b/stubs/livewire/resources/views/teams/team-member-manager.blade.php
@@ -203,7 +203,7 @@
 
         <x-slot name="footer">
             <x-jet-secondary-button wire:click="stopManagingRole" wire:loading.attr="disabled">
-                {{ __('Nevermind') }}
+                {{ __('Never Mind') }}
             </x-jet-secondary-button>
 
             <x-jet-button class="ml-2" wire:click="updateRole" wire:loading.attr="disabled">
@@ -224,7 +224,7 @@
 
         <x-slot name="footer">
             <x-jet-secondary-button wire:click="$toggle('confirmingLeavingTeam')" wire:loading.attr="disabled">
-                {{ __('Nevermind') }}
+                {{ __('Never Mind') }}
             </x-jet-secondary-button>
 
             <x-jet-danger-button class="ml-2" wire:click="leaveTeam" wire:loading.attr="disabled">
@@ -245,7 +245,7 @@
 
         <x-slot name="footer">
             <x-jet-secondary-button wire:click="$toggle('confirmingTeamMemberRemoval')" wire:loading.attr="disabled">
-                {{ __('Nevermind') }}
+                {{ __('Never Mind') }}
             </x-jet-secondary-button>
 
             <x-jet-danger-button class="ml-2" wire:click="removeTeamMember" wire:loading.attr="disabled">


### PR DESCRIPTION
"Nevermind" isn't really a word, but at a minimum, it's not a verb; the usage in a button should be "Never Mind". This PR replaces all uses of the former with the latter.

Apologies if this was meant to be an homage to Kurt Cobain and I'm ruining it 😉.
