### PR TITLE
[2.x] Return null for profile photo url if `managesProfilePhotos` is disabled

### DIFF
--- a/src/HasProfilePhoto.php
+++ b/src/HasProfilePhoto.php
@@ -54,6 +54,10 @@ trait HasProfilePhoto
      */
     public function getProfilePhotoUrlAttribute()
     {
+        if (!Features::managesProfilePhotos()) {
+            return null;
+        }
+
         return $this->profile_photo_path
                     ? Storage::disk($this->profilePhotoDisk())->url($this->profile_photo_path)
                     : $this->defaultProfilePhotoUrl();

--- a/src/HasProfilePhoto.php
+++ b/src/HasProfilePhoto.php
@@ -54,7 +54,7 @@ trait HasProfilePhoto
      */
     public function getProfilePhotoUrlAttribute()
     {
-        if (!Features::managesProfilePhotos()) {
+        if (! Features::managesProfilePhotos()) {
             return null;
         }
 


### PR DESCRIPTION
This PR changes the `getProfilePhotoUrlAttribute()` to return `null` if the application does not have profile photos enabled.

The reason for this is in the Spark billing portal, the profile photo is display as initials, even when the application has profile photos disabled:

![Screen Shot 2021-02-18 at 8 27 15 AM](https://user-images.githubusercontent.com/791222/108379466-34016480-71c3-11eb-8b2e-684101079934.png)
