### PR TITLE
Fix typehint

### DIFF
--- a/src/HasTeams.php
+++ b/src/HasTeams.php
@@ -56,7 +56,7 @@ trait HasTeams
     /**
      * Get all of the teams the user owns or belongs to.
      *
-     * @return \Illuminate\Collections\Collection
+     * @return \Illuminate\Support\Collection
      */
     public function allTeams()
     {


### PR DESCRIPTION
I'm guessing there's a higher chance of people having installed the illuminate/support than illuminate/collections

Fixing this docblock will help IDEs like PhpStorm using autocompletion.