### PR TITLE
[2.x] - Remove '.native' deprecated modifier in vue3

### DIFF
--- a/stubs/inertia/resources/js/Jetstream/ConfirmsPassword.vue
+++ b/stubs/inertia/resources/js/Jetstream/ConfirmsPassword.vue
@@ -16,18 +16,18 @@
                     <jet-input type="password" class="mt-1 block w-3/4" placeholder="Password"
                                 ref="password"
                                 v-model="form.password"
-                                @keyup.enter.native="confirmPassword" />
+                                @keyup.enter="confirmPassword" />
 
                     <jet-input-error :message="form.error" class="mt-2" />
                 </div>
             </template>
 
             <template #footer>
-                <jet-secondary-button @click.native="closeModal">
+                <jet-secondary-button @click="closeModal">
                     Cancel
                 </jet-secondary-button>
 
-                <jet-button class="ml-2" @click.native="confirmPassword" :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
+                <jet-button class="ml-2" @click="confirmPassword" :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
                     {{ button }}
                 </jet-button>
             </template>

--- a/stubs/inertia/resources/js/Pages/API/ApiTokenManager.vue
+++ b/stubs/inertia/resources/js/Pages/API/ApiTokenManager.vue
@@ -106,7 +106,7 @@
             </template>
 
             <template #footer>
-                <jet-secondary-button @click.native="displayingToken = false">
+                <jet-secondary-button @click="displayingToken = false">
                     Close
                 </jet-secondary-button>
             </template>
@@ -130,11 +130,11 @@
             </template>
 
             <template #footer>
-                <jet-secondary-button @click.native="managingPermissionsFor = null">
+                <jet-secondary-button @click="managingPermissionsFor = null">
                     Cancel
                 </jet-secondary-button>
 
-                <jet-button class="ml-2" @click.native="updateApiToken" :class="{ 'opacity-25': updateApiTokenForm.processing }" :disabled="updateApiTokenForm.processing">
+                <jet-button class="ml-2" @click="updateApiToken" :class="{ 'opacity-25': updateApiTokenForm.processing }" :disabled="updateApiTokenForm.processing">
                     Save
                 </jet-button>
             </template>
@@ -151,11 +151,11 @@
             </template>
 
             <template #footer>
-                <jet-secondary-button @click.native="apiTokenBeingDeleted = null">
+                <jet-secondary-button @click="apiTokenBeingDeleted = null">
                     Cancel
                 </jet-secondary-button>
 
-                <jet-danger-button class="ml-2" @click.native="deleteApiToken" :class="{ 'opacity-25': deleteApiTokenForm.processing }" :disabled="deleteApiTokenForm.processing">
+                <jet-danger-button class="ml-2" @click="deleteApiToken" :class="{ 'opacity-25': deleteApiTokenForm.processing }" :disabled="deleteApiTokenForm.processing">
                     Delete
                 </jet-danger-button>
             </template>

--- a/stubs/inertia/resources/js/Pages/Profile/DeleteUserForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/DeleteUserForm.vue
@@ -14,7 +14,7 @@
             </div>
 
             <div class="mt-5">
-                <jet-danger-button @click.native="confirmUserDeletion">
+                <jet-danger-button @click="confirmUserDeletion">
                     Delete Account
                 </jet-danger-button>
             </div>
@@ -32,18 +32,18 @@
                         <jet-input type="password" class="mt-1 block w-3/4" placeholder="Password"
                                     ref="password"
                                     v-model="form.password"
-                                    @keyup.enter.native="deleteUser" />
+                                    @keyup.enter="deleteUser" />
 
                         <jet-input-error :message="form.errors.password" class="mt-2" />
                     </div>
                 </template>
 
                 <template #footer>
-                    <jet-secondary-button @click.native="closeModal">
+                    <jet-secondary-button @click="closeModal">
                         Cancel
                     </jet-secondary-button>
 
-                    <jet-danger-button class="ml-2" @click.native="deleteUser" :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
+                    <jet-danger-button class="ml-2" @click="deleteUser" :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
                         Delete Account
                     </jet-danger-button>
                 </template>

--- a/stubs/inertia/resources/js/Pages/Profile/LogoutOtherBrowserSessionsForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/LogoutOtherBrowserSessionsForm.vue
@@ -44,7 +44,7 @@
             </div>
 
             <div class="flex items-center mt-5">
-                <jet-button @click.native="confirmLogout">
+                <jet-button @click="confirmLogout">
                     Log Out Other Browser Sessions
                 </jet-button>
 
@@ -66,18 +66,18 @@
                         <jet-input type="password" class="mt-1 block w-3/4" placeholder="Password"
                                     ref="password"
                                     v-model="form.password"
-                                    @keyup.enter.native="logoutOtherBrowserSessions" />
+                                    @keyup.enter="logoutOtherBrowserSessions" />
 
                         <jet-input-error :message="form.errors.password" class="mt-2" />
                     </div>
                 </template>
 
                 <template #footer>
-                    <jet-secondary-button @click.native="closeModal">
+                    <jet-secondary-button @click="closeModal">
                         Cancel
                     </jet-secondary-button>
 
-                    <jet-button class="ml-2" @click.native="logoutOtherBrowserSessions" :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
+                    <jet-button class="ml-2" @click="logoutOtherBrowserSessions" :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
                         Log Out Other Browser Sessions
                     </jet-button>
                 </template>

--- a/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
@@ -30,11 +30,11 @@
                     </span>
                 </div>
 
-                <jet-secondary-button class="mt-2 mr-2" type="button" @click.native.prevent="selectNewPhoto">
+                <jet-secondary-button class="mt-2 mr-2" type="button" @click.prevent="selectNewPhoto">
                     Select A New Photo
                 </jet-secondary-button>
 
-                <jet-secondary-button type="button" class="mt-2" @click.native.prevent="deletePhoto" v-if="user.profile_photo_path">
+                <jet-secondary-button type="button" class="mt-2" @click.prevent="deletePhoto" v-if="user.profile_photo_path">
                     Remove Photo
                 </jet-secondary-button>
 

--- a/stubs/inertia/resources/js/Pages/Teams/DeleteTeamForm.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/DeleteTeamForm.vue
@@ -14,7 +14,7 @@
             </div>
 
             <div class="mt-5">
-                <jet-danger-button @click.native="confirmTeamDeletion">
+                <jet-danger-button @click="confirmTeamDeletion">
                     Delete Team
                 </jet-danger-button>
             </div>
@@ -30,11 +30,11 @@
                 </template>
 
                 <template #footer>
-                    <jet-secondary-button @click.native="confirmingTeamDeletion = false">
+                    <jet-secondary-button @click="confirmingTeamDeletion = false">
                         Cancel
                     </jet-secondary-button>
 
-                    <jet-danger-button class="ml-2" @click.native="deleteTeam" :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
+                    <jet-danger-button class="ml-2" @click="deleteTeam" :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
                         Delete Team
                     </jet-danger-button>
                 </template>

--- a/stubs/inertia/resources/js/Pages/Teams/TeamMemberManager.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/TeamMemberManager.vue
@@ -192,11 +192,11 @@
             </template>
 
             <template #footer>
-                <jet-secondary-button @click.native="currentlyManagingRole = false">
+                <jet-secondary-button @click="currentlyManagingRole = false">
                     Cancel
                 </jet-secondary-button>
 
-                <jet-button class="ml-2" @click.native="updateRole" :class="{ 'opacity-25': updateRoleForm.processing }" :disabled="updateRoleForm.processing">
+                <jet-button class="ml-2" @click="updateRole" :class="{ 'opacity-25': updateRoleForm.processing }" :disabled="updateRoleForm.processing">
                     Save
                 </jet-button>
             </template>
@@ -213,11 +213,11 @@
             </template>
 
             <template #footer>
-                <jet-secondary-button @click.native="confirmingLeavingTeam = false">
+                <jet-secondary-button @click="confirmingLeavingTeam = false">
                     Cancel
                 </jet-secondary-button>
 
-                <jet-danger-button class="ml-2" @click.native="leaveTeam" :class="{ 'opacity-25': leaveTeamForm.processing }" :disabled="leaveTeamForm.processing">
+                <jet-danger-button class="ml-2" @click="leaveTeam" :class="{ 'opacity-25': leaveTeamForm.processing }" :disabled="leaveTeamForm.processing">
                     Leave
                 </jet-danger-button>
             </template>
@@ -234,11 +234,11 @@
             </template>
 
             <template #footer>
-                <jet-secondary-button @click.native="teamMemberBeingRemoved = null">
+                <jet-secondary-button @click="teamMemberBeingRemoved = null">
                     Cancel
                 </jet-secondary-button>
 
-                <jet-danger-button class="ml-2" @click.native="removeTeamMember" :class="{ 'opacity-25': removeTeamMemberForm.processing }" :disabled="removeTeamMemberForm.processing">
+                <jet-danger-button class="ml-2" @click="removeTeamMember" :class="{ 'opacity-25': removeTeamMemberForm.processing }" :disabled="removeTeamMemberForm.processing">
                     Remove
                 </jet-danger-button>
             </template>


### PR DESCRIPTION
This PR contains changes for Inertia vue stubs.

Based on vue3 recommended rules, the `.native` modifier on `v-on` directive is deprecated, according to the vue eslint rulesets https://eslint.vuejs.org/rules/no-deprecated-v-on-native-modifier.html it seems that in vue3 we can use the `v-on` directive on custom components as well.