### PR TITLE
Prevent network request when pressing escape to close modal

### DIFF
--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -14,7 +14,7 @@ $maxWidth = [
 
 <div
     x-data="{
-        show: @entangle($attributes->wire('model')),
+        show: @entangle($attributes->wire('model')).defer,
         focusables() {
             // All focusable element types...
             let selector = 'a, button, input, textarea, select, details, [tabindex]:not([tabindex=\'-1\'])'


### PR DESCRIPTION
This PR contains a micro-optimisation, but a nice one.

Right now, if you close the modal with `esc` a network request is being made. 

By using `defer`, no network request will be made when hitting escape. I've confirmed this improved behaviour in one of my projects.

Livewire docs on `defer` are here: https://laravel-livewire.com/docs/2.x/alpine-js#extracting-blade-components