### PR TITLE
Skip TwoFactorAuthenticationSettingsTest if not enabled

### DIFF
--- a/stubs/tests/inertia/TwoFactorAuthenticationSettingsTest.php
+++ b/stubs/tests/inertia/TwoFactorAuthenticationSettingsTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Fortify\Features;
 use Tests\TestCase;
 
 class TwoFactorAuthenticationSettingsTest extends TestCase
@@ -12,6 +13,10 @@ class TwoFactorAuthenticationSettingsTest extends TestCase
 
     public function test_two_factor_authentication_can_be_enabled()
     {
+        if (! Features::enabled(Features::twoFactorAuthentication([]))) {
+            return $this->markTestSkipped('Two-factor Authentication support is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->create());
 
         $this->withSession(['auth.password_confirmed_at' => time()]);
@@ -24,6 +29,10 @@ class TwoFactorAuthenticationSettingsTest extends TestCase
 
     public function test_recovery_codes_can_be_regenerated()
     {
+        if (! Features::enabled(Features::twoFactorAuthentication([]))) {
+            return $this->markTestSkipped('Two-factor Authentication support is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->create());
 
         $this->withSession(['auth.password_confirmed_at' => time()]);
@@ -41,6 +50,10 @@ class TwoFactorAuthenticationSettingsTest extends TestCase
 
     public function test_two_factor_authentication_can_be_disabled()
     {
+        if (! Features::enabled(Features::twoFactorAuthentication([]))) {
+            return $this->markTestSkipped('Two-factor Authentication support is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->create());
 
         $this->withSession(['auth.password_confirmed_at' => time()]);

--- a/stubs/tests/livewire/TwoFactorAuthenticationSettingsTest.php
+++ b/stubs/tests/livewire/TwoFactorAuthenticationSettingsTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Fortify\Features;
 use Laravel\Jetstream\Http\Livewire\TwoFactorAuthenticationForm;
 use Livewire\Livewire;
 use Tests\TestCase;
@@ -14,6 +15,10 @@ class TwoFactorAuthenticationSettingsTest extends TestCase
 
     public function test_two_factor_authentication_can_be_enabled()
     {
+        if (! Features::enabled(Features::twoFactorAuthentication([]))) {
+            return $this->markTestSkipped('Two-factor Authentication support is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->create());
 
         $this->withSession(['auth.password_confirmed_at' => time()]);
@@ -29,6 +34,10 @@ class TwoFactorAuthenticationSettingsTest extends TestCase
 
     public function test_recovery_codes_can_be_regenerated()
     {
+        if (! Features::enabled(Features::twoFactorAuthentication([]))) {
+            return $this->markTestSkipped('Two-factor Authentication support is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->create());
 
         $this->withSession(['auth.password_confirmed_at' => time()]);
@@ -47,6 +56,10 @@ class TwoFactorAuthenticationSettingsTest extends TestCase
 
     public function test_two_factor_authentication_can_be_disabled()
     {
+        if (! Features::enabled(Features::twoFactorAuthentication([]))) {
+            return $this->markTestSkipped('Two-factor Authentication support is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->create());
 
         $this->withSession(['auth.password_confirmed_at' => time()]);


### PR DESCRIPTION
Currently, the `TwoFactorAuthenticationSettingsTest` is always executed, but fails when Two-Factor Authentication feature is disabled.

This PR is just a fix to make sure (stubs) Test suite works as expected.
