### PR TITLE
Test team features only when active

### DIFF
--- a/stubs/tests/inertia/ApiTokenPermissionsTest.php
+++ b/stubs/tests/inertia/ApiTokenPermissionsTest.php
@@ -18,7 +18,7 @@ class ApiTokenPermissionsTest extends TestCase
             return $this->markTestSkipped('API support is not enabled.');
         }
 
-        if( Features::hasTeamFeatures()) {
+        if (Features::hasTeamFeatures()) {
             $this->actingAs($user = User::factory()->withPersonalTeam()->create());
         } else {
             $this->actingAs($user = User::factory()->create());

--- a/stubs/tests/inertia/ApiTokenPermissionsTest.php
+++ b/stubs/tests/inertia/ApiTokenPermissionsTest.php
@@ -18,7 +18,11 @@ class ApiTokenPermissionsTest extends TestCase
             return $this->markTestSkipped('API support is not enabled.');
         }
 
-        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+        if( Features::hasTeamFeatures()) {
+            $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+        } else {
+            $this->actingAs($user = User::factory()->create());
+        }
 
         $token = $user->tokens()->create([
             'name' => 'Test Token',

--- a/stubs/tests/inertia/CreateApiTokenTest.php
+++ b/stubs/tests/inertia/CreateApiTokenTest.php
@@ -17,7 +17,7 @@ class CreateApiTokenTest extends TestCase
             return $this->markTestSkipped('API support is not enabled.');
         }
 
-        if( Features::hasTeamFeatures()) {
+        if (Features::hasTeamFeatures()) {
             $this->actingAs($user = User::factory()->withPersonalTeam()->create());
         } else {
             $this->actingAs($user = User::factory()->create());

--- a/stubs/tests/inertia/CreateApiTokenTest.php
+++ b/stubs/tests/inertia/CreateApiTokenTest.php
@@ -17,7 +17,11 @@ class CreateApiTokenTest extends TestCase
             return $this->markTestSkipped('API support is not enabled.');
         }
 
-        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+        if( Features::hasTeamFeatures()) {
+            $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+        } else {
+            $this->actingAs($user = User::factory()->create());
+        }
 
         $response = $this->post('/user/api-tokens', [
             'name' => 'Test Token',

--- a/stubs/tests/inertia/DeleteApiTokenTest.php
+++ b/stubs/tests/inertia/DeleteApiTokenTest.php
@@ -18,7 +18,7 @@ class DeleteApiTokenTest extends TestCase
             return $this->markTestSkipped('API support is not enabled.');
         }
 
-        if( Features::hasTeamFeatures()) {
+        if (Features::hasTeamFeatures()) {
             $this->actingAs($user = User::factory()->withPersonalTeam()->create());
         } else {
             $this->actingAs($user = User::factory()->create());

--- a/stubs/tests/inertia/DeleteApiTokenTest.php
+++ b/stubs/tests/inertia/DeleteApiTokenTest.php
@@ -18,7 +18,11 @@ class DeleteApiTokenTest extends TestCase
             return $this->markTestSkipped('API support is not enabled.');
         }
 
-        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+        if( Features::hasTeamFeatures()) {
+            $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+        } else {
+            $this->actingAs($user = User::factory()->create());
+        }
 
         $token = $user->tokens()->create([
             'name' => 'Test Token',

--- a/stubs/tests/livewire/ApiTokenPermissionsTest.php
+++ b/stubs/tests/livewire/ApiTokenPermissionsTest.php
@@ -20,7 +20,7 @@ class ApiTokenPermissionsTest extends TestCase
             return $this->markTestSkipped('API support is not enabled.');
         }
 
-        if( Features::hasTeamFeatures()) {
+        if (Features::hasTeamFeatures()) {
             $this->actingAs($user = User::factory()->withPersonalTeam()->create());
         } else {
             $this->actingAs($user = User::factory()->create());

--- a/stubs/tests/livewire/ApiTokenPermissionsTest.php
+++ b/stubs/tests/livewire/ApiTokenPermissionsTest.php
@@ -20,7 +20,11 @@ class ApiTokenPermissionsTest extends TestCase
             return $this->markTestSkipped('API support is not enabled.');
         }
 
-        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+        if( Features::hasTeamFeatures()) {
+            $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+        } else {
+            $this->actingAs($user = User::factory()->create());
+        }
 
         $token = $user->tokens()->create([
             'name' => 'Test Token',

--- a/stubs/tests/livewire/CreateApiTokenTest.php
+++ b/stubs/tests/livewire/CreateApiTokenTest.php
@@ -19,7 +19,7 @@ class CreateApiTokenTest extends TestCase
             return $this->markTestSkipped('API support is not enabled.');
         }
 
-        if( Features::hasTeamFeatures()) {
+        if (Features::hasTeamFeatures()) {
             $this->actingAs($user = User::factory()->withPersonalTeam()->create());
         } else {
             $this->actingAs($user = User::factory()->create());

--- a/stubs/tests/livewire/CreateApiTokenTest.php
+++ b/stubs/tests/livewire/CreateApiTokenTest.php
@@ -19,7 +19,11 @@ class CreateApiTokenTest extends TestCase
             return $this->markTestSkipped('API support is not enabled.');
         }
 
-        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+        if( Features::hasTeamFeatures()) {
+            $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+        } else {
+            $this->actingAs($user = User::factory()->create());
+        }
 
         Livewire::test(ApiTokenManager::class)
                     ->set(['createApiTokenForm' => [

--- a/stubs/tests/livewire/DeleteApiTokenTest.php
+++ b/stubs/tests/livewire/DeleteApiTokenTest.php
@@ -20,7 +20,7 @@ class DeleteApiTokenTest extends TestCase
             return $this->markTestSkipped('API support is not enabled.');
         }
 
-        if( Features::hasTeamFeatures()) {
+        if (Features::hasTeamFeatures()) {
             $this->actingAs($user = User::factory()->withPersonalTeam()->create());
         } else {
             $this->actingAs($user = User::factory()->create());

--- a/stubs/tests/livewire/DeleteApiTokenTest.php
+++ b/stubs/tests/livewire/DeleteApiTokenTest.php
@@ -20,7 +20,11 @@ class DeleteApiTokenTest extends TestCase
             return $this->markTestSkipped('API support is not enabled.');
         }
 
-        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+        if( Features::hasTeamFeatures()) {
+            $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+        } else {
+            $this->actingAs($user = User::factory()->create());
+        }
 
         $token = $user->tokens()->create([
             'name' => 'Test Token',


### PR DESCRIPTION
Add a condition in the Inertia and Livewire tests to only test team features if Teams have been enabled. At present, some tests are failing because they expect teams to always be enabled.

This is my first, proper, PR for Laravel, so, if there is a better way to address this issue (like making `withPersonalTeam()` return null if the teams feature isn't enabled), I'm more than happy to head down that path, just point me in that direction!