### PR TITLE
[2.x] Add an error message output when submitting a form

### DIFF
--- a/stubs/inertia/resources/js/Jetstream/ActionMessage.vue
+++ b/stubs/inertia/resources/js/Jetstream/ActionMessage.vue
@@ -1,15 +1,61 @@
 <template>
-    <div>
-        <transition leave-active-class="transition ease-in duration-1000" leave-from-class="opacity-100" leave-to-class="opacity-0">
-            <div v-show="on" class="text-sm text-gray-600">
-                <slot />
-            </div>
-        </transition>
+    <div class="text-sm">
+        <transition-group leave-active-class="transition ease-in duration-1000" leave-from-class="opacity-100" leave-to-class="opacity-0">
+            <span v-show="on || recentlySuccessful" key="successful" class="text-gray-600">
+                <slot>Saved.</slot>
+            </span>
+            <span v-if="!!onError" v-show="recentlyError" key="error" class="text-red-600">
+                <slot name="error">Whoops! Something went wrong.</slot>
+            </span>
+        </transition-group>
     </div>
 </template>
 
 <script>
-    export default {
-        props: ['on'],
+let recentlyActionTimeoutId = null;
+
+export default {
+    props: {
+        on: {
+            type: Boolean,
+            default: false,
+            required: false
+        },
+        onSuccess: {
+            type: Boolean,
+            default: false,
+            required: false,
+        },
+        onError: {
+            type: Boolean,
+            default: null,
+            required: false,
+        }
+    },
+    watch: {
+        onSuccess(value) {
+            if (value) {
+                this.timer('recentlySuccessful')
+            }
+        },
+        onError(value) {
+            if (value) {
+                this.timer('recentlyError')
+            }
+        }
+    },
+    data() {
+        return {
+            recentlySuccessful: false,
+            recentlyError: false,
+        }
+    },
+    methods: {
+        timer(variable) {
+            this[variable] = true
+            clearTimeout(recentlyActionTimeoutId)
+            recentlyActionTimeoutId = setTimeout(() => this[variable] = false, 2000)
+        }
     }
+}
 </script>

--- a/stubs/inertia/resources/js/Pages/Profile/UpdatePasswordForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/UpdatePasswordForm.vue
@@ -29,9 +29,7 @@
         </template>
 
         <template #actions>
-            <jet-action-message :on="form.recentlySuccessful" class="mr-3">
-                Saved.
-            </jet-action-message>
+            <jet-action-message :on="form.recentlySuccessful" :on-error="form.hasErrors" class="mr-3"></jet-action-message>
 
             <jet-button :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
                 Save

--- a/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
@@ -57,9 +57,7 @@
         </template>
 
         <template #actions>
-            <jet-action-message :on="form.recentlySuccessful" class="mr-3">
-                Saved.
-            </jet-action-message>
+            <jet-action-message :on="form.recentlySuccessful" :on-error="form.hasErrors" class="mr-3"></jet-action-message>
 
             <jet-button :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
                 Save

--- a/stubs/inertia/resources/js/Pages/Teams/UpdateTeamNameForm.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/UpdateTeamNameForm.vue
@@ -38,9 +38,7 @@
         </template>
 
         <template #actions v-if="permissions.canUpdateTeam">
-            <jet-action-message :on="form.recentlySuccessful" class="mr-3">
-                Saved.
-            </jet-action-message>
+            <jet-action-message :on="form.recentlySuccessful" class="mr-3"></jet-action-message>
 
             <jet-button :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
                 Save


### PR DESCRIPTION
Sometimes forms are large and when submitting them with incorrect data, we do not receive an error message near the form submit button, as it happens when the form is successfully submitted. Adding an error message output on form submission will help when submitting large and long forms that may not fit on the page, or when scrolling the page below invalid fields and clicking the submit button. It will also be convenient on mobile devices, especially with small screens where even a relatively small form will no longer fit on the screen.
Another solution would be to add `recentlyError` to the **Inertia** package, but the developer can not always output messages only from the **Inertia** form, so an additional option could be to transfer his own properties of success (`onSuccess`) or failure (`onError`) into the `ActionMessage` component and tracking them there so that it looks like passing the `recentlySuccessful` property from the **Inertia** form. For compatibility, and also, if the developer wants to display only a message about the success of the **Inertia** form submission, it is possible to transfer only the `on` property as it was before without any changes.

For example, there if we type wrong name in form on **Profile** page, we not getting error. We only need to guess that something was wrong.
<img src="https://user-images.githubusercontent.com/18280400/110234699-f7609780-7f3c-11eb-87ba-3e14472ad882.png" alt="without_error (iPhone 5_SE)" width="300" />

But, if show error message, everything will become clear.
<img src="https://user-images.githubusercontent.com/18280400/110234831-bddc5c00-7f3d-11eb-9534-fda31979920c.png" alt="with_error (iPhone 5_SE)" width="300" />

Perhaps my code needs to be corrected, since I don't have much experience with this.