### PR TITLE
Stubs: Mix assets not included when Laravel installed in subdirectory.

### DIFF
--- a/stubs/inertia/resources/views/app.blade.php
+++ b/stubs/inertia/resources/views/app.blade.php
@@ -11,11 +11,11 @@
         <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap">
 
         <!-- Styles -->
-        <link rel="stylesheet" href="{{ mix('css/app.css') }}">
+        <link rel="stylesheet" href="{{ url(mix('css/app.css')) }}">
 
         <!-- Scripts -->
         @routes
-        <script src="{{ mix('js/app.js') }}" defer></script>
+        <script src="{{ url(mix('js/app.js')) }}" defer></script>
     </head>
     <body class="font-sans antialiased">
         @inertia

--- a/stubs/livewire/resources/views/layouts/app.blade.php
+++ b/stubs/livewire/resources/views/layouts/app.blade.php
@@ -11,12 +11,12 @@
         <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap">
 
         <!-- Styles -->
-        <link rel="stylesheet" href="{{ mix('css/app.css') }}">
+        <link rel="stylesheet" href="{{ url(mix('css/app.css')) }}">
 
         @livewireStyles
 
         <!-- Scripts -->
-        <script src="{{ mix('js/app.js') }}" defer></script>
+        <script src="{{ url(mix('js/app.js')) }}" defer></script>
     </head>
     <body class="font-sans antialiased">
         <x-jet-banner />

--- a/stubs/livewire/resources/views/layouts/guest.blade.php
+++ b/stubs/livewire/resources/views/layouts/guest.blade.php
@@ -11,10 +11,10 @@
         <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap">
 
         <!-- Styles -->
-        <link rel="stylesheet" href="{{ mix('css/app.css') }}">
+        <link rel="stylesheet" href="{{ url(mix('css/app.css')) }}">
 
         <!-- Scripts -->
-        <script src="{{ mix('js/app.js') }}" defer></script>
+        <script src="{{ url(mix('js/app.js')) }}" defer></script>
     </head>
     <body>
         <div class="font-sans text-gray-900 antialiased">


### PR DESCRIPTION
# Problem

When laravel is installed in a subdirectory (e.g. https://test.example.org/laravel), the javascript and css build files are not loaded in either the livewire or mix stack.

# Fix

It is required to wrap the calls for the ``mix()`` function in these templates, which returns links relative to laravel's base url, in laravel's native url-generating function ``url()``