### PR TITLE
Reduce amount of queries for Teams feature

### DIFF
--- a/src/Http/Middleware/ShareInertiaData.php
+++ b/src/Http/Middleware/ShareInertiaData.php
@@ -42,7 +42,9 @@ class ShareInertiaData
                 }
 
                 if (Jetstream::hasTeamFeatures() && $request->user()) {
-                    $request->user()->currentTeam;
+                    $request->user()->setRelation('currentTeam', $request->user()->allTeams()->filter(function ($team) use ($request) {
+                        return $team->id === $request->user()->current_team_id;
+                    })->first());
                 }
 
                 return array_merge($request->user()->toArray(), array_filter([


### PR DESCRIPTION
The inertia middleware which is used to share data to the frontend currently runs 3 queries to load all teams and the current team. 

1. Load all owned teams
2. Merge all other teams 
3. Load the currentTeam

However, this PR removes the last query since the currentTeam is one of the teams that's loaded in allTeams. This might just be a slight performance improvement! I hope it's worth merging into Jetstream.