### PR TITLE
[2.x] Add a tag dropdown link

### DIFF
--- a/stubs/inertia/resources/js/Jetstream/DropdownLink.vue
+++ b/stubs/inertia/resources/js/Jetstream/DropdownLink.vue
@@ -3,6 +3,10 @@
         <button type="submit" class="block w-full px-4 py-2 text-sm leading-5 text-gray-700 text-left hover:bg-gray-100 focus:outline-none focus:bg-gray-100 transition duration-150 ease-in-out" v-if="as == 'button'">
             <slot></slot>
         </button>
+        
+        <a :href="href" class="block px-4 py-2 text-sm leading-5 text-gray-700 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 transition duration-150 ease-in-out" v-else-if="as =='a'">
+            <slot></slot>
+        </a>
 
         <inertia-link :href="href" class="block px-4 py-2 text-sm leading-5 text-gray-700 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 transition duration-150 ease-in-out" v-else>
             <slot></slot>


### PR DESCRIPTION
PR adds `<a>` tag to the `<jet-dropdown-link>` component.

When adding spark billing, it would be cleaner to:
```html
<jet-dropdown-link as="a" :href="route('spark.portal')">
    Billing
</jet-dropdown-link>
```
compared to manually adding the tailwind classes to `<a>` to avoid inertia navigation.
```html
<a :href="route('spark.portal')" class="block px-4 py-2 text-sm leading-5 text-gray-700 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 transition duration-150 ease-in-out">
    Billing
</a>
```
Used `as="a"` to stay in line with `as="button"`