### PR TITLE
[2.x] Don't require autoprefixer

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -124,7 +124,6 @@ class InstallCommand extends Command
                 '@tailwindcss/forms' => '^0.2.1',
                 '@tailwindcss/typography' => '^0.3.0',
                 'alpinejs' => '^2.7.3',
-                'autoprefixer' => '^10.0.2',
                 'postcss-import' => '^12.0.1',
                 'tailwindcss' => '^2.0.1',
             ] + $packages;
@@ -275,7 +274,6 @@ EOF;
                 '@tailwindcss/typography' => '^0.3.0',
                 'postcss-import' => '^12.0.1',
                 'tailwindcss' => '^2.0.1',
-                'autoprefixer' => '^10.0.2',
                 'vue' => '^3.0.5',
                 '@vue/compiler-sfc' => '^3.0.5',
                 'vue-loader' => '^16.1.2',

--- a/stubs/inertia/webpack.mix.js
+++ b/stubs/inertia/webpack.mix.js
@@ -15,7 +15,6 @@ mix.js('resources/js/app.js', 'public/js').vue()
     .postCss('resources/css/app.css', 'public/css', [
         require('postcss-import'),
         require('tailwindcss'),
-        require('autoprefixer'),
     ])
     .webpackConfig(require('./webpack.config'));
 

--- a/stubs/livewire/webpack.mix.js
+++ b/stubs/livewire/webpack.mix.js
@@ -15,7 +15,6 @@ mix.js('resources/js/app.js', 'public/js')
     .postCss('resources/css/app.css', 'public/css', [
         require('postcss-import'),
         require('tailwindcss'),
-        require('autoprefixer'),
     ]);
 
 if (mix.inProduction()) {


### PR DESCRIPTION
Installing Jetstream requires `autoprefixer` in the `package.json` file, as well as requires it explicity in the `webpack.mix.js` file. 

However, I don't believe this is required.

[Laravel Mix will run CSS through Autoprefixer by default](https://laravel-mix.com/docs/6.0/autoprefixer), and as such it's not explicitly required in [Tailwind's Laravel installation page either](https://tailwindcss.com/docs/guides/laravel).

Removing this shouldn't affect the end build at all, just means we're not installing unnecessary boilerplate.
