### PR TITLE
[2.x] Button component href handling

### DIFF
--- a/resources/views/components/button.blade.php
+++ b/resources/views/components/button.blade.php
@@ -1,3 +1,9 @@
-<button {{ $attributes->merge(['type' => 'submit', 'class' => 'inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:shadow-outline-gray disabled:opacity-25 transition ease-in-out duration-150']) }}>
-    {{ $slot }}
-</button>
+@if($attributes->has('href'))
+    <a href="{{ $attributes->get('href') }}" {{ $attributes->merge(['class' => 'inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:shadow-outline-gray disabled:opacity-25 transition ease-in-out duration-150']) }}>
+        {{ $slot }}
+    </a>
+@else
+    <button {{ $attributes->merge(['type' => 'submit', 'class' => 'inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:shadow-outline-gray disabled:opacity-25 transition ease-in-out duration-150']) }}>
+        {{ $slot }}
+    </button>
+@endif

--- a/stubs/inertia/resources/js/Jetstream/Button.vue
+++ b/stubs/inertia/resources/js/Jetstream/Button.vue
@@ -1,5 +1,8 @@
 <template>
-    <button :type="type" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:shadow-outline-gray disabled:opacity-25 transition ease-in-out duration-150">
+    <a :href="href" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:shadow-outline-gray transition ease-in-out duration-150" v-if="href">
+        <slot></slot>
+    </a>
+    <button :type="type" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:shadow-outline-gray transition ease-in-out duration-150" v-else>
         <slot></slot>
     </button>
 </template>
@@ -11,6 +14,10 @@
                 type: String,
                 default: 'submit',
             },
+            href: {
+                type: String,
+                default: null
+            }
         }
     }
 </script>

--- a/stubs/inertia/resources/js/Jetstream/Button.vue
+++ b/stubs/inertia/resources/js/Jetstream/Button.vue
@@ -1,7 +1,10 @@
 <template>
-    <a :href="href" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:shadow-outline-gray transition ease-in-out duration-150" v-if="href">
+    <a :href="href" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:shadow-outline-gray transition ease-in-out duration-150" v-if="href && as == 'a'">
         <slot></slot>
     </a>
+    <inertia-link :href="href" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:shadow-outline-gray transition ease-in-out duration-150" v-else-if="href">
+        <slot></slot>
+    </inertia-link>
     <button :type="type" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:shadow-outline-gray transition ease-in-out duration-150" v-else>
         <slot></slot>
     </button>
@@ -14,6 +17,10 @@
                 type: String,
                 default: 'submit',
             },
+            as: {
+                type: String,
+                default: 'button'
+            }
             href: {
                 type: String,
                 default: null


### PR DESCRIPTION
PR adds `href` support to `<jet-button>` to allow using button style with links.

Prevents needing to create another button style definition.

```html
<jet-button :href="route('projects.create')">
    New
</jet-button>
```
Otherwise would need to duplicate the tailwind classes:
```html
<inertia-link :href="route('projects.create')" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:shadow-outline-gray transition ease-in-out duration-150">
    New
</inertia-link>
```

Also allows external links using the `as="a"` convention in `<jet-nav-link>`

```html
<jet-button :href="order.stripe_link" as="a">
    View Invoice
</jet-button>
```

<img width="858" alt="jetstream button" src="https://user-images.githubusercontent.com/29180903/111853335-f9d5d080-88f0-11eb-8bd9-ce0d842aecc5.png">