### PR TITLE
[2.x] Livewire - mobile menu transition

### DIFF
--- a/stubs/livewire/resources/views/navigation-menu.blade.php
+++ b/stubs/livewire/resources/views/navigation-menu.blade.php
@@ -136,7 +136,7 @@
     </div>
 
     <!-- Responsive Navigation Menu -->
-    <div :class="{'block': open, 'hidden': ! open}" class="hidden sm:hidden">
+    <div class="relative overflow-hidden transition-all duration-700 sm:hidden max-h-0" x-ref="responsiveNavMenu" x-bind:style="open ? 'max-height: ' + $refs.responsiveNavMenu.scrollHeight + 'px' : ''">
         <div class="pt-2 pb-3 space-y-1">
             <x-jet-responsive-nav-link href="{{ route('dashboard') }}" :active="request()->routeIs('dashboard')">
                 {{ __('Dashboard') }}


### PR DESCRIPTION
This PR is to add a slide-down transition when the responsive menu is expanding/collapsing.

![mobile-menu-transition](https://s4.gifyu.com/images/mobile-menu-transition.gif)
