### PR TITLE
correct the forgot-password route name

### DIFF
--- a/stubs/inertia/resources/js/Pages/Auth/ForgotPassword.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/ForgotPassword.vue
@@ -61,7 +61,7 @@
 
         methods: {
             submit() {
-                this.form.post(this.route('password.email'))
+                this.form.post(this.route('password.request'))
             }
         }
     }

--- a/stubs/livewire/resources/views/auth/forgot-password.blade.php
+++ b/stubs/livewire/resources/views/auth/forgot-password.blade.php
@@ -16,7 +16,7 @@
 
         <x-jet-validation-errors class="mb-4" />
 
-        <form method="POST" action="{{ route('password.email') }}">
+        <form method="POST" action="{{ route('password.request') }}">
             @csrf
 
             <div class="block">


### PR DESCRIPTION
This PR addresses this change in Laravel Fortify https://github.com/laravel/fortify/pull/240. If that PR in Fortify is accepted, it means this route name: (password.email) will no longer exist and Jetstream should be updated as well.

Briefly, Fortify for GET request to forgot-password route has already a name, and we can use the same route name for the POST request.

Best Regards,

Hamed Panjeh,
panjeh at gmail.com