### PR TITLE
Added "SwitchTeam" action - Allows to modify behaviour if user switches team.

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -447,6 +447,7 @@ EOF;
         copy(__DIR__.'/../../stubs/app/Actions/Jetstream/InviteTeamMember.php', app_path('Actions/Jetstream/InviteTeamMember.php'));
         copy(__DIR__.'/../../stubs/app/Actions/Jetstream/RemoveTeamMember.php', app_path('Actions/Jetstream/RemoveTeamMember.php'));
         copy(__DIR__.'/../../stubs/app/Actions/Jetstream/UpdateTeamName.php', app_path('Actions/Jetstream/UpdateTeamName.php'));
+        copy(__DIR__.'/../../stubs/app/Actions/Jetstream/SwitchTeam.php', app_path('Actions/Jetstream/SwitchTeam.php'));
 
         copy(__DIR__.'/../../stubs/app/Actions/Fortify/CreateNewUserWithTeams.php', app_path('Actions/Fortify/CreateNewUser.php'));
 

--- a/src/Contracts/SwitchesTeams.php
+++ b/src/Contracts/SwitchesTeams.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Laravel\Jetstream\Contracts;
+
+interface SwitchesTeams
+{
+    /**
+     * @param mixed $user
+     * @param int   $teamId
+     *
+     * @return mixed
+     */
+    public function switch($user, int $teamId);
+}

--- a/src/Http/Controllers/CurrentTeamController.php
+++ b/src/Http/Controllers/CurrentTeamController.php
@@ -8,7 +8,6 @@ use Laravel\Jetstream\Contracts\SwitchesTeams;
 
 class CurrentTeamController extends Controller
 {
-
     /**
      * Switches the authenticated user's current team.
      *

--- a/src/Http/Controllers/CurrentTeamController.php
+++ b/src/Http/Controllers/CurrentTeamController.php
@@ -4,24 +4,21 @@ namespace Laravel\Jetstream\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
-use Laravel\Jetstream\Jetstream;
+use Laravel\Jetstream\Contracts\SwitchesTeams;
 
 class CurrentTeamController extends Controller
 {
+
     /**
-     * Update the authenticated user's current team.
+     * Switches the authenticated user's current team.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param \Illuminate\Http\Request                   $request
+     * @param \Laravel\Jetstream\Contracts\SwitchesTeams $creator
+     *
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function update(Request $request)
+    public function update(Request $request, SwitchesTeams $creator)
     {
-        $team = Jetstream::newTeamModel()->findOrFail($request->team_id);
-
-        if (! $request->user()->switchTeam($team)) {
-            abort(403);
-        }
-
-        return redirect(config('fortify.home'), 303);
+        return $creator->switch($request->user(), $request->team_id);
     }
 }

--- a/src/Jetstream.php
+++ b/src/Jetstream.php
@@ -9,6 +9,7 @@ use Laravel\Jetstream\Contracts\DeletesTeams;
 use Laravel\Jetstream\Contracts\DeletesUsers;
 use Laravel\Jetstream\Contracts\InvitesTeamMembers;
 use Laravel\Jetstream\Contracts\RemovesTeamMembers;
+use Laravel\Jetstream\Contracts\SwitchesTeams;
 use Laravel\Jetstream\Contracts\UpdatesTeamNames;
 
 class Jetstream
@@ -428,6 +429,17 @@ class Jetstream
     public static function deleteUsersUsing(string $class)
     {
         return app()->singleton(DeletesUsers::class, $class);
+    }
+
+    /**
+     * Register a class / callback that should be used to switch user's team.
+     *
+     * @param  string  $class
+     * @return void
+     */
+    public static function switchTeamUsing(string $class)
+    {
+        return app()->singleton(SwitchesTeams::class, $class);
     }
 
     /**

--- a/src/JetstreamServiceProvider.php
+++ b/src/JetstreamServiceProvider.php
@@ -186,6 +186,10 @@ class JetstreamServiceProvider extends ServiceProvider
             __DIR__.'/../stubs/inertia/resources/js/Jetstream/Checkbox.vue' => resource_path('js/Jetstream/Checkbox.vue'),
             __DIR__.'/../stubs/inertia/resources/js/Jetstream/ValidationErrors.vue' => resource_path('js/Jetstream/ValidationErrors.vue'),
         ], 'jetstream-inertia-auth-pages');
+
+        $this->publishes([
+            __DIR__.'/../stubs/app/Actions/Jetstream/SwitchTeam.php' => base_path('app/Actions/Jetstream/SwitchTeam.php'),
+        ], 'jetstream-actions');
     }
 
     /**

--- a/stubs/app/Actions/Jetstream/SwitchTeam.php
+++ b/stubs/app/Actions/Jetstream/SwitchTeam.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Actions\Jetstream;
+
+use Laravel\Jetstream\Contracts\SwitchesTeams;
+use Laravel\Jetstream\Jetstream;
+
+class SwitchTeam implements SwitchesTeams
+{
+    /**
+     * Switch to selected team
+     *
+     * @param mixed $user
+     * @param int   $teamId
+     *
+     * @return mixed
+     */
+    public function switch($user, int $teamId)
+    {
+        $team = Jetstream::newTeamModel()->findOrFail($teamId);
+
+        if (!$user->switchTeam($team)) {
+            abort(403);
+        }
+
+        return redirect(config('fortify.home'), 303);
+    }
+}

--- a/stubs/app/Actions/Jetstream/SwitchTeam.php
+++ b/stubs/app/Actions/Jetstream/SwitchTeam.php
@@ -8,10 +8,10 @@ use Laravel\Jetstream\Jetstream;
 class SwitchTeam implements SwitchesTeams
 {
     /**
-     * Switch to selected team
+     * Switch to selected team.
      *
-     * @param mixed $user
-     * @param int   $teamId
+     * @param  mixed  $user
+     * @param  int  $teamId
      *
      * @return mixed
      */
@@ -19,7 +19,7 @@ class SwitchTeam implements SwitchesTeams
     {
         $team = Jetstream::newTeamModel()->findOrFail($teamId);
 
-        if (!$user->switchTeam($team)) {
+        if (! $user->switchTeam($team)) {
             abort(403);
         }
 

--- a/stubs/app/Providers/JetstreamWithTeamsServiceProvider.php
+++ b/stubs/app/Providers/JetstreamWithTeamsServiceProvider.php
@@ -8,6 +8,7 @@ use App\Actions\Jetstream\DeleteTeam;
 use App\Actions\Jetstream\DeleteUser;
 use App\Actions\Jetstream\InviteTeamMember;
 use App\Actions\Jetstream\RemoveTeamMember;
+use App\Actions\Jetstream\SwitchTeam;
 use App\Actions\Jetstream\UpdateTeamName;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Jetstream\Jetstream;
@@ -34,6 +35,7 @@ class JetstreamServiceProvider extends ServiceProvider
         $this->configurePermissions();
 
         Jetstream::createTeamsUsing(CreateTeam::class);
+        Jetstream::switchTeamUsing(SwitchTeam::class);
         Jetstream::updateTeamNamesUsing(UpdateTeamName::class);
         Jetstream::addTeamMembersUsing(AddTeamMember::class);
         Jetstream::inviteTeamMembersUsing(InviteTeamMember::class);


### PR DESCRIPTION
**PR "SwitchTeam" Jetstream/Action**

This PR allows developers to change the "team switch" implementation in their app by modifying `app/Actions/Jetstream/SwitchTeam.php`. 

A team switch could be triggerd by the user by selecting a Team in the Teams dropdown.

_Usecase 1:_ Redirect to the team's landing page after the user switched the team.
_Usecase 2:_ Show the form of the team, if some required informations for the Team are missing from the user.

The feature is available in new Jetstream installations automatically without any required modification.

For exising projects, a simple migration path is explained below. 

Following a short example.

**Example for the "SwitchTeam" Jetstream/Action**

Redirect to the route "teams.show" of the selected team.

```
// app/Actions/Jetstream/SwitchTeam.php
public function switch($user, int $teamId)
{
    // Get team by id, switch user's current team, than redirect.

    return redirect(route('teams.show', $team));
}
```
**Migration path - Existing Jetstream Projects**

1.) artisan: Publish "jetstream-actions" with artisan command

`php artisan vendor:publish --tag=jetstream-actions`

2.) Manually update JetstreamServiceProvider, add Jetstream::switchTeamUsing()

```
// app/Providers/JetstreamServiceProvider.php - boot()
Jetstream::switchTeamUsing(SwitchTeam::class);
```

**Troubleshooting**

Problem: Error message "`Target [Laravel\Jetstream\Contracts\SwitchesTeams] is not instantiable.`"

Solution: This occurs in existing Jetstream installations only. The Jetstream::switchTeamUsing(SwitchTeam::class) line is missing in the JetstreamServiceProvider. (See "Migration path")


