### PR TITLE
Remove redundant usage of `tap()` helper

### DIFF
--- a/src/HasProfilePhoto.php
+++ b/src/HasProfilePhoto.php
@@ -16,17 +16,15 @@ trait HasProfilePhoto
      */
     public function updateProfilePhoto(UploadedFile $photo)
     {
-        tap($this->profile_photo_path, function ($previous) use ($photo) {
-            $this->forceFill([
-                'profile_photo_path' => $photo->storePublicly(
-                    'profile-photos', ['disk' => $this->profilePhotoDisk()]
-                ),
-            ])->save();
+        $this->forceFill([
+            'profile_photo_path' => $photo->storePublicly(
+                'profile-photos', ['disk' => $this->profilePhotoDisk()]
+            ),
+        ])->save();
 
-            if ($previous) {
-                Storage::disk($this->profilePhotoDisk())->delete($previous);
-            }
-        });
+        if ($this->profile_photo_path) {
+            Storage::disk($this->profilePhotoDisk())->delete($this->profile_photo_path);
+        }
     }
 
     /**


### PR DESCRIPTION
Just a cleanup, came across it in a project and thought I'd help out :) 