### PR TITLE
[2.x] Load modal slot on show

### DIFF
--- a/stubs/inertia/resources/js/Jetstream/Modal.vue
+++ b/stubs/inertia/resources/js/Jetstream/Modal.vue
@@ -20,7 +20,7 @@
                         leave-from-class="opacity-100 translate-y-0 sm:scale-100"
                         leave-to-class="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95">
                     <div v-show="show" class="mb-6 bg-white rounded-lg overflow-hidden shadow-xl transform transition-all sm:w-full sm:mx-auto" :class="maxWidthClass">
-                        <slot></slot>
+                        <slot v-if="show"></slot>
                     </div>
                 </transition>
             </div>


### PR DESCRIPTION
**Problem:**

Components within modals render when `<jet-modal :show="false">` currently.

**Effects:** 

- modals with components that request data on mount.. fires on page load
- modals with forms partially completed, closed, reopened.. not fresh form

**Solution:**

Adding `v-if` to the `<slot>` insures the the `v-show` still transitions but slot contents render each `open`