### PR TITLE
[2.x] Add scroll-region to modal

### DIFF
--- a/stubs/inertia/resources/js/Jetstream/Modal.vue
+++ b/stubs/inertia/resources/js/Jetstream/Modal.vue
@@ -1,7 +1,7 @@
 <template>
     <teleport to="body">
         <transition leave-active-class="duration-200">
-            <div v-show="show" class="fixed inset-0 overflow-y-auto px-4 py-6 sm:px-0 z-50">
+            <div v-show="show" class="fixed inset-0 overflow-y-auto px-4 py-6 sm:px-0 z-50" scroll-region>
                 <transition enter-active-class="ease-out duration-300"
                         enter-from-class="opacity-0"
                         enter-to-class="opacity-100"


### PR DESCRIPTION
Modals with inertia forms that `preserveScroll: false` won't scroll top on error without `scroll-region`

Docs: https://inertiajs.com/scroll-management#scroll-regions