### PR TITLE
Request namespace may also need to be imported

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -98,8 +98,8 @@ Jetstream 2.0's Inertia stack uses Vue based authentication pages. In order to u
 Or, if you wish to to continue to render your Blade based authentication views in Jetstream 2.x, you should add the following code to the `boot` method of your application's `JetstreamServiceProvider` class:
 
 ```php
-use Illuminate\Support\Facades\Route;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
 use Laravel\Fortify\Fortify;
 
 Fortify::loginView(function () {

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -99,6 +99,7 @@ Or, if you wish to to continue to render your Blade based authentication views i
 
 ```php
 use Illuminate\Support\Facades\Route;
+use Illuminate\Http\Request;
 use Laravel\Fortify\Fortify;
 
 Fortify::loginView(function () {


### PR DESCRIPTION
Just noticed a missing namespace on the upgrade guide