### PR TITLE
[2.x] Get team and user by their ID when using team feature

### DIFF
--- a/src/HasTeams.php
+++ b/src/HasTeams.php
@@ -228,7 +228,8 @@ trait HasTeams
      * @param  mixed  $team
      * @return void
      */
-    private function getTeamById(&$team) {
+    private function getTeamById(&$team)
+    {
         if (is_int($team)) {
             $team = Jetstream::teamModel()::find($team);
         }

--- a/src/Team.php
+++ b/src/Team.php
@@ -1,140 +1,141 @@
 <?php
 
-    namespace Laravel\Jetstream;
+namespace Laravel\Jetstream;
 
-    use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Model;
 
-    abstract class Team extends Model
+abstract class Team extends Model
+{
+    /**
+     * Get the owner of the team.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function owner()
     {
-        /**
-         * Get the owner of the team.
-         *
-         * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
-         */
-        public function owner()
-        {
-            return $this->belongsTo(Jetstream::userModel(), 'user_id');
+        return $this->belongsTo(Jetstream::userModel(), 'user_id');
+    }
+
+    /**
+     * Get all of the team's users including its owner.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function allUsers()
+    {
+        return $this->users->merge([$this->owner]);
+    }
+
+    /**
+     * Get all of the users that belong to the team.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     */
+    public function users()
+    {
+        return $this->belongsToMany(Jetstream::userModel(), Jetstream::membershipModel())
+            ->withPivot('role')
+            ->withTimestamps()
+            ->as('membership');
+    }
+
+    /**
+     * Determine if the given user belongs to the team.
+     *
+     * @param  \App\Models\User|int  $user
+     * @return bool
+     */
+    public function hasUser($user)
+    {
+        $this->getUserById($user);
+
+        return $this->users->contains($user) || $user->ownsTeam($this);
+    }
+
+    /**
+     * Determine if the given email address belongs to a user on the team.
+     *
+     * @param  string  $email
+     * @return bool
+     */
+    public function hasUserWithEmail(string $email)
+    {
+        return $this->allUsers()->contains(function ($user) use ($email) {
+            return $user->email === $email;
+        });
+    }
+
+    /**
+     * Determine if the given user has the given permission on the team.
+     *
+     * @param  \App\Models\User|int  $user
+     * @param  string  $permission
+     * @return bool
+     */
+    public function userHasPermission($user, $permission)
+    {
+        $this->getUserById($user);
+
+        return $user->hasTeamPermission($this, $permission);
+    }
+
+    /**
+     * Get all of the pending user invitations for the team.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function teamInvitations()
+    {
+        return $this->hasMany(Jetstream::teamInvitationModel());
+    }
+
+    /**
+     * Remove the given user from the team.
+     *
+     * @param  \App\Models\User|int  $user
+     * @return void
+     */
+    public function removeUser($user)
+    {
+        $this->getUserById($user);
+
+        if ($user->current_team_id === $this->id) {
+            $user->forceFill([
+                'current_team_id' => null,
+            ])->save();
         }
 
-        /**
-         * Get all of the team's users including its owner.
-         *
-         * @return \Illuminate\Support\Collection
-         */
-        public function allUsers()
-        {
-            return $this->users->merge([$this->owner]);
-        }
+        $this->users()->detach($user);
+    }
 
-        /**
-         * Get all of the users that belong to the team.
-         *
-         * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
-         */
-        public function users()
-        {
-            return $this->belongsToMany(Jetstream::userModel(), Jetstream::membershipModel())
-                ->withPivot('role')
-                ->withTimestamps()
-                ->as('membership');
-        }
+    /**
+     * Purge all of the team's resources.
+     *
+     * @return void
+     */
+    public function purge()
+    {
+        $this->owner()->where('current_team_id', $this->id)
+            ->update(['current_team_id' => null]);
 
-        /**
-         * Determine if the given user belongs to the team.
-         *
-         * @param  \App\Models\User|int  $user
-         * @return bool
-         */
-        public function hasUser($user)
-        {
-            $this->getUserById($user);
+        $this->users()->where('current_team_id', $this->id)
+            ->update(['current_team_id' => null]);
 
-            return $this->users->contains($user) || $user->ownsTeam($this);
-        }
+        $this->users()->detach();
 
-        /**
-         * Determine if the given email address belongs to a user on the team.
-         *
-         * @param  string  $email
-         * @return bool
-         */
-        public function hasUserWithEmail(string $email)
-        {
-            return $this->allUsers()->contains(function ($user) use ($email) {
-                return $user->email === $email;
-            });
-        }
+        $this->delete();
+    }
 
-        /**
-         * Determine if the given user has the given permission on the team.
-         *
-         * @param  \App\Models\User|int  $user
-         * @param  string  $permission
-         * @return bool
-         */
-        public function userHasPermission($user, $permission)
-        {
-            $this->getUserById($user);
-
-            return $user->hasTeamPermission($this, $permission);
-        }
-
-        /**
-         * Get all of the pending user invitations for the team.
-         *
-         * @return \Illuminate\Database\Eloquent\Relations\HasMany
-         */
-        public function teamInvitations()
-        {
-            return $this->hasMany(Jetstream::teamInvitationModel());
-        }
-
-        /**
-         * Remove the given user from the team.
-         *
-         * @param  \App\Models\User|int  $user
-         * @return void
-         */
-        public function removeUser($user)
-        {
-            $this->getUserById($user);
-
-            if ($user->current_team_id === $this->id) {
-                $user->forceFill([
-                    'current_team_id' => null,
-                ])->save();
-            }
-
-            $this->users()->detach($user);
-        }
-
-        /**
-         * Purge all of the team's resources.
-         *
-         * @return void
-         */
-        public function purge()
-        {
-            $this->owner()->where('current_team_id', $this->id)
-                ->update(['current_team_id' => null]);
-
-            $this->users()->where('current_team_id', $this->id)
-                ->update(['current_team_id' => null]);
-
-            $this->users()->detach();
-
-            $this->delete();
-        }
-
-        /**
-         * Retrieves the user model if the ID is provided.
-         *
-         * @param  \App\Models\User|int  $user
-         * @return void
-         */
-        private function getUserById(&$user) {
-            if (is_int($user)) {
-                $user = Jetstream::userModel()::find($user);
-            }
+    /**
+     * Retrieves the user model if the ID is provided.
+     *
+     * @param  \App\Models\User|int  $user
+     * @return void
+     */
+    private function getUserById(&$user)
+    {
+        if (is_int($user)) {
+            $user = Jetstream::userModel()::find($user);
         }
     }
+}

--- a/src/Team.php
+++ b/src/Team.php
@@ -1,122 +1,140 @@
 <?php
 
-namespace Laravel\Jetstream;
+    namespace Laravel\Jetstream;
 
-use Illuminate\Database\Eloquent\Model;
+    use Illuminate\Database\Eloquent\Model;
 
-abstract class Team extends Model
-{
-    /**
-     * Get the owner of the team.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
-     */
-    public function owner()
+    abstract class Team extends Model
     {
-        return $this->belongsTo(Jetstream::userModel(), 'user_id');
-    }
-
-    /**
-     * Get all of the team's users including its owner.
-     *
-     * @return \Illuminate\Support\Collection
-     */
-    public function allUsers()
-    {
-        return $this->users->merge([$this->owner]);
-    }
-
-    /**
-     * Get all of the users that belong to the team.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
-     */
-    public function users()
-    {
-        return $this->belongsToMany(Jetstream::userModel(), Jetstream::membershipModel())
-                        ->withPivot('role')
-                        ->withTimestamps()
-                        ->as('membership');
-    }
-
-    /**
-     * Determine if the given user belongs to the team.
-     *
-     * @param  \App\Models\User  $user
-     * @return bool
-     */
-    public function hasUser($user)
-    {
-        return $this->users->contains($user) || $user->ownsTeam($this);
-    }
-
-    /**
-     * Determine if the given email address belongs to a user on the team.
-     *
-     * @param  string  $email
-     * @return bool
-     */
-    public function hasUserWithEmail(string $email)
-    {
-        return $this->allUsers()->contains(function ($user) use ($email) {
-            return $user->email === $email;
-        });
-    }
-
-    /**
-     * Determine if the given user has the given permission on the team.
-     *
-     * @param  \App\Models\User  $user
-     * @param  string  $permission
-     * @return bool
-     */
-    public function userHasPermission($user, $permission)
-    {
-        return $user->hasTeamPermission($this, $permission);
-    }
-
-    /**
-     * Get all of the pending user invitations for the team.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
-     */
-    public function teamInvitations()
-    {
-        return $this->hasMany(Jetstream::teamInvitationModel());
-    }
-
-    /**
-     * Remove the given user from the team.
-     *
-     * @param  \App\Models\User  $user
-     * @return void
-     */
-    public function removeUser($user)
-    {
-        if ($user->current_team_id === $this->id) {
-            $user->forceFill([
-                'current_team_id' => null,
-            ])->save();
+        /**
+         * Get the owner of the team.
+         *
+         * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+         */
+        public function owner()
+        {
+            return $this->belongsTo(Jetstream::userModel(), 'user_id');
         }
 
-        $this->users()->detach($user);
-    }
+        /**
+         * Get all of the team's users including its owner.
+         *
+         * @return \Illuminate\Support\Collection
+         */
+        public function allUsers()
+        {
+            return $this->users->merge([$this->owner]);
+        }
 
-    /**
-     * Purge all of the team's resources.
-     *
-     * @return void
-     */
-    public function purge()
-    {
-        $this->owner()->where('current_team_id', $this->id)
+        /**
+         * Get all of the users that belong to the team.
+         *
+         * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+         */
+        public function users()
+        {
+            return $this->belongsToMany(Jetstream::userModel(), Jetstream::membershipModel())
+                ->withPivot('role')
+                ->withTimestamps()
+                ->as('membership');
+        }
+
+        /**
+         * Determine if the given user belongs to the team.
+         *
+         * @param  \App\Models\User|int  $user
+         * @return bool
+         */
+        public function hasUser($user)
+        {
+            $this->getUserById($user);
+
+            return $this->users->contains($user) || $user->ownsTeam($this);
+        }
+
+        /**
+         * Determine if the given email address belongs to a user on the team.
+         *
+         * @param  string  $email
+         * @return bool
+         */
+        public function hasUserWithEmail(string $email)
+        {
+            return $this->allUsers()->contains(function ($user) use ($email) {
+                return $user->email === $email;
+            });
+        }
+
+        /**
+         * Determine if the given user has the given permission on the team.
+         *
+         * @param  \App\Models\User|int  $user
+         * @param  string  $permission
+         * @return bool
+         */
+        public function userHasPermission($user, $permission)
+        {
+            $this->getUserById($user);
+
+            return $user->hasTeamPermission($this, $permission);
+        }
+
+        /**
+         * Get all of the pending user invitations for the team.
+         *
+         * @return \Illuminate\Database\Eloquent\Relations\HasMany
+         */
+        public function teamInvitations()
+        {
+            return $this->hasMany(Jetstream::teamInvitationModel());
+        }
+
+        /**
+         * Remove the given user from the team.
+         *
+         * @param  \App\Models\User|int  $user
+         * @return void
+         */
+        public function removeUser($user)
+        {
+            $this->getUserById($user);
+
+            if ($user->current_team_id === $this->id) {
+                $user->forceFill([
+                    'current_team_id' => null,
+                ])->save();
+            }
+
+            $this->users()->detach($user);
+        }
+
+        /**
+         * Purge all of the team's resources.
+         *
+         * @return void
+         */
+        public function purge()
+        {
+            $this->owner()->where('current_team_id', $this->id)
                 ->update(['current_team_id' => null]);
 
-        $this->users()->where('current_team_id', $this->id)
+            $this->users()->where('current_team_id', $this->id)
                 ->update(['current_team_id' => null]);
 
-        $this->users()->detach();
+            $this->users()->detach();
 
-        $this->delete();
+            $this->delete();
+        }
+
+        /**
+         * Retrieves the user model if the ID is provided.
+         *
+         * @param  \App\Models\User|int  $user
+         * @return void
+         */
+        private function getUserById(&$user) {
+            if (is_int($user)) {
+                $user = Jetstream::userModel()::find($user);
+            }
+        }
     }
-}


### PR DESCRIPTION
One of the things I most love about Laravel is the fact that when operating with models you can usually provide the model object or its ID and Laravel does all the magic.

Working with Livewire, it may be really common the interaction with another model's ID instead of the whole model.

I've implemented two private methods that may increase the DX by searching automatically the User or the Team model when trying to interact with each other.

Tell me if this PR needs a bit of work on it or it will work just like this.

### Likely Improvements

I haven't spent too much time checking the existence of the model because I've seen that the code already relies on the developer, but if needed it may be adjusted by replacing the `find()` with the `findOrFail()` one.