### PR TITLE
[2.x] Add section title aside slot 

### DIFF
--- a/resources/views/components/section-title.blade.php
+++ b/resources/views/components/section-title.blade.php
@@ -1,9 +1,12 @@
-<div class="md:col-span-1">
+<div class="md:col-span-1 flex justify-between">
     <div class="px-4 sm:px-0">
         <h3 class="text-lg font-medium text-gray-900">{{ $title }}</h3>
 
         <p class="mt-1 text-sm text-gray-600">
             {{ $description }}
         </p>
+    </div>
+    <div class="px-4 sm:px-0">
+        {{ $aside ?? '' }}
     </div>
 </div>

--- a/resources/views/components/section-title.blade.php
+++ b/resources/views/components/section-title.blade.php
@@ -6,6 +6,7 @@
             {{ $description }}
         </p>
     </div>
+
     <div class="px-4 sm:px-0">
         {{ $aside ?? '' }}
     </div>

--- a/stubs/inertia/resources/js/Jetstream/SectionTitle.vue
+++ b/stubs/inertia/resources/js/Jetstream/SectionTitle.vue
@@ -9,6 +9,7 @@
                 <slot name="description"></slot>
             </p>
         </div>
+
         <div class="px-4 sm:px-0">
             <slot name="aside"></slot>
         </div>

--- a/stubs/inertia/resources/js/Jetstream/SectionTitle.vue
+++ b/stubs/inertia/resources/js/Jetstream/SectionTitle.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="md:col-span-1">
+    <div class="md:col-span-1 flex justify-between">
         <div class="px-4 sm:px-0">
             <h3 class="text-lg font-medium text-gray-900">
                 <slot name="title"></slot>
@@ -8,6 +8,9 @@
             <p class="mt-1 text-sm text-gray-600">
                 <slot name="description"></slot>
             </p>
+        </div>
+        <div class="px-4 sm:px-0">
+            <slot name="aside"></slot>
         </div>
     </div>
 </template>


### PR DESCRIPTION
PR allows content in the top right of the `jet-section-title` component

Got inspiration from [Laravel Vapor's UI](https://vapor.laravel.com/#:~:text=Multiple%20Environments) & found it very useful as a default

I referred to it as `aside` incase anyone moves the slot to the left for RTL

---

<img width="1166" alt="Screen Shot 2021-03-24 at 9 40 20 PM" src="https://user-images.githubusercontent.com/29180903/112405905-89acbd80-8ce9-11eb-96ac-7360a0537037.png">

<img width="1166" alt="Screen Shot 2021-03-24 at 9 46 54 PM" src="https://user-images.githubusercontent.com/29180903/112406397-751cf500-8cea-11eb-9fdf-476488c8fc65.png">

<img width="1123" alt="Screen Shot 2021-03-24 at 11 17 20 PM" src="https://user-images.githubusercontent.com/29180903/112413747-1c078e00-8cf7-11eb-9eec-c4b8fb298f2d.png">

Works nicely with / without, mobile, `jet-button`, `jet-dropdown` & `form-select`

---

Vue

```html
<jet-section-title class="mb-5">
    <template #title>Posts</template>
    <template #description>Here are the posts</template>
    <template #aside>
        <jet-secondary-button @click="$inertia.visit(route('posts.create'))">
            New Post
        </jet-secondary-button>
    </template>
</jet-section-title>
```

Livewire

```html
<x-jet-section-title>
    <x-slot name="title">Posts</x-slot>
    <x-slot name="description">Here are the posts</x-slot>
    <x-slot name="aside">
        <x-jet-secondary-button>
            Create Post
        </x-jet-secondary-button>
    </x-slot>
</x-jet-section-title>
```