### PR TITLE
Enhance tests

### DIFF
--- a/stubs/tests/inertia/DeleteAccountTest.php
+++ b/stubs/tests/inertia/DeleteAccountTest.php
@@ -17,7 +17,10 @@ class DeleteAccountTest extends TestCase
             return $this->markTestSkipped('Account deletion is not enabled.');
         }
 
-        $this->actingAs($user = User::factory()->create());
+        $user = Features::hasTeamFeatures()
+                ? User::factory()->withPersonalTeam()->create()
+                : User::factory()->create();
+        $this->actingAs($user);
 
         $response = $this->delete('/user', [
             'password' => 'password',
@@ -32,7 +35,10 @@ class DeleteAccountTest extends TestCase
             return $this->markTestSkipped('Account deletion is not enabled.');
         }
 
-        $this->actingAs($user = User::factory()->create());
+        $user = Features::hasTeamFeatures()
+                ? User::factory()->withPersonalTeam()->create()
+                : User::factory()->create();
+        $this->actingAs($user);
 
         $response = $this->delete('/user', [
             'password' => 'wrong-password',

--- a/stubs/tests/inertia/LeaveTeamTest.php
+++ b/stubs/tests/inertia/LeaveTeamTest.php
@@ -15,7 +15,7 @@ class LeaveTeamTest extends TestCase
         $user = User::factory()->withPersonalTeam()->create();
 
         $user->currentTeam->users()->attach(
-            $otherUser = User::factory()->create(), ['role' => 'admin']
+            $otherUser = User::factory()->withPersonalTeam()->create(), ['role' => 'admin']
         );
 
         $this->actingAs($otherUser);

--- a/stubs/tests/inertia/ProfileInformationTest.php
+++ b/stubs/tests/inertia/ProfileInformationTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Jetstream\Features;
 use Tests\TestCase;
 
 class ProfileInformationTest extends TestCase
@@ -12,7 +13,10 @@ class ProfileInformationTest extends TestCase
 
     public function test_profile_information_can_be_updated()
     {
-        $this->actingAs($user = User::factory()->create());
+        $user = Features::hasTeamFeatures()
+                ? User::factory()->withPersonalTeam()->create()
+                : User::factory()->create();
+        $this->actingAs($user);
 
         $response = $this->put('/user/profile-information', [
             'name' => 'Test Name',

--- a/stubs/tests/inertia/RemoveTeamMemberTest.php
+++ b/stubs/tests/inertia/RemoveTeamMemberTest.php
@@ -15,7 +15,7 @@ class RemoveTeamMemberTest extends TestCase
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $user->currentTeam->users()->attach(
-            $otherUser = User::factory()->create(), ['role' => 'admin']
+            $otherUser = User::factory()->withPersonalTeam()->create(), ['role' => 'admin']
         );
 
         $response = $this->delete('/teams/'.$user->currentTeam->id.'/members/'.$otherUser->id);
@@ -28,7 +28,7 @@ class RemoveTeamMemberTest extends TestCase
         $user = User::factory()->withPersonalTeam()->create();
 
         $user->currentTeam->users()->attach(
-            $otherUser = User::factory()->create(), ['role' => 'admin']
+            $otherUser = User::factory()->withPersonalTeam()->create(), ['role' => 'admin']
         );
 
         $this->actingAs($otherUser);

--- a/stubs/tests/inertia/TwoFactorAuthenticationSettingsTest.php
+++ b/stubs/tests/inertia/TwoFactorAuthenticationSettingsTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Jetstream\Features;
 use Tests\TestCase;
 
 class TwoFactorAuthenticationSettingsTest extends TestCase
@@ -12,7 +13,10 @@ class TwoFactorAuthenticationSettingsTest extends TestCase
 
     public function test_two_factor_authentication_can_be_enabled()
     {
-        $this->actingAs($user = User::factory()->create());
+        $user = Features::hasTeamFeatures()
+                ? User::factory()->withPersonalTeam()->create()
+                : User::factory()->create();
+        $this->actingAs($user);
 
         $this->withSession(['auth.password_confirmed_at' => time()]);
 
@@ -24,7 +28,10 @@ class TwoFactorAuthenticationSettingsTest extends TestCase
 
     public function test_recovery_codes_can_be_regenerated()
     {
-        $this->actingAs($user = User::factory()->create());
+        $user = Features::hasTeamFeatures()
+                ? User::factory()->withPersonalTeam()->create()
+                : User::factory()->create();
+        $this->actingAs($user);
 
         $this->withSession(['auth.password_confirmed_at' => time()]);
 
@@ -41,7 +48,10 @@ class TwoFactorAuthenticationSettingsTest extends TestCase
 
     public function test_two_factor_authentication_can_be_disabled()
     {
-        $this->actingAs($user = User::factory()->create());
+        $user = Features::hasTeamFeatures()
+                ? User::factory()->withPersonalTeam()->create()
+                : User::factory()->create();
+        $this->actingAs($user);
 
         $this->withSession(['auth.password_confirmed_at' => time()]);
 

--- a/stubs/tests/inertia/UpdatePasswordTest.php
+++ b/stubs/tests/inertia/UpdatePasswordTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Hash;
+use Laravel\Jetstream\Features;
 use Tests\TestCase;
 
 class UpdatePasswordTest extends TestCase
@@ -13,7 +14,10 @@ class UpdatePasswordTest extends TestCase
 
     public function test_password_can_be_updated()
     {
-        $this->actingAs($user = User::factory()->create());
+        $user = Features::hasTeamFeatures()
+            ? User::factory()->withPersonalTeam()->create()
+            : User::factory()->create();
+        $this->actingAs($user);
 
         $response = $this->put('/user/password', [
             'current_password' => 'password',
@@ -26,7 +30,10 @@ class UpdatePasswordTest extends TestCase
 
     public function test_current_password_must_be_correct()
     {
-        $this->actingAs($user = User::factory()->create());
+        $user = Features::hasTeamFeatures()
+            ? User::factory()->withPersonalTeam()->create()
+            : User::factory()->create();
+        $this->actingAs($user);
 
         $response = $this->put('/user/password', [
             'current_password' => 'wrong-password',
@@ -41,7 +48,10 @@ class UpdatePasswordTest extends TestCase
 
     public function test_new_passwords_must_match()
     {
-        $this->actingAs($user = User::factory()->create());
+        $user = Features::hasTeamFeatures()
+            ? User::factory()->withPersonalTeam()->create()
+            : User::factory()->create();
+        $this->actingAs($user);
 
         $response = $this->put('/user/password', [
             'current_password' => 'password',

--- a/stubs/tests/livewire/DeleteAccountTest.php
+++ b/stubs/tests/livewire/DeleteAccountTest.php
@@ -19,7 +19,10 @@ class DeleteAccountTest extends TestCase
             return $this->markTestSkipped('Account deletion is not enabled.');
         }
 
-        $this->actingAs($user = User::factory()->create());
+        $user = Features::hasTeamFeatures()
+                ? User::factory()->withPersonalTeam()->create()
+                : User::factory()->create();
+        $this->actingAs($user);
 
         $component = Livewire::test(DeleteUserForm::class)
                         ->set('password', 'password')
@@ -34,7 +37,10 @@ class DeleteAccountTest extends TestCase
             return $this->markTestSkipped('Account deletion is not enabled.');
         }
 
-        $this->actingAs($user = User::factory()->create());
+        $user = Features::hasTeamFeatures()
+                ? User::factory()->withPersonalTeam()->create()
+                : User::factory()->create();
+        $this->actingAs($user);
 
         Livewire::test(DeleteUserForm::class)
                         ->set('password', 'wrong-password')

--- a/stubs/tests/livewire/LeaveTeamTest.php
+++ b/stubs/tests/livewire/LeaveTeamTest.php
@@ -17,7 +17,7 @@ class LeaveTeamTest extends TestCase
         $user = User::factory()->withPersonalTeam()->create();
 
         $user->currentTeam->users()->attach(
-            $otherUser = User::factory()->create(), ['role' => 'admin']
+            $otherUser = User::factory()->withPersonalTeam()->create(), ['role' => 'admin']
         );
 
         $this->actingAs($otherUser);

--- a/stubs/tests/livewire/ProfileInformationTest.php
+++ b/stubs/tests/livewire/ProfileInformationTest.php
@@ -4,8 +4,8 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Laravel\Jetstream\Http\Livewire\UpdateProfileInformationForm;
 use Laravel\Jetstream\Features;
+use Laravel\Jetstream\Http\Livewire\UpdateProfileInformationForm;
 use Livewire\Livewire;
 use Tests\TestCase;
 

--- a/stubs/tests/livewire/ProfileInformationTest.php
+++ b/stubs/tests/livewire/ProfileInformationTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Jetstream\Http\Livewire\UpdateProfileInformationForm;
+use Laravel\Jetstream\Features;
 use Livewire\Livewire;
 use Tests\TestCase;
 
@@ -14,7 +15,10 @@ class ProfileInformationTest extends TestCase
 
     public function test_current_profile_information_is_available()
     {
-        $this->actingAs($user = User::factory()->create());
+        $user = Features::hasTeamFeatures()
+                ? User::factory()->withPersonalTeam()->create()
+                : User::factory()->create();
+        $this->actingAs($user);
 
         $component = Livewire::test(UpdateProfileInformationForm::class);
 
@@ -24,7 +28,10 @@ class ProfileInformationTest extends TestCase
 
     public function test_profile_information_can_be_updated()
     {
-        $this->actingAs($user = User::factory()->create());
+        $user = Features::hasTeamFeatures()
+                ? User::factory()->withPersonalTeam()->create()
+                : User::factory()->create();
+        $this->actingAs($user);
 
         Livewire::test(UpdateProfileInformationForm::class)
                 ->set('state', ['name' => 'Test Name', 'email' => 'test@example.com'])

--- a/stubs/tests/livewire/RemoveTeamMemberTest.php
+++ b/stubs/tests/livewire/RemoveTeamMemberTest.php
@@ -17,7 +17,7 @@ class RemoveTeamMemberTest extends TestCase
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $user->currentTeam->users()->attach(
-            $otherUser = User::factory()->create(), ['role' => 'admin']
+            $otherUser = User::factory()->withPersonalTeam()->create(), ['role' => 'admin']
         );
 
         $component = Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])
@@ -32,7 +32,7 @@ class RemoveTeamMemberTest extends TestCase
         $user = User::factory()->withPersonalTeam()->create();
 
         $user->currentTeam->users()->attach(
-            $otherUser = User::factory()->create(), ['role' => 'admin']
+            $otherUser = User::factory()->withPersonalTeam()->create(), ['role' => 'admin']
         );
 
         $this->actingAs($otherUser);

--- a/stubs/tests/livewire/TwoFactorAuthenticationSettingsTest.php
+++ b/stubs/tests/livewire/TwoFactorAuthenticationSettingsTest.php
@@ -4,8 +4,8 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Laravel\Jetstream\Http\Livewire\TwoFactorAuthenticationForm;
 use Laravel\Jetstream\Features;
+use Laravel\Jetstream\Http\Livewire\TwoFactorAuthenticationForm;
 use Livewire\Livewire;
 use Tests\TestCase;
 

--- a/stubs/tests/livewire/TwoFactorAuthenticationSettingsTest.php
+++ b/stubs/tests/livewire/TwoFactorAuthenticationSettingsTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Jetstream\Http\Livewire\TwoFactorAuthenticationForm;
+use Laravel\Jetstream\Features;
 use Livewire\Livewire;
 use Tests\TestCase;
 
@@ -14,7 +15,10 @@ class TwoFactorAuthenticationSettingsTest extends TestCase
 
     public function test_two_factor_authentication_can_be_enabled()
     {
-        $this->actingAs($user = User::factory()->create());
+        $user = Features::hasTeamFeatures()
+                ? User::factory()->withPersonalTeam()->create()
+                : User::factory()->create();
+        $this->actingAs($user);
 
         $this->withSession(['auth.password_confirmed_at' => time()]);
 
@@ -29,7 +33,10 @@ class TwoFactorAuthenticationSettingsTest extends TestCase
 
     public function test_recovery_codes_can_be_regenerated()
     {
-        $this->actingAs($user = User::factory()->create());
+        $user = Features::hasTeamFeatures()
+                ? User::factory()->withPersonalTeam()->create()
+                : User::factory()->create();
+        $this->actingAs($user);
 
         $this->withSession(['auth.password_confirmed_at' => time()]);
 
@@ -47,7 +54,10 @@ class TwoFactorAuthenticationSettingsTest extends TestCase
 
     public function test_two_factor_authentication_can_be_disabled()
     {
-        $this->actingAs($user = User::factory()->create());
+        $user = Features::hasTeamFeatures()
+                ? User::factory()->withPersonalTeam()->create()
+                : User::factory()->create();
+        $this->actingAs($user);
 
         $this->withSession(['auth.password_confirmed_at' => time()]);
 

--- a/stubs/tests/livewire/UpdatePasswordTest.php
+++ b/stubs/tests/livewire/UpdatePasswordTest.php
@@ -6,7 +6,9 @@ use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Hash;
 use Laravel\Jetstream\Http\Livewire\UpdatePasswordForm;
+use Laravel\Jetstream\Features;
 use Livewire\Livewire;
+
 use Tests\TestCase;
 
 class UpdatePasswordTest extends TestCase
@@ -15,7 +17,10 @@ class UpdatePasswordTest extends TestCase
 
     public function test_password_can_be_updated()
     {
-        $this->actingAs($user = User::factory()->create());
+        $user = Features::hasTeamFeatures()
+            ? User::factory()->withPersonalTeam()->create()
+            : User::factory()->create();
+        $this->actingAs($user);
 
         Livewire::test(UpdatePasswordForm::class)
                 ->set('state', [
@@ -30,7 +35,10 @@ class UpdatePasswordTest extends TestCase
 
     public function test_current_password_must_be_correct()
     {
-        $this->actingAs($user = User::factory()->create());
+        $user = Features::hasTeamFeatures()
+            ? User::factory()->withPersonalTeam()->create()
+            : User::factory()->create();
+        $this->actingAs($user);
 
         Livewire::test(UpdatePasswordForm::class)
                 ->set('state', [
@@ -46,7 +54,10 @@ class UpdatePasswordTest extends TestCase
 
     public function test_new_passwords_must_match()
     {
-        $this->actingAs($user = User::factory()->create());
+        $user = Features::hasTeamFeatures()
+            ? User::factory()->withPersonalTeam()->create()
+            : User::factory()->create();
+        $this->actingAs($user);
 
         Livewire::test(UpdatePasswordForm::class)
                 ->set('state', [

--- a/stubs/tests/livewire/UpdatePasswordTest.php
+++ b/stubs/tests/livewire/UpdatePasswordTest.php
@@ -5,10 +5,9 @@ namespace Tests\Feature;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Hash;
-use Laravel\Jetstream\Http\Livewire\UpdatePasswordForm;
 use Laravel\Jetstream\Features;
+use Laravel\Jetstream\Http\Livewire\UpdatePasswordForm;
 use Livewire\Livewire;
-
 use Tests\TestCase;
 
 class UpdatePasswordTest extends TestCase


### PR DESCRIPTION
Jetstream with Inertia in team mode generally expects users to have at least one team (the personal team). Not all test classes did follow this rule and created users without team even if the team feature was enabled.

We faced a problem in the `share()` method of `HandleInertiaRequests` where we wanted to get information from the user's team and share it in the request. Running the unit tests then resulted in an error, because for some unit tests the user did come without a team. 

To avoid this I propose to check if the team feature is enabled in the tests and add a team if necessary. I did not want to skip the tests because they are quite useful.

The changes have been incorporated in Inertia and Livewire test stubs. I have checked them with a fresh Jetstream installation and everything works.

Please let me know if I have to change anything.
