### PR TITLE
[2.x] Accept any type of response in RedirectsActions trait

### DIFF
--- a/src/RedirectsActions.php
+++ b/src/RedirectsActions.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Jetstream;
 
-use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Response;
 
 trait RedirectsActions
 {
@@ -10,7 +10,7 @@ trait RedirectsActions
      * Get the redirect response for the given action.
      *
      * @param  mixed  $action
-     * @return \Illuminate\Http\RedirectResponse
+     * @return \Illuminate\Http\Response
      */
     public function redirectPath($action)
     {
@@ -22,6 +22,6 @@ trait RedirectsActions
                                 : config('fortify.home');
         }
 
-        return $response instanceof RedirectResponse ? $response : redirect($response);
+        return $response instanceof Response ? $response : redirect($response);
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

If you change the behavior of the Inertia stack you're expected to update the Livewire stack as well and vica versa.
-->

This PR allows users to use `Inertia::location` in redirect actions. Since that response is not directly a `RedirectResponse` (see https://inertiajs.com/redirects#external-redirects) it could not be used so far. Sometimes this kind of response is necessary to force a complete reload.