### PR TITLE
withPersonalTeam factory method sets current team on the user

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -64,6 +64,10 @@ class UserFactory extends Factory
                     return ['name' => $user->name.'\'s Team', 'user_id' => $user->id, 'personal_team' => true];
                 }),
             'ownedTeams'
-        );
+        )->afterCreating(function (User $user) {
+            if ($user->personalTeam()) {
+                $user->currentTeam();
+            }
+        });
     }
 }


### PR DESCRIPTION
I have added this in my current project to lighten the load of adding a user with a personal team and then setting the current team. The scenarios where you want the personal team set as the current team seem to out weigh the opposite. 

This will assist in testing applications that set the team member id based on the authenticated user. This stub is only added in a new application so breaking changes should not be an issue.
