### PR TITLE
Fix RegistrationTest failure due to duplicate email addresses

### DIFF
--- a/stubs/tests/RegistrationTest.php
+++ b/stubs/tests/RegistrationTest.php
@@ -22,7 +22,7 @@ class RegistrationTest extends TestCase
     {
         $response = $this->post('/register', [
             'name' => 'Test User',
-            'email' => 'test@example.com',
+            'email' => 'testuser@example.com',
             'password' => 'password',
             'password_confirmation' => 'password',
             'terms' => Jetstream::hasTermsAndPrivacyPolicyFeature(),


### PR DESCRIPTION
This PR fixes the RegistrationTest which fails by default due to having the same email address for the dummy user as Livewire's ProfileInformationTest. This should be the case in the Intertia variant of the test as well.

```php
// stubs/tests/livewire/ProfileInformationTest.php
    public function test_profile_information_can_be_updated()
    {
        $this->actingAs($user = User::factory()->create());

        Livewire::test(UpdateProfileInformationForm::class)
                ->set('state', ['name' => 'Test Name', 'email' => 'test@example.com']) // THIS
                ->call('updateProfileInformation');

        $this->assertEquals('Test Name', $user->fresh()->name);
        $this->assertEquals('test@example.com', $user->fresh()->email);
    }

// stubs/tests/inertia/RegistrationTest.php
    public function test_new_users_can_register()
    {
        $response = $this->post('/register', [
            'name' => 'Test User',
            'email' => 'test@example.com', // THIS
            'password' => 'password',
            'password_confirmation' => 'password',
            'terms' => Jetstream::hasTermsAndPrivacyPolicyFeature(),
        ]);

        $this->assertAuthenticated();
        $response->assertRedirect(RouteServiceProvider::HOME);
    }
```

The test would fail due to not being able to register second user with the same email address.

**The dummy email in RegistrationTest is changed by this PR.**