### PR TITLE
Check for session before attempting to invalidate

### DIFF
--- a/src/Http/Livewire/DeleteUserForm.php
+++ b/src/Http/Livewire/DeleteUserForm.php
@@ -64,7 +64,7 @@ class DeleteUserForm extends Component
 
         $auth->logout();
 
-        if ($request->session) {
+        if ($request->hasSession()) {
             $request->session()->invalidate();
             $request->session()->regenerateToken();
         }

--- a/src/Http/Livewire/DeleteUserForm.php
+++ b/src/Http/Livewire/DeleteUserForm.php
@@ -64,7 +64,7 @@ class DeleteUserForm extends Component
 
         $auth->logout();
 
-        if($request->session) {
+        if ($request->session) {
             $request->session()->invalidate();
             $request->session()->regenerateToken();
         }

--- a/src/Http/Livewire/DeleteUserForm.php
+++ b/src/Http/Livewire/DeleteUserForm.php
@@ -64,8 +64,10 @@ class DeleteUserForm extends Component
 
         $auth->logout();
 
-        $request->session()->invalidate();
-        $request->session()->regenerateToken();
+        if($request->session) {
+            $request->session()->invalidate();
+            $request->session()->regenerateToken();
+        }
 
         return redirect('/');
     }


### PR DESCRIPTION
This is my first PR to a Laravel repo so please let me know if I'm doing anything incorrectly here.

All this pull request is doing is ensuring there is a session (with a single `if` statement) before attempting to destroy it in `src/Http/Livewire/DeleteUserForm.php`. 

```php
        if ($request->hasSession()) {
            $request->session()->invalidate();
            $request->session()->regenerateToken();
        }
```
Previously either of these two lines would break the TestableLivewire in [stubs/test/livewire/DeleteAccountTest.php:24](https://github.com/laravel/jetstream/blob/39d50ec0dda28ae2077baf9df307509a09307d75/stubs/tests/livewire/DeleteAccountTest.php#L24)

```php
         $request->session()->invalidate();
         $request->session()->regenerateToken();
```

This change will keep it from breaking tests in downstream apps that have had Jetstream installed with `php artisan jetstream:install livewire`.

This only affect cases where there is no `$request->session()` to `invalidate()`.

Since we are simply skipping two lines of code run when there isn't a session, and doing nothing else differently when there is, this should not affect anything anywhere else, nor will it break anything.

This would close the issue I opened here:
https://github.com/laravel/jetstream/issues/749