### PR TITLE
replace $request->session() with session()

### DIFF
--- a/src/Http/Livewire/DeleteUserForm.php
+++ b/src/Http/Livewire/DeleteUserForm.php
@@ -3,7 +3,6 @@
 namespace Laravel\Jetstream\Http\Livewire;
 
 use Illuminate\Contracts\Auth\StatefulGuard;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\ValidationException;
@@ -45,7 +44,6 @@ class DeleteUserForm extends Component
     /**
      * Delete the current user.
      *
-     * @param  \Illuminate\Http\Request  $request
      * @param  \Laravel\Jetstream\Contracts\DeletesUsers  $deleter
      * @param  \Illuminate\Contracts\Auth\StatefulGuard  $auth
      * @return \Illuminate\Routing\Redirector|\Illuminate\Http\RedirectResponse

--- a/src/Http/Livewire/DeleteUserForm.php
+++ b/src/Http/Livewire/DeleteUserForm.php
@@ -50,7 +50,7 @@ class DeleteUserForm extends Component
      * @param  \Illuminate\Contracts\Auth\StatefulGuard  $auth
      * @return \Illuminate\Routing\Redirector|\Illuminate\Http\RedirectResponse
      */
-    public function deleteUser(Request $request, DeletesUsers $deleter, StatefulGuard $auth)
+    public function deleteUser(DeletesUsers $deleter, StatefulGuard $auth)
     {
         $this->resetErrorBag();
 
@@ -64,10 +64,8 @@ class DeleteUserForm extends Component
 
         $auth->logout();
 
-        if ($request->hasSession()) {
-            $request->session()->invalidate();
-            $request->session()->regenerateToken();
-        }
+        session()->invalidate();
+        session()->regenerateToken();
 
         return redirect('/');
     }


### PR DESCRIPTION
This PR (refactor) replaces The calls to methods on `$request->session()` with  `session()` as per @calebporzio 's recommendation in https://github.com/livewire/livewire/issues/936#issuecomment-652099995.

This also eliminates the need for the `if ($request->hasSession())` condition in my previous PR, thus bringing the code back one level of indentation. 

Tested with the following steps:

```
laravel new jetstream-demo
```
```
cd jetstream-demo
```
```
composer require laravel/jetstream
```

```
php artisan jetstream:install livewire
```
```
npm install && npm run dev
```
```
vi phpunit.xml
```
```diff
-        <!-- <server name="DB_CONNECTION" value="sqlite"/> -->
-       <!-- <server name="DB_DATABASE" value=":memory:"/> -->
+       <server name="DB_CONNECTION" value="sqlite"/>
+       <server name="DB_DATABASE" value=":memory:"/>
```
```
php artisan test
```

Also tested in chromium browser against https://github.com/laravel/jetstream/issues/730

----
@telkins @Loots-it 

https://github.com/laravel/jetstream/pull/742

https://github.com/laravel/jetstream/pull/750#issuecomment-815662156