### PR TITLE
[2.x] Exclude hidden inputs from focusable elements

### DIFF
--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -17,7 +17,7 @@ $maxWidth = [
         show: @entangle($attributes->wire('model')).defer,
         focusables() {
             // All focusable element types...
-            let selector = 'a, button, input, textarea, select, details, [tabindex]:not([tabindex=\'-1\'])'
+            let selector = 'a, button, input:not([type=\'hidden\'], textarea, select, details, [tabindex]:not([tabindex=\'-1\'])'
 
             return [...$el.querySelectorAll(selector)]
                 // All non-disabled elements...


### PR DESCRIPTION
Currently if there is any `<input type="hidden">` inside the modal, tabbing stops when that element is next.

This PR excludes such hidden inputs via the query-selector, so that focus progression is no longer stopped.
I couldn't find any existing tests for the modal or its tabbing in this repo, so I haven't updated or added any tests.