### PR TITLE
[2.x] Disable Teams tests when the feature is disabled

### DIFF
--- a/stubs/tests/inertia/CreateTeamTest.php
+++ b/stubs/tests/inertia/CreateTeamTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Jetstream\Features;
 use Tests\TestCase;
 
 class CreateTeamTest extends TestCase
@@ -12,6 +13,10 @@ class CreateTeamTest extends TestCase
 
     public function test_teams_can_be_created()
     {
+        if (!Features::hasTeamFeatures()) {
+            $this->markTestSkipped('Jetstream Teams feature is disabled');
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $response = $this->post('/teams', [

--- a/stubs/tests/inertia/CreateTeamTest.php
+++ b/stubs/tests/inertia/CreateTeamTest.php
@@ -13,7 +13,7 @@ class CreateTeamTest extends TestCase
 
     public function test_teams_can_be_created()
     {
-        if (!Features::hasTeamFeatures()) {
+        if (! Features::hasTeamFeatures()) {
             $this->markTestSkipped('Jetstream Teams feature is disabled');
         }
 

--- a/stubs/tests/inertia/DeleteTeamTest.php
+++ b/stubs/tests/inertia/DeleteTeamTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Models\Team;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Jetstream\Features;
 use Tests\TestCase;
 
 class DeleteTeamTest extends TestCase
@@ -13,6 +14,10 @@ class DeleteTeamTest extends TestCase
 
     public function test_teams_can_be_deleted()
     {
+        if (! Features::hasTeamFeatures()) {
+            $this->markTestSkipped('Jetstream Teams feature is disabled');
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $user->ownedTeams()->save($team = Team::factory()->make([
@@ -31,6 +36,10 @@ class DeleteTeamTest extends TestCase
 
     public function test_personal_teams_cant_be_deleted()
     {
+        if (! Features::hasTeamFeatures()) {
+            $this->markTestSkipped('Jetstream Teams feature is disabled');
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $response = $this->delete('/teams/'.$user->currentTeam->id);

--- a/stubs/tests/inertia/InviteTeamMemberTest.php
+++ b/stubs/tests/inertia/InviteTeamMemberTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Mail;
+use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Mail\TeamInvitation;
 use Tests\TestCase;
 
@@ -14,6 +15,10 @@ class InviteTeamMemberTest extends TestCase
 
     public function test_team_members_can_be_invited_to_team()
     {
+        if (! Features::hasTeamFeatures()) {
+            $this->markTestSkipped('Jetstream Teams feature is disabled');
+        }
+
         Mail::fake();
 
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
@@ -30,6 +35,10 @@ class InviteTeamMemberTest extends TestCase
 
     public function test_team_member_invitations_can_be_cancelled()
     {
+        if (! Features::hasTeamFeatures()) {
+            $this->markTestSkipped('Jetstream Teams feature is disabled');
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $invitation = $user->currentTeam->teamInvitations()->create([

--- a/stubs/tests/inertia/LeaveTeamTest.php
+++ b/stubs/tests/inertia/LeaveTeamTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Jetstream\Features;
 use Tests\TestCase;
 
 class LeaveTeamTest extends TestCase
@@ -12,6 +13,10 @@ class LeaveTeamTest extends TestCase
 
     public function test_users_can_leave_teams()
     {
+        if (! Features::hasTeamFeatures()) {
+            $this->markTestSkipped('Jetstream Teams feature is disabled');
+        }
+
         $user = User::factory()->withPersonalTeam()->create();
 
         $user->currentTeam->users()->attach(
@@ -27,6 +32,10 @@ class LeaveTeamTest extends TestCase
 
     public function test_team_owners_cant_leave_their_own_team()
     {
+        if (! Features::hasTeamFeatures()) {
+            $this->markTestSkipped('Jetstream Teams feature is disabled');
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $response = $this->delete('/teams/'.$user->currentTeam->id.'/members/'.$user->id);

--- a/stubs/tests/inertia/RemoveTeamMemberTest.php
+++ b/stubs/tests/inertia/RemoveTeamMemberTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Jetstream\Features;
 use Tests\TestCase;
 
 class RemoveTeamMemberTest extends TestCase
@@ -12,6 +13,10 @@ class RemoveTeamMemberTest extends TestCase
 
     public function test_team_members_can_be_removed_from_teams()
     {
+        if (! Features::hasTeamFeatures()) {
+            $this->markTestSkipped('Jetstream Teams feature is disabled');
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $user->currentTeam->users()->attach(
@@ -25,6 +30,10 @@ class RemoveTeamMemberTest extends TestCase
 
     public function test_only_team_owner_can_remove_team_members()
     {
+        if (! Features::hasTeamFeatures()) {
+            $this->markTestSkipped('Jetstream Teams feature is disabled');
+        }
+
         $user = User::factory()->withPersonalTeam()->create();
 
         $user->currentTeam->users()->attach(

--- a/stubs/tests/inertia/UpdateTeamMemberRoleTest.php
+++ b/stubs/tests/inertia/UpdateTeamMemberRoleTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Jetstream\Features;
 use Tests\TestCase;
 
 class UpdateTeamMemberRoleTest extends TestCase
@@ -12,6 +13,10 @@ class UpdateTeamMemberRoleTest extends TestCase
 
     public function test_team_member_roles_can_be_updated()
     {
+        if (! Features::hasTeamFeatures()) {
+            $this->markTestSkipped('Jetstream Teams feature is disabled');
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $user->currentTeam->users()->attach(
@@ -29,6 +34,10 @@ class UpdateTeamMemberRoleTest extends TestCase
 
     public function test_only_team_owner_can_update_team_member_roles()
     {
+        if (! Features::hasTeamFeatures()) {
+            $this->markTestSkipped('Jetstream Teams feature is disabled');
+        }
+
         $user = User::factory()->withPersonalTeam()->create();
 
         $user->currentTeam->users()->attach(

--- a/stubs/tests/inertia/UpdateTeamNameTest.php
+++ b/stubs/tests/inertia/UpdateTeamNameTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Jetstream\Features;
 use Tests\TestCase;
 
 class UpdateTeamNameTest extends TestCase
@@ -12,6 +13,10 @@ class UpdateTeamNameTest extends TestCase
 
     public function test_team_names_can_be_updated()
     {
+        if (! Features::hasTeamFeatures()) {
+            $this->markTestSkipped('Jetstream Teams feature is disabled');
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $response = $this->put('/teams/'.$user->currentTeam->id, [

--- a/stubs/tests/livewire/CreateTeamTest.php
+++ b/stubs/tests/livewire/CreateTeamTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Http\Livewire\CreateTeamForm;
 use Livewire\Livewire;
 use Tests\TestCase;
@@ -14,6 +15,10 @@ class CreateTeamTest extends TestCase
 
     public function test_teams_can_be_created()
     {
+        if (! Features::hasTeamFeatures()) {
+            $this->markTestSkipped('Jetstream Teams feature is disabled');
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         Livewire::test(CreateTeamForm::class)

--- a/stubs/tests/livewire/DeleteTeamTest.php
+++ b/stubs/tests/livewire/DeleteTeamTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Models\Team;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Http\Livewire\DeleteTeamForm;
 use Livewire\Livewire;
 use Tests\TestCase;
@@ -15,6 +16,10 @@ class DeleteTeamTest extends TestCase
 
     public function test_teams_can_be_deleted()
     {
+        if (! Features::hasTeamFeatures()) {
+            $this->markTestSkipped('Jetstream Teams feature is disabled');
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $user->ownedTeams()->save($team = Team::factory()->make([
@@ -34,6 +39,10 @@ class DeleteTeamTest extends TestCase
 
     public function test_personal_teams_cant_be_deleted()
     {
+        if (! Features::hasTeamFeatures()) {
+            $this->markTestSkipped('Jetstream Teams feature is disabled');
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $component = Livewire::test(DeleteTeamForm::class, ['team' => $user->currentTeam])

--- a/stubs/tests/livewire/InviteTeamMemberTest.php
+++ b/stubs/tests/livewire/InviteTeamMemberTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Mail;
+use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Http\Livewire\TeamMemberManager;
 use Laravel\Jetstream\Mail\TeamInvitation;
 use Livewire\Livewire;
@@ -16,6 +17,10 @@ class InviteTeamMemberTest extends TestCase
 
     public function test_team_members_can_be_invited_to_team()
     {
+        if (! Features::hasTeamFeatures()) {
+            $this->markTestSkipped('Jetstream Teams feature is disabled');
+        }
+
         Mail::fake();
 
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
@@ -33,6 +38,10 @@ class InviteTeamMemberTest extends TestCase
 
     public function test_team_member_invitations_can_be_cancelled()
     {
+        if (! Features::hasTeamFeatures()) {
+            $this->markTestSkipped('Jetstream Teams feature is disabled');
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         // Add the team member...

--- a/stubs/tests/livewire/LeaveTeamTest.php
+++ b/stubs/tests/livewire/LeaveTeamTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Http\Livewire\TeamMemberManager;
 use Livewire\Livewire;
 use Tests\TestCase;
@@ -14,6 +15,10 @@ class LeaveTeamTest extends TestCase
 
     public function test_users_can_leave_teams()
     {
+        if (! Features::hasTeamFeatures()) {
+            $this->markTestSkipped('Jetstream Teams feature is disabled');
+        }
+
         $user = User::factory()->withPersonalTeam()->create();
 
         $user->currentTeam->users()->attach(
@@ -30,6 +35,10 @@ class LeaveTeamTest extends TestCase
 
     public function test_team_owners_cant_leave_their_own_team()
     {
+        if (! Features::hasTeamFeatures()) {
+            $this->markTestSkipped('Jetstream Teams feature is disabled');
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $component = Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])

--- a/stubs/tests/livewire/RemoveTeamMemberTest.php
+++ b/stubs/tests/livewire/RemoveTeamMemberTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Http\Livewire\TeamMemberManager;
 use Livewire\Livewire;
 use Tests\TestCase;
@@ -14,6 +15,10 @@ class RemoveTeamMemberTest extends TestCase
 
     public function test_team_members_can_be_removed_from_teams()
     {
+        if (! Features::hasTeamFeatures()) {
+            $this->markTestSkipped('Jetstream Teams feature is disabled');
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $user->currentTeam->users()->attach(
@@ -29,6 +34,10 @@ class RemoveTeamMemberTest extends TestCase
 
     public function test_only_team_owner_can_remove_team_members()
     {
+        if (! Features::hasTeamFeatures()) {
+            $this->markTestSkipped('Jetstream Teams feature is disabled');
+        }
+
         $user = User::factory()->withPersonalTeam()->create();
 
         $user->currentTeam->users()->attach(

--- a/stubs/tests/livewire/UpdateTeamMemberRoleTest.php
+++ b/stubs/tests/livewire/UpdateTeamMemberRoleTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Http\Livewire\TeamMemberManager;
 use Livewire\Livewire;
 use Tests\TestCase;
@@ -14,6 +15,10 @@ class UpdateTeamMemberRoleTest extends TestCase
 
     public function test_team_member_roles_can_be_updated()
     {
+        if (! Features::hasTeamFeatures()) {
+            $this->markTestSkipped('Jetstream Teams feature is disabled');
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $user->currentTeam->users()->attach(
@@ -32,6 +37,10 @@ class UpdateTeamMemberRoleTest extends TestCase
 
     public function test_only_team_owner_can_update_team_member_roles()
     {
+        if (! Features::hasTeamFeatures()) {
+            $this->markTestSkipped('Jetstream Teams feature is disabled');
+        }
+
         $user = User::factory()->withPersonalTeam()->create();
 
         $user->currentTeam->users()->attach(

--- a/stubs/tests/livewire/UpdateTeamNameTest.php
+++ b/stubs/tests/livewire/UpdateTeamNameTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Http\Livewire\UpdateTeamNameForm;
 use Livewire\Livewire;
 use Tests\TestCase;
@@ -14,6 +15,10 @@ class UpdateTeamNameTest extends TestCase
 
     public function test_team_names_can_be_updated()
     {
+        if (! Features::hasTeamFeatures()) {
+            $this->markTestSkipped('Jetstream Teams feature is disabled');
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         Livewire::test(UpdateTeamNameForm::class, ['team' => $user->currentTeam])


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

If you change the behavior of the Inertia stack you're expected to update the Livewire stack as well and vica versa.
-->

Automatically skip tests that affect Teams feature when it is disabled.

Thank you.
