### PR TITLE
[2.x] Lovecoding git logout nav link

### DIFF
--- a/stubs/livewire/resources/views/navigation-menu.blade.php
+++ b/stubs/livewire/resources/views/navigation-menu.blade.php
@@ -112,7 +112,7 @@
                             <form method="POST" action="{{ route('logout') }}">
                                 @csrf
 
-                                <x-jet-dropdown-link href="#"
+                                <x-jet-dropdown-link href="javascript:void(0);"
                                          onclick="event.preventDefault();
                                                 this.closest('form').submit();">
                                     {{ __('Logout') }}
@@ -174,7 +174,7 @@
                 <form method="POST" action="{{ route('logout') }}">
                     @csrf
 
-                    <x-jet-responsive-nav-link href="#"
+                    <x-jet-responsive-nav-link href="javascript:void(0);"
                                    onclick="event.preventDefault();
                                     this.closest('form').submit();">
                         {{ __('Logout') }}

--- a/stubs/livewire/resources/views/navigation-menu.blade.php
+++ b/stubs/livewire/resources/views/navigation-menu.blade.php
@@ -112,7 +112,7 @@
                             <form method="POST" action="{{ route('logout') }}">
                                 @csrf
 
-                                <x-jet-dropdown-link href="{{ route('logout') }}"
+                                <x-jet-dropdown-link href="#"
                                          onclick="event.preventDefault();
                                                 this.closest('form').submit();">
                                     {{ __('Logout') }}
@@ -174,7 +174,7 @@
                 <form method="POST" action="{{ route('logout') }}">
                     @csrf
 
-                    <x-jet-responsive-nav-link href="{{ route('logout') }}"
+                    <x-jet-responsive-nav-link href="#"
                                    onclick="event.preventDefault();
                                     this.closest('form').submit();">
                         {{ __('Logout') }}


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

If you change the behavior of the Inertia stack you're expected to update the Livewire stack as well and vica versa.
-->
-Change navigation link for logout.
When we click logout link with "open link in new tab" (middle mouse button click),  "The GET method is not supported for this route. Supported methods: POST." error throws.

If we put "javascript:void(0);" or "#", we can remove this error.

I know this is useless but default app links should eliminate all possible errors. :)