### PR TITLE
[2.x] Add missing assertions in PasswordConfirmationTest stub

### DIFF
--- a/stubs/tests/PasswordConfirmationTest.php
+++ b/stubs/tests/PasswordConfirmationTest.php
@@ -32,6 +32,7 @@ class PasswordConfirmationTest extends TestCase
 
         $response->assertRedirect();
         $response->assertSessionHasNoErrors();
+        $response->assertSessionHas('auth.password_confirmed_at');
     }
 
     public function test_password_is_not_confirmed_with_invalid_password()
@@ -43,5 +44,6 @@ class PasswordConfirmationTest extends TestCase
         ]);
 
         $response->assertSessionHasErrors();
+        $response->assertSessionMissing('auth.password_confirmed_at');
     }
 }


### PR DESCRIPTION
Adds session has/missing `auth.password_confirmed_at` (the main action the password confirmation does)