### PR TITLE
Use quote for cancelling team member

### DIFF
--- a/stubs/livewire/resources/views/teams/team-member-manager.blade.php
+++ b/stubs/livewire/resources/views/teams/team-member-manager.blade.php
@@ -98,7 +98,7 @@
                                     @if (Gate::check('removeTeamMember', $team))
                                         <!-- Cancel Team Invitation -->
                                         <button class="cursor-pointer ml-6 text-sm text-red-500 focus:outline-none"
-                                                            wire:click="cancelTeamInvitation({{ $invitation->id }})">
+                                                            wire:click="cancelTeamInvitation('{{ $invitation->id }}')">
                                             {{ __('Cancel') }}
                                         </button>
                                     @endif


### PR DESCRIPTION
Here I changed jetstream on my app to accept UUID as primary keys, so this must be escaped to accept both int and string primary keys.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

If you change the behavior of the Inertia stack you're expected to update the Livewire stack as well and vice versa.
-->
