### PR TITLE
[2.x] Add $request->currentTeam() for classy retrieval

### DIFF
--- a/src/JetstreamServiceProvider.php
+++ b/src/JetstreamServiceProvider.php
@@ -76,6 +76,12 @@ class JetstreamServiceProvider extends ServiceProvider
         $this->configureRoutes();
         $this->configureCommands();
 
+        if (Features::hasTeamFeatures()) {
+            Request::macro('currentTeam', function ($guard = null) {
+                return optional($this->user($guard))->currentTeam;
+            });
+        }
+
         RedirectResponse::macro('banner', function ($message) {
             return $this->with('flash', [
                 'bannerStyle' => 'success',


### PR DESCRIPTION
I think using a Request macro is much classier than getting the user and retrieving the current team by relation:

Before:
```php
$team = $request->user()->currentTeam;

$team = $request->user('some-guard')->currentTeam;
```

After:
```php
$team = $request->currentTeam();

$team = $request->currentTeam('some-guard');
```