### PR TITLE
[2.x] Get model of PersonalAccessToken before deleting it to make sure the deleting/deleted events are triggered

### DIFF
--- a/src/Http/Controllers/Inertia/ApiTokenController.php
+++ b/src/Http/Controllers/Inertia/ApiTokenController.php
@@ -82,7 +82,7 @@ class ApiTokenController extends Controller
      */
     public function destroy(Request $request, $tokenId)
     {
-        $request->user()->tokens()->where('id', $tokenId)->delete();
+        $request->user()->tokens()->where('id', $tokenId)->first()->delete();
 
         return back(303);
     }

--- a/src/Http/Livewire/ApiTokenManager.php
+++ b/src/Http/Livewire/ApiTokenManager.php
@@ -172,7 +172,7 @@ class ApiTokenManager extends Component
      */
     public function deleteApiToken()
     {
-        $this->user->tokens()->where('id', $this->apiTokenIdBeingDeleted)->delete();
+        $this->user->tokens()->where('id', $this->apiTokenIdBeingDeleted)->first()->delete();
 
         $this->user->load('tokens');
 


### PR DESCRIPTION
Jetstream/Sanctum supports overwriting the PersonalAccessTokenModel via `Sanctum::$personalAccessTokenModel`

In the current state Jetstream will delete tokens via the query builder without fetching the token first, which will not trigger the deleting/deleted events.

There are some use-cases where you might want to "mirror" the changes to tokens to an API gateway.