### PR TITLE
Check OwnsTeam for null teams

### DIFF
--- a/src/HasTeams.php
+++ b/src/HasTeams.php
@@ -104,6 +104,11 @@ trait HasTeams
      */
     public function ownsTeam($team)
     {
+        if(is_null($team))
+        {
+            return false;
+        }
+        
         return $this->id == $team->{$this->getForeignKey()};
     }
 

--- a/src/HasTeams.php
+++ b/src/HasTeams.php
@@ -107,7 +107,7 @@ trait HasTeams
         if (is_null($team)) {
             return false;
         }
-        
+
         return $this->id == $team->{$this->getForeignKey()};
     }
 

--- a/src/HasTeams.php
+++ b/src/HasTeams.php
@@ -104,8 +104,7 @@ trait HasTeams
      */
     public function ownsTeam($team)
     {
-        if(is_null($team))
-        {
+        if(is_null($team)) {
             return false;
         }
         

--- a/src/HasTeams.php
+++ b/src/HasTeams.php
@@ -104,7 +104,7 @@ trait HasTeams
      */
     public function ownsTeam($team)
     {
-        if(is_null($team)) {
+        if (is_null($team)) {
             return false;
         }
         


### PR DESCRIPTION
Fixes an error for null teams by adding a check to see if the team passed is null, and returns false instead of throwing an exception.