### PR TITLE
Add register route link on login view

### DIFF
--- a/stubs/inertia/resources/js/Pages/Auth/Login.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/Login.vue
@@ -28,7 +28,11 @@
                 </label>
             </div>
 
-            <div class="flex items-center justify-end mt-4">
+            <div class="flex items-center justify-between mt-4">
+                <inertia-link :href="route('register')" class="underline text-sm text-gray-600 hover:text-gray-900">
+                    Not registered yet?
+                </inertia-link>
+
                 <inertia-link v-if="canResetPassword" :href="route('password.request')" class="underline text-sm text-gray-600 hover:text-gray-900">
                     Forgot your password?
                 </inertia-link>

--- a/stubs/livewire/resources/views/auth/login.blade.php
+++ b/stubs/livewire/resources/views/auth/login.blade.php
@@ -32,7 +32,11 @@
                 </label>
             </div>
 
-            <div class="flex items-center justify-end mt-4">
+            <div class="flex items-center justify-between mt-4">
+                <a class="underline text-sm text-gray-600 hover:text-gray-900" href="{{ route('register') }}">
+                    {{ __('Not registered yet?') }}
+                </a>
+
                 @if (Route::has('password.request'))
                     <a class="underline text-sm text-gray-600 hover:text-gray-900" href="{{ route('password.request') }}">
                         {{ __('Forgot your password?') }}


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

If you change the behavior of the Inertia stack you're expected to update the Livewire stack as well and vice versa.
-->

When a user lands on the Login view, there is no specific link or button that points to the registration route.

This PR adds a "Not registered yet?" link on the Login view for Inertia and Livewire presets.

![Captura de pantalla 2021-04-28 a las 23 28 58](https://user-images.githubusercontent.com/6053012/116475041-9046cb80-a879-11eb-94e2-c2b2382d424f.png)


