### PR TITLE
[2.x] Create a user withPersonalTeam only if the teams feature is enabled

### DIFF
--- a/stubs/tests/EmailVerificationTest.php
+++ b/stubs/tests/EmailVerificationTest.php
@@ -22,9 +22,13 @@ class EmailVerificationTest extends TestCase
             return $this->markTestSkipped('Email verification not enabled.');
         }
 
-        $user = User::factory()->withPersonalTeam()->create([
-            'email_verified_at' => null,
-        ]);
+        $user = JetstreamFeatures::hasTeamFeatures() ?
+            User::factory()->withPersonalTeam()->create([
+                'email_verified_at' => null,
+            ]) :
+            User::factory()->create([
+                'email_verified_at' => null,
+            ]);
 
         $response = $this->actingAs($user)->get('/email/verify');
 


### PR DESCRIPTION
- Jetstream Version: 2.3.4
- Jetstream Stack: Inertia
- Uses Teams: no
- Laravel Version: 8.40.0
- PHP Version: 7.4.16
- Database Driver & Version: MySQL 8.0.21

### Description:
After I created a fresh installation of latest Laravel version and installed Jetstream with teams disabled and other features enabled, I ran the `php artisan test` and I get this error:
```
• Tests\Feature\EmailVerificationTest > email verification screen can be rendered
   BadMethodCallException 

  Call to undefined method Database\Factories\UserFactory::withPersonalTeam()

  at vendor/laravel/framework/src/Illuminate/Support/Traits/ForwardsCalls.php:50
     46▕      * @throws \BadMethodCallException
     47▕      */
     48▕     protected static function throwBadMethodCallException($method)
     49▕     {
  ➜  50▕         throw new BadMethodCallException(sprintf(
     51▕             'Call to undefined method %s::%s()', static::class, $method
     52▕         ));
     53▕     }
     54▕ }

      +1 vendor frames 
  2   tests/Feature/EmailVerificationTest.php:25
      Illuminate\Database\Eloquent\Factories\Factory::__call("withPersonalTeam", [])
```

### Steps To Reproduce:
- Install Jetstream without teams
- Enable email verification and all Jetstream features except teams
- run `php artisan test`
