### PR TITLE
[2.x] Fix error messages margins around rounded inputs

### DIFF
--- a/resources/views/components/confirms-password.blade.php
+++ b/resources/views/components/confirms-password.blade.php
@@ -29,7 +29,7 @@
                         wire:model.defer="confirmablePassword"
                         wire:keydown.enter="confirmPassword" />
 
-            <x-jet-input-error for="confirmable_password" class="mt-2" />
+            <x-jet-input-error for="confirmable_password" class="mt-1 ml-1" />
         </div>
     </x-slot>
 

--- a/stubs/inertia/resources/js/Jetstream/ConfirmsPassword.vue
+++ b/stubs/inertia/resources/js/Jetstream/ConfirmsPassword.vue
@@ -18,7 +18,7 @@
                                 v-model="form.password"
                                 @keyup.enter="confirmPassword" />
 
-                    <jet-input-error :message="form.error" class="mt-2" />
+                    <jet-input-error :message="form.error" class="mt-1 ml-1" />
                 </div>
             </template>
 

--- a/stubs/inertia/resources/js/Pages/API/ApiTokenManager.vue
+++ b/stubs/inertia/resources/js/Pages/API/ApiTokenManager.vue
@@ -15,7 +15,7 @@
                 <div class="col-span-6 sm:col-span-4">
                     <jet-label for="name" value="Name" />
                     <jet-input id="name" type="text" class="mt-1 block w-full" v-model="createApiTokenForm.name" autofocus />
-                    <jet-input-error :message="createApiTokenForm.errors.name" class="mt-2" />
+                    <jet-input-error :message="createApiTokenForm.errors.name" class="mt-1 ml-1" />
                 </div>
 
                 <!-- Token Permissions -->

--- a/stubs/inertia/resources/js/Pages/Profile/DeleteUserForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/DeleteUserForm.vue
@@ -34,7 +34,7 @@
                                     v-model="form.password"
                                     @keyup.enter="deleteUser" />
 
-                        <jet-input-error :message="form.errors.password" class="mt-2" />
+                        <jet-input-error :message="form.errors.password" class="mt-1 ml-1" />
                     </div>
                 </template>
 

--- a/stubs/inertia/resources/js/Pages/Profile/LogoutOtherBrowserSessionsForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/LogoutOtherBrowserSessionsForm.vue
@@ -68,7 +68,7 @@
                                     v-model="form.password"
                                     @keyup.enter="logoutOtherBrowserSessions" />
 
-                        <jet-input-error :message="form.errors.password" class="mt-2" />
+                        <jet-input-error :message="form.errors.password" class="mt-1 ml-1" />
                     </div>
                 </template>
 

--- a/stubs/inertia/resources/js/Pages/Profile/UpdatePasswordForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/UpdatePasswordForm.vue
@@ -12,19 +12,19 @@
             <div class="col-span-6 sm:col-span-4">
                 <jet-label for="current_password" value="Current Password" />
                 <jet-input id="current_password" type="password" class="mt-1 block w-full" v-model="form.current_password" ref="current_password" autocomplete="current-password" />
-                <jet-input-error :message="form.errors.current_password" class="mt-2" />
+                <jet-input-error :message="form.errors.current_password" class="mt-1 ml-1" />
             </div>
 
             <div class="col-span-6 sm:col-span-4">
                 <jet-label for="password" value="New Password" />
                 <jet-input id="password" type="password" class="mt-1 block w-full" v-model="form.password" ref="password" autocomplete="new-password" />
-                <jet-input-error :message="form.errors.password" class="mt-2" />
+                <jet-input-error :message="form.errors.password" class="mt-1 ml-1" />
             </div>
 
             <div class="col-span-6 sm:col-span-4">
                 <jet-label for="password_confirmation" value="Confirm Password" />
                 <jet-input id="password_confirmation" type="password" class="mt-1 block w-full" v-model="form.password_confirmation" autocomplete="new-password" />
-                <jet-input-error :message="form.errors.password_confirmation" class="mt-2" />
+                <jet-input-error :message="form.errors.password_confirmation" class="mt-1 ml-1" />
             </div>
         </template>
 

--- a/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
@@ -38,21 +38,21 @@
                     Remove Photo
                 </jet-secondary-button>
 
-                <jet-input-error :message="form.errors.photo" class="mt-2" />
+                <jet-input-error :message="form.errors.photo" class="mt-1 ml-1" />
             </div>
 
             <!-- Name -->
             <div class="col-span-6 sm:col-span-4">
                 <jet-label for="name" value="Name" />
                 <jet-input id="name" type="text" class="mt-1 block w-full" v-model="form.name" autocomplete="name" />
-                <jet-input-error :message="form.errors.name" class="mt-2" />
+                <jet-input-error :message="form.errors.name" class="mt-1 ml-1" />
             </div>
 
             <!-- Email -->
             <div class="col-span-6 sm:col-span-4">
                 <jet-label for="email" value="Email" />
                 <jet-input id="email" type="email" class="mt-1 block w-full" v-model="form.email" />
-                <jet-input-error :message="form.errors.email" class="mt-2" />
+                <jet-input-error :message="form.errors.email" class="mt-1 ml-1" />
             </div>
         </template>
 

--- a/stubs/inertia/resources/js/Pages/Teams/CreateTeamForm.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/CreateTeamForm.vue
@@ -25,7 +25,7 @@
             <div class="col-span-6 sm:col-span-4">
                 <jet-label for="name" value="Team Name" />
                 <jet-input id="name" type="text" class="mt-1 block w-full" v-model="form.name" autofocus />
-                <jet-input-error :message="form.errors.name" class="mt-2" />
+                <jet-input-error :message="form.errors.name" class="mt-1 ml-1" />
             </div>
         </template>
 

--- a/stubs/inertia/resources/js/Pages/Teams/TeamMemberManager.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/TeamMemberManager.vue
@@ -24,13 +24,13 @@
                     <div class="col-span-6 sm:col-span-4">
                         <jet-label for="email" value="Email" />
                         <jet-input id="email" type="email" class="mt-1 block w-full" v-model="addTeamMemberForm.email" />
-                        <jet-input-error :message="addTeamMemberForm.errors.email" class="mt-2" />
+                        <jet-input-error :message="addTeamMemberForm.errors.email" class="mt-1 ml-1" />
                     </div>
 
                     <!-- Role -->
                     <div class="col-span-6 lg:col-span-4" v-if="availableRoles.length > 0">
                         <jet-label for="roles" value="Role" />
-                        <jet-input-error :message="addTeamMemberForm.errors.role" class="mt-2" />
+                        <jet-input-error :message="addTeamMemberForm.errors.role" class="mt-1 ml-1" />
 
                         <div class="relative z-0 mt-1 border border-gray-200 rounded-lg cursor-pointer">
                             <button type="button" class="relative px-4 py-3 inline-flex w-full rounded-lg focus:z-10 focus:outline-none focus:border-blue-300 focus:ring focus:ring-blue-200"

--- a/stubs/inertia/resources/js/Pages/Teams/UpdateTeamNameForm.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/UpdateTeamNameForm.vue
@@ -33,7 +33,7 @@
                             v-model="form.name"
                             :disabled="! permissions.canUpdateTeam" />
 
-                <jet-input-error :message="form.errors.name" class="mt-2" />
+                <jet-input-error :message="form.errors.name" class="mt-1 ml-1" />
             </div>
         </template>
 

--- a/stubs/livewire/resources/views/api/api-token-manager.blade.php
+++ b/stubs/livewire/resources/views/api/api-token-manager.blade.php
@@ -14,7 +14,7 @@
             <div class="col-span-6 sm:col-span-4">
                 <x-jet-label for="name" value="{{ __('Token Name') }}" />
                 <x-jet-input id="name" type="text" class="mt-1 block w-full" wire:model.defer="createApiTokenForm.name" autofocus />
-                <x-jet-input-error for="name" class="mt-2" />
+                <x-jet-input-error for="name" class="mt-1 ml-1" />
             </div>
 
             <!-- Token Permissions -->

--- a/stubs/livewire/resources/views/profile/delete-user-form.blade.php
+++ b/stubs/livewire/resources/views/profile/delete-user-form.blade.php
@@ -34,7 +34,7 @@
                                 wire:model.defer="password"
                                 wire:keydown.enter="deleteUser" />
 
-                    <x-jet-input-error for="password" class="mt-2" />
+                    <x-jet-input-error for="password" class="mt-1 ml-1" />
                 </div>
             </x-slot>
 

--- a/stubs/livewire/resources/views/profile/logout-other-browser-sessions-form.blade.php
+++ b/stubs/livewire/resources/views/profile/logout-other-browser-sessions-form.blade.php
@@ -77,7 +77,7 @@
                                 wire:model.defer="password"
                                 wire:keydown.enter="logoutOtherBrowserSessions" />
 
-                    <x-jet-input-error for="password" class="mt-2" />
+                    <x-jet-input-error for="password" class="mt-1 ml-1" />
                 </div>
             </x-slot>
 

--- a/stubs/livewire/resources/views/profile/update-password-form.blade.php
+++ b/stubs/livewire/resources/views/profile/update-password-form.blade.php
@@ -11,19 +11,19 @@
         <div class="col-span-6 sm:col-span-4">
             <x-jet-label for="current_password" value="{{ __('Current Password') }}" />
             <x-jet-input id="current_password" type="password" class="mt-1 block w-full" wire:model.defer="state.current_password" autocomplete="current-password" />
-            <x-jet-input-error for="current_password" class="mt-2" />
+            <x-jet-input-error for="current_password" class="mt-1 ml-1" />
         </div>
 
         <div class="col-span-6 sm:col-span-4">
             <x-jet-label for="password" value="{{ __('New Password') }}" />
             <x-jet-input id="password" type="password" class="mt-1 block w-full" wire:model.defer="state.password" autocomplete="new-password" />
-            <x-jet-input-error for="password" class="mt-2" />
+            <x-jet-input-error for="password" class="mt-1 ml-1" />
         </div>
 
         <div class="col-span-6 sm:col-span-4">
             <x-jet-label for="password_confirmation" value="{{ __('Confirm Password') }}" />
             <x-jet-input id="password_confirmation" type="password" class="mt-1 block w-full" wire:model.defer="state.password_confirmation" autocomplete="new-password" />
-            <x-jet-input-error for="password_confirmation" class="mt-2" />
+            <x-jet-input-error for="password_confirmation" class="mt-1 ml-1" />
         </div>
     </x-slot>
 

--- a/stubs/livewire/resources/views/profile/update-profile-information-form.blade.php
+++ b/stubs/livewire/resources/views/profile/update-profile-information-form.blade.php
@@ -48,7 +48,7 @@
                     </x-jet-secondary-button>
                 @endif
 
-                <x-jet-input-error for="photo" class="mt-2" />
+                <x-jet-input-error for="photo" class="mt-1 ml-1" />
             </div>
         @endif
 
@@ -56,14 +56,14 @@
         <div class="col-span-6 sm:col-span-4">
             <x-jet-label for="name" value="{{ __('Name') }}" />
             <x-jet-input id="name" type="text" class="mt-1 block w-full" wire:model.defer="state.name" autocomplete="name" />
-            <x-jet-input-error for="name" class="mt-2" />
+            <x-jet-input-error for="name" class="mt-1 ml-1" />
         </div>
 
         <!-- Email -->
         <div class="col-span-6 sm:col-span-4">
             <x-jet-label for="email" value="{{ __('Email') }}" />
             <x-jet-input id="email" type="email" class="mt-1 block w-full" wire:model.defer="state.email" />
-            <x-jet-input-error for="email" class="mt-2" />
+            <x-jet-input-error for="email" class="mt-1 ml-1" />
         </div>
     </x-slot>
 

--- a/stubs/livewire/resources/views/teams/create-team-form.blade.php
+++ b/stubs/livewire/resources/views/teams/create-team-form.blade.php
@@ -24,7 +24,7 @@
         <div class="col-span-6 sm:col-span-4">
             <x-jet-label for="name" value="{{ __('Team Name') }}" />
             <x-jet-input id="name" type="text" class="mt-1 block w-full" wire:model.defer="state.name" autofocus />
-            <x-jet-input-error for="name" class="mt-2" />
+            <x-jet-input-error for="name" class="mt-1 ml-1" />
         </div>
     </x-slot>
 

--- a/stubs/livewire/resources/views/teams/team-member-manager.blade.php
+++ b/stubs/livewire/resources/views/teams/team-member-manager.blade.php
@@ -24,14 +24,14 @@
                     <div class="col-span-6 sm:col-span-4">
                         <x-jet-label for="email" value="{{ __('Email') }}" />
                         <x-jet-input id="email" type="email" class="mt-1 block w-full" wire:model.defer="addTeamMemberForm.email" />
-                        <x-jet-input-error for="email" class="mt-2" />
+                        <x-jet-input-error for="email" class="mt-1 ml-1" />
                     </div>
 
                     <!-- Role -->
                     @if (count($this->roles) > 0)
                         <div class="col-span-6 lg:col-span-4">
                             <x-jet-label for="role" value="{{ __('Role') }}" />
-                            <x-jet-input-error for="role" class="mt-2" />
+                            <x-jet-input-error for="role" class="mt-1 ml-1" />
 
                             <div class="relative z-0 mt-1 border border-gray-200 rounded-lg cursor-pointer">
                                 @foreach ($this->roles as $index => $role)

--- a/stubs/livewire/resources/views/teams/update-team-name-form.blade.php
+++ b/stubs/livewire/resources/views/teams/update-team-name-form.blade.php
@@ -32,7 +32,7 @@
                         wire:model.defer="state.name"
                         :disabled="! Gate::check('update', $team)" />
 
-            <x-jet-input-error for="name" class="mt-2" />
+            <x-jet-input-error for="name" class="mt-1 ml-1" />
         </div>
     </x-slot>
 


### PR DESCRIPTION
It's just a common UX mistake to not add a small left margin to elements that stick nearby to rounded elements. And even if they had an `mt-2` to be breathable, an `mt-1` makes them stick better to the input. Can be a game-changer when you have multiple inputs that need validation.

Consider the following before & after:

Before:
![before](https://user-images.githubusercontent.com/21983456/116744030-708edf00-aa02-11eb-8bdf-bf6e2bf2c8dc.png)

After:
![after](https://user-images.githubusercontent.com/21983456/116744049-7684c000-aa02-11eb-9373-4ff6da3260a5.png)

Even if it's not too much and it is a small change, it actually does offer a better overview of the elements due to the ratio compared with the input roundness.