### PR TITLE
[2.x] Inertia - clear user profile photo input

### DIFF
--- a/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
@@ -111,7 +111,8 @@
 
                 this.form.post(route('user-profile-information.update'), {
                     errorBag: 'updateProfileInformation',
-                    preserveScroll: true
+                    preserveScroll: true,
+                    onSuccess: () => (this.clearPhotoFileInput())
                 });
             },
 
@@ -132,8 +133,17 @@
             deletePhoto() {
                 this.$inertia.delete(route('current-user-photo.destroy'), {
                     preserveScroll: true,
-                    onSuccess: () => (this.photoPreview = null),
+                    onSuccess: () => {
+                        this.photoPreview = null;
+                        this.clearPhotoFileInput();
+                    },
                 });
+            },
+
+            clearPhotoFileInput() {
+                if (this.$refs.photo?.value) {
+                    this.$refs.photo.value = null;
+                }
             },
         },
     }

--- a/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
@@ -112,7 +112,7 @@
                 this.form.post(route('user-profile-information.update'), {
                     errorBag: 'updateProfileInformation',
                     preserveScroll: true,
-                    onSuccess: () => (this.clearPhotoFileInput())
+                    onSuccess: () => (this.clearPhotoFileInput()),
                 });
             },
 


### PR DESCRIPTION
### Description:

On inertia js stack, if jetstream profile photos feature is enabled then user selects a new photo and hits the save button several times without refreshing the page, the photo file input does not get cleared and inertia form would send the same file for each profile update post request via inertia post, also server would handle the file upload each time.

### Steps to reproduce:

#### Case 1

- Enable profile photos feature
- Visit the user profile page
- Select a new photo
- Click on the save button and do not refresh or navigate
- Save++
- Check form payload or users table profile_photo_path attribute or storage folder

#### Case 2

- Visit user profile page
- Select a new photo
- Click save and do not refresh or navigate
- Click remove photo button and click save, the removed photo will reappear again.