### PR TITLE
[2.x] Inertia - ensure file selection is not empty before updating profile photo preview

### DIFF
--- a/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
@@ -122,7 +122,8 @@
 
             updatePhotoPreview() {
                 const photo = this.$refs.photo.files[0];
-                if (!photo) return;
+
+                if (! photo) return;
 
                 const reader = new FileReader();
 

--- a/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
@@ -121,13 +121,16 @@
             },
 
             updatePhotoPreview() {
+                const photo = this.$refs.photo.files[0];
+                if (!photo) return;
+
                 const reader = new FileReader();
 
                 reader.onload = (e) => {
                     this.photoPreview = e.target.result;
                 };
 
-                reader.readAsDataURL(this.$refs.photo.files[0]);
+                reader.readAsDataURL(photo);
             },
 
             deletePhoto() {


### PR DESCRIPTION
**Description**
While selecting a new profile photo, canceling the file selection window results in errors being displayed in the console saying,

`Failed to execute 'readAsDataURL' on 'FileReader': parameter 1 is not of type 'Blob'.`

[Video demonstration](https://streamable.com/ick9ee)

For some reason, the `@change="updatePhotoPreview"` method is being triggered although no changes were made to the input. Possibly a Vue related issue since this doesn't happen in the Livewire stack?

Probably worth noting that I've run into this issue on Windows and specifically Chromium based browsers.


**Steps to reproduce**
- Enable profile photos feature.
- Visit the user profile page.
- Select a new photo.
- Select a new photo again, only this time leave your selection empty and click cancel.