### PR TITLE
[2.x] Remove dark classes from QR Code

### DIFF
--- a/stubs/inertia/resources/js/Pages/Profile/TwoFactorAuthenticationForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/TwoFactorAuthenticationForm.vue
@@ -31,7 +31,7 @@
                         </p>
                     </div>
 
-                    <div class="mt-4 dark:p-4 dark:w-56 dark:bg-white" v-html="qrCode">
+                    <div class="mt-4" v-html="qrCode">
                     </div>
                 </div>
 

--- a/stubs/livewire/resources/views/profile/two-factor-authentication-form.blade.php
+++ b/stubs/livewire/resources/views/profile/two-factor-authentication-form.blade.php
@@ -30,7 +30,7 @@
                     </p>
                 </div>
 
-                <div class="mt-4 dark:p-4 dark:w-56 dark:bg-white">
+                <div class="mt-4">
                     {!! $this->user->twoFactorQrCodeSvg() !!}
                 </div>
             @endif


### PR DESCRIPTION
This pull request removes dark classes from QR Code since Jetstream do not support dark mode.
