### PR TITLE
[2.x] Changed the column type of profile_photo_path

### DIFF
--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -21,7 +21,7 @@ class CreateUsersTable extends Migration
             $table->string('password');
             $table->rememberToken();
             $table->foreignId('current_team_id')->nullable();
-            $table->text('profile_photo_path')->nullable();
+            $table->string('profile_photo_path', 2048)->nullable();
             $table->timestamps();
         });
     }


### PR DESCRIPTION
As the TEXT type on some DBs, creates an column with a limit of 2/4 GB.

This should increase compatibly with other DBs, with no impact on the migration it self. But we DO limit the column length, which is a good thing for this column use case. As a good practice URI should not be longer then 2K.

There is no mention of max URI length in the RFC3986, but there are limitation imposed by the software like the browsers them self.

|DB        |typeString                                                                           |typeTinyText |typeText     |typeMediumText|typeLongText |
|----------|-------------------------------------------------------------------------------------|-------------|-------------|--------------|-------------|
|MySQL     |varchar({$column->length})                                                           |tinytext     |text         |mediumtext    |longtext     |
|PostgreSQL|varchar({$column->length})                                                           |varchar(255) |text         |text          |text         |
|SQLite    |varchar                                                                              |text         |text         |text          |text         |
|MSSQL     |varchar({$column->length})                                                           |nvarchar(255)|nvarchar(max)|nvarchar(max) |nvarchar(max)|
|Informix  |varchar({$column->length}) : length < 255 <br/>lvarchar({$column->length}) : length >= 255| text         |text         |text          |text         |

ref: issue #789