### PR TITLE
Add request banner & request dangerBanner macro

### DIFF
--- a/src/JetstreamServiceProvider.php
+++ b/src/JetstreamServiceProvider.php
@@ -76,6 +76,16 @@ class JetstreamServiceProvider extends ServiceProvider
         $this->configureRoutes();
         $this->configureCommands();
 
+        Request::macro('banner', function ($message) {
+            $this->session()->flash('flash.banner', $message);
+            $this->session()->flash('flash.bannerStyle', 'success');
+        });
+
+        Request::macro('dangerBanner', function ($message) {
+            $this->session()->flash('flash.banner', $message);
+            $this->session()->flash('flash.bannerStyle', 'danger');
+        });
+
         RedirectResponse::macro('banner', function ($message) {
             return $this->with('flash', [
                 'bannerStyle' => 'success',


### PR DESCRIPTION
## Description

it adds `banner` and `dangerBanner` request macros

## Benefit to end users

it could make easier to show jetstream banner and jetstream danger banner when a resource method returns a `view()` or an `inertia response`.

there is a scenario where a method does not return a redirect, an example could be:

```php
public function index(Request $request)
{
    if($this->paymentMethod->status === PaymentMethod::NOT_AVAILABLE) {
        $request->dangerBanner('your payment method is not available anymore');
    }
    
    $servers = Server::all();
    return Inertia::render('Servers/Index', compact('servers'));
}
```

Of course the logic could be change to another file/action, but for the sake to keep it simple to explain, it is enough, it would be useful on both stacks, it is just an example with Inertia.
