### PR TITLE
fix cors policy errors with inertia stack

### DIFF
--- a/stubs/inertia/resources/views/app.blade.php
+++ b/stubs/inertia/resources/views/app.blade.php
@@ -19,5 +19,9 @@
     </head>
     <body class="font-sans antialiased">
         @inertia
+
+        @if (app()->isLocal())
+            <script src="http://localhost:3000/browser-sync/browser-sync-client.js"></script>
+        @endif
     </body>
 </html>

--- a/stubs/inertia/resources/views/app.blade.php
+++ b/stubs/inertia/resources/views/app.blade.php
@@ -20,8 +20,8 @@
     <body class="font-sans antialiased">
         @inertia
 
-        @if (app()->isLocal())
+        @env ('local')
             <script src="http://localhost:3000/browser-sync/browser-sync-client.js"></script>
-        @endif
+        @endenv
     </body>
 </html>


### PR DESCRIPTION
## Description

on inertia stack a when you run `npm install && npm run watch` if you work with `.test` domains like Laravel Valet add, the watcher does not add live reload with `browserSync` you must work with `localhost` ip to work with vue components.

to avoid this by adding this tag on `app.blade.php` file on inertia stack it would reload `.test` domains as it is a `localhost` domain.

## How it help the end user

it avoid confusion on why vue components does not reload using browserSync by default, and make easier the workflow with inertia and of course with jetstream.
