### PR TITLE
[2.x] Allow Role's `$name` and `$description` to be translated

### DIFF
--- a/src/Role.php
+++ b/src/Role.php
@@ -71,8 +71,8 @@ class Role implements JsonSerializable
     {
         return [
             'key' => $this->key,
-            'name' => $this->name,
-            'description' => $this->description,
+            'name' => __($this->name),
+            'description' => __($this->description),
             'permissions' => $this->permissions,
         ];
     }


### PR DESCRIPTION
I'm not sure whether this should be considered as a breaking change. But this will avoid loading translation early in the request lifecycle and instead only require it to be translated when returning a response.