### PR TITLE
Skip registration tests if Fortify registration is disabled

### DIFF
--- a/stubs/tests/RegistrationTest.php
+++ b/stubs/tests/RegistrationTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Providers\RouteServiceProvider;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Fortify\Features;
 use Laravel\Jetstream\Jetstream;
 use Tests\TestCase;
 
@@ -13,13 +14,32 @@ class RegistrationTest extends TestCase
 
     public function test_registration_screen_can_be_rendered()
     {
+        if (! Features::enabled(Features::registration())) {
+            return $this->markTestSkipped('Registration support is not enabled.');
+        }
+
         $response = $this->get('/register');
 
         $response->assertStatus(200);
     }
 
+    public function test_registration_screen_cannot_be_rendered_if_support_is_disabled()
+    {
+        if (Features::enabled(Features::registration())) {
+            return $this->markTestSkipped('Registration support is enabled.');
+        }
+
+        $response = $this->get('/register');
+
+        $response->assertStatus(404);
+    }
+
     public function test_new_users_can_register()
     {
+        if (! Features::enabled(Features::registration())) {
+            return $this->markTestSkipped('Registration support is not enabled.');
+        }
+
         $response = $this->post('/register', [
             'name' => 'Test User',
             'email' => 'test@example.com',


### PR DESCRIPTION
Added checks to skip the tests if the registration support in Fortify is disabled, otherwise the tests fail.

