### PR TITLE
Remove overflow property when unmounted

### DIFF
--- a/stubs/inertia/resources/js/Jetstream/Modal.vue
+++ b/stubs/inertia/resources/js/Jetstream/Modal.vue
@@ -73,7 +73,10 @@ export default {
             }
 
             onMounted(() => document.addEventListener('keydown', closeOnEscape))
-            onUnmounted(() => document.removeEventListener('keydown', closeOnEscape))
+            onUnmounted(() => {
+                document.removeEventListener('keydown', closeOnEscape)
+                document.body.style.overflow = null
+            })
 
             return {
                 close,


### PR DESCRIPTION
Remove the <body> overflow:hidden style when the modal component is unmounted.

Fixes #800

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

If you change the behavior of the Inertia stack you're expected to update the Livewire stack as well and vice versa.
-->
