### PR TITLE
Update InstallCommand.php

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -265,7 +265,7 @@ EOF;
     protected function installInertiaStack()
     {
         // Install Inertia...
-        $this->requireComposerPackages('inertiajs/inertia-laravel:^0.3.5', 'laravel/sanctum:^2.6', 'tightenco/ziggy:^1.0');
+        $this->requireComposerPackages('inertiajs/inertia-laravel:^0.4.2', 'laravel/sanctum:^2.6', 'tightenco/ziggy:^1.0');
 
         // Install NPM packages...
         $this->updateNodePackages(function ($packages) {

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -270,9 +270,9 @@ EOF;
         // Install NPM packages...
         $this->updateNodePackages(function ($packages) {
             return [
-                '@inertiajs/inertia' => '^0.8.4',
-                '@inertiajs/inertia-vue3' => '^0.3.5',
-                '@inertiajs/progress' => '^0.2.4',
+                '@inertiajs/inertia' => '^0.9.1',
+                '@inertiajs/inertia-vue3' => '^0.4.2',
+                '@inertiajs/progress' => '^0.2.5',
                 '@tailwindcss/forms' => '^0.2.1',
                 '@tailwindcss/typography' => '^0.3.0',
                 'postcss-import' => '^12.0.1',


### PR DESCRIPTION
Similar to the issue I ran into with this https://github.com/laravel/breeze/pull/70/files

The current dependencies won't allow `spark-stripe` to be installed.