### PR TITLE
Tailwind JIT-Mode

### DIFF
--- a/stubs/inertia/tailwind.config.js
+++ b/stubs/inertia/tailwind.config.js
@@ -1,6 +1,7 @@
 const defaultTheme = require('tailwindcss/defaultTheme');
 
 module.exports = {
+    mode: 'jit',
     purge: [
         './vendor/laravel/framework/src/Illuminate/Pagination/resources/views/*.blade.php',
         './vendor/laravel/jetstream/**/*.blade.php',

--- a/stubs/livewire/tailwind.config.js
+++ b/stubs/livewire/tailwind.config.js
@@ -1,6 +1,7 @@
 const defaultTheme = require('tailwindcss/defaultTheme');
 
 module.exports = {
+    mode: 'jit',
     purge: [
         './vendor/laravel/framework/src/Illuminate/Pagination/resources/views/*.blade.php',
         './vendor/laravel/jetstream/**/*.blade.php',


### PR DESCRIPTION
Tailwind offers a new just-in-time mode for Tailwind V2.1+. This feature is currently in preview, but I believe it is already productive in the current version. I suggest the use of Tailwind jit. It offers some very valuable advantages. See the further [documentation](https://tailwindcss.com/docs/just-in-time-mode)