### PR TITLE
[2.x] Support both Alpine V2 and V3

### DIFF
--- a/resources/views/components/action-message.blade.php
+++ b/resources/views/components/action-message.blade.php
@@ -2,7 +2,7 @@
 
 <div x-data="{ shown: false, timeout: null }"
     x-init="@this.on('{{ $on }}', () => { clearTimeout(timeout); shown = true; timeout = setTimeout(() => { shown = false }, 2000);  })"
-    x-show="shown"
+    x-show.transition.out.opacity.duration.1500ms="shown"
     x-transition:leave.opacity.duration.1500ms
     style="display: none;"
     {{ $attributes->merge(['class' => 'text-sm text-gray-600']) }}>

--- a/resources/views/components/dropdown.blade.php
+++ b/resources/views/components/dropdown.blade.php
@@ -25,7 +25,7 @@ switch ($width) {
 }
 @endphp
 
-<div class="relative" x-data="{ open: false }" @click.outside="open = false" @close.stop="open = false">
+<div class="relative" x-data="{ open: false }" @click.away="open = false" @close.stop="open = false">
     <div @click="open = ! open">
         {{ $trigger }}
     </div>


### PR DESCRIPTION
Problem scenario:
* Someone updates Jetstream to the latest version that supports Alpine V3
* They don't update their Alpine version to V3 (because package.json/app.js doesn't get automatically updated)
* Jetsream is now broken in the following two ways:
  * The top right menu doesn't work because it uses `@click.outside` which is new in V3
![image](https://user-images.githubusercontent.com/3670578/123270967-5cc99b80-d4ce-11eb-8e82-68437043b126.png)
  * The little "Saved." indicator doesn't transition out because it uses `x-transition...` which is new in V3
![image](https://user-images.githubusercontent.com/3670578/123270996-62bf7c80-d4ce-11eb-9d6c-56ef8f9a018d.png)


Solution:
* Use `.away` instead of `.outside` - they are aliases and both exist in V2 and V3
* Include the legacy `x-show.transition...` as well as the new `x-transition...` helpers. Each will work on their respective versions without causing breakages.

After this PR, all Jetsream stubs will be upgrade safe and support any version of Alpine a project is using.