### PR TITLE
[2.x] Add ability to focus first modal element on opening

### DIFF
--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -33,7 +33,7 @@ $maxWidth = [
     x-init="$watch('show', value => {
         if (value) {
             document.body.classList.add('overflow-y-hidden');
-            {{ $attributes->has('focusable') ? 'setTimeout(() => firstFocusable().focus(), 10)' : '' }}
+            {{ $attributes->has('focusable') ? 'setTimeout(() => firstFocusable().focus(), 100)' : '' }}
         } else {
             document.body.classList.remove('overflow-y-hidden');
         }

--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -33,6 +33,7 @@ $maxWidth = [
     x-init="$watch('show', value => {
         if (value) {
             document.body.classList.add('overflow-y-hidden');
+            {{ $attributes->has('focusable') ? 'setTimeout(() => firstFocusable().focus(), 10)' : '' }}
         } else {
             document.body.classList.remove('overflow-y-hidden');
         }


### PR DESCRIPTION
This PR adds ability to use `focusable` attribute for focusing on first modal **_focusable_** element.
`<x-jet-dialog-modal wire:model="model" focusable>`
It's much faster, then tapping to first element on every modal open and makes user experience smoother and easier.
Otherwise, you can continue using current behaviour without breaking anything.