### PR TITLE
Update dropdown.blade.php

### DIFF
--- a/resources/views/components/dropdown.blade.php
+++ b/resources/views/components/dropdown.blade.php
@@ -25,7 +25,7 @@ switch ($width) {
 }
 @endphp
 
-<div class="relative" x-data="{ open: false }" @click.away="open = false" @close.stop="open = false">
+<div class="relative inline-flex" x-data="{ open: false }" @click.away="open = false" @close.stop="open = false">
     <div @click="open = ! open">
         {{ $trigger }}
     </div>

--- a/stubs/inertia/resources/js/Jetstream/Dropdown.vue
+++ b/stubs/inertia/resources/js/Jetstream/Dropdown.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="relative">
+    <div class="relative inline-flex">
         <div @click="open = ! open">
             <slot name="trigger"></slot>
         </div>


### PR DESCRIPTION
Add `inline-flex` to the outermost div element. It ensures that the size of the element is adjusted to the child content.
Without `inline-flex`, I have the problem that the alpine `@click` function is also executed outside the `$trigger` area.

![Bildschirmfoto von 2021-07-01 00-15-18](https://user-images.githubusercontent.com/44020272/124038796-07c3e300-da02-11eb-85f6-fd171ca8752f.png)
