### PR TITLE
Fix Inertia Default Banner Component Does Not Show After Dismissing

### DIFF
--- a/stubs/inertia/resources/js/Jetstream/Banner.vue
+++ b/stubs/inertia/resources/js/Jetstream/Banner.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <div :class="{ 'bg-indigo-500': style == 'success', 'bg-red-700': style == 'danger' }" v-if="show && message">
+        <div :class="{ 'bg-indigo-500': style == 'success', 'bg-red-700': style == 'danger' }" v-if="message">
             <div class="max-w-screen-xl mx-auto py-2 px-3 sm:px-6 lg:px-8">
                 <div class="flex items-center justify-between flex-wrap">
                     <div class="w-0 flex-1 flex items-center min-w-0">
@@ -25,7 +25,7 @@
                             class="-mr-1 flex p-2 rounded-md focus:outline-none sm:-mr-2 transition"
                             :class="{ 'hover:bg-indigo-600 focus:bg-indigo-600': style == 'success', 'hover:bg-red-600 focus:bg-red-600': style == 'danger' }"
                             aria-label="Dismiss"
-                            @click.prevent="show = false">
+                            @click.prevent="this.$page.props.jetstream.flash.banner = null">
                             <svg class="h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
                             </svg>
@@ -40,9 +40,7 @@
 <script>
     export default {
         data() {
-            return {
-                show: true,
-            }
+            return {}
         },
 
         computed: {


### PR DESCRIPTION
Right now dismissing the banner, it is not shown when newer message is flashed because the show property is set to false while dismissing.

This PR removes the show property and instead only depend upon the message property to toggle the banner. While dismissing just set ``this.$page.props.jetstream.flash.banner == null``


