### PR TITLE
Add Vue file extension to all Vue components imported

### DIFF
--- a/stubs/inertia/resources/js/Jetstream/ActionSection.vue
+++ b/stubs/inertia/resources/js/Jetstream/ActionSection.vue
@@ -14,7 +14,7 @@
 </template>
 
 <script>
-    import JetSectionTitle from './SectionTitle'
+    import JetSectionTitle from './SectionTitle.vue'
 
     export default {
         components: {

--- a/stubs/inertia/resources/js/Jetstream/ConfirmationModal.vue
+++ b/stubs/inertia/resources/js/Jetstream/ConfirmationModal.vue
@@ -28,7 +28,7 @@
 </template>
 
 <script>
-    import Modal from './Modal'
+    import Modal from './Modal.vue'
 
     export default {
         emits: ['close'],

--- a/stubs/inertia/resources/js/Jetstream/ConfirmsPassword.vue
+++ b/stubs/inertia/resources/js/Jetstream/ConfirmsPassword.vue
@@ -36,11 +36,11 @@
 </template>
 
 <script>
-    import JetButton from './Button'
-    import JetDialogModal from './DialogModal'
-    import JetInput from './Input'
-    import JetInputError from './InputError'
-    import JetSecondaryButton from './SecondaryButton'
+    import JetButton from './Button.vue'
+    import JetDialogModal from './DialogModal.vue'
+    import JetInput from './Input.vue'
+    import JetInputError from './InputError.vue'
+    import JetSecondaryButton from './SecondaryButton.vue'
 
     export default {
         emits: ['confirmed'],

--- a/stubs/inertia/resources/js/Jetstream/DialogModal.vue
+++ b/stubs/inertia/resources/js/Jetstream/DialogModal.vue
@@ -20,7 +20,7 @@
 </template>
 
 <script>
-    import Modal from './Modal'
+    import Modal from './Modal.vue'
 
     export default {
         emits: ['close'],

--- a/stubs/inertia/resources/js/Jetstream/FormSection.vue
+++ b/stubs/inertia/resources/js/Jetstream/FormSection.vue
@@ -23,7 +23,7 @@
 </template>
 
 <script>
-    import JetSectionTitle from './SectionTitle'
+    import JetSectionTitle from './SectionTitle.vue'
 
     export default {
         emits: ['submitted'],

--- a/stubs/inertia/resources/js/Jetstream/Welcome.vue
+++ b/stubs/inertia/resources/js/Jetstream/Welcome.vue
@@ -94,7 +94,7 @@
 </template>
 
 <script>
-    import JetApplicationLogo from '@/Jetstream/ApplicationLogo'
+    import JetApplicationLogo from '@/Jetstream/ApplicationLogo.vue'
 
     export default {
         components: {

--- a/stubs/inertia/resources/js/Layouts/AppLayout.vue
+++ b/stubs/inertia/resources/js/Layouts/AppLayout.vue
@@ -230,12 +230,12 @@
 </template>
 
 <script>
-    import JetApplicationMark from '@/Jetstream/ApplicationMark'
-    import JetBanner from '@/Jetstream/Banner'
-    import JetDropdown from '@/Jetstream/Dropdown'
-    import JetDropdownLink from '@/Jetstream/DropdownLink'
-    import JetNavLink from '@/Jetstream/NavLink'
-    import JetResponsiveNavLink from '@/Jetstream/ResponsiveNavLink'
+    import JetApplicationMark from '@/Jetstream/ApplicationMark.vue'
+    import JetBanner from '@/Jetstream/Banner.vue'
+    import JetDropdown from '@/Jetstream/Dropdown.vue'
+    import JetDropdownLink from '@/Jetstream/DropdownLink.vue'
+    import JetNavLink from '@/Jetstream/NavLink.vue'
+    import JetResponsiveNavLink from '@/Jetstream/ResponsiveNavLink.vue'
 
     export default {
         components: {

--- a/stubs/inertia/resources/js/Pages/API/ApiTokenManager.vue
+++ b/stubs/inertia/resources/js/Pages/API/ApiTokenManager.vue
@@ -164,19 +164,19 @@
 </template>
 
 <script>
-    import JetActionMessage from '@/Jetstream/ActionMessage'
-    import JetActionSection from '@/Jetstream/ActionSection'
-    import JetButton from '@/Jetstream/Button'
-    import JetConfirmationModal from '@/Jetstream/ConfirmationModal'
-    import JetDangerButton from '@/Jetstream/DangerButton'
-    import JetDialogModal from '@/Jetstream/DialogModal'
-    import JetFormSection from '@/Jetstream/FormSection'
-    import JetInput from '@/Jetstream/Input'
-    import JetCheckbox from '@/Jetstream/Checkbox'
-    import JetInputError from '@/Jetstream/InputError'
-    import JetLabel from '@/Jetstream/Label'
-    import JetSecondaryButton from '@/Jetstream/SecondaryButton'
-    import JetSectionBorder from '@/Jetstream/SectionBorder'
+    import JetActionMessage from '@/Jetstream/ActionMessage.vue'
+    import JetActionSection from '@/Jetstream/ActionSection.vue'
+    import JetButton from '@/Jetstream/Button.vue'
+    import JetConfirmationModal from '@/Jetstream/ConfirmationModal.vue'
+    import JetDangerButton from '@/Jetstream/DangerButton.vue'
+    import JetDialogModal from '@/Jetstream/DialogModal.vue'
+    import JetFormSection from '@/Jetstream/FormSection.vue'
+    import JetInput from '@/Jetstream/Input.vue'
+    import JetCheckbox from '@/Jetstream/Checkbox.vue'
+    import JetInputError from '@/Jetstream/InputError.vue'
+    import JetLabel from '@/Jetstream/Label.vue'
+    import JetSecondaryButton from '@/Jetstream/SecondaryButton.vue'
+    import JetSectionBorder from '@/Jetstream/SectionBorder.vue'
 
     export default {
         components: {

--- a/stubs/inertia/resources/js/Pages/API/Index.vue
+++ b/stubs/inertia/resources/js/Pages/API/Index.vue
@@ -17,8 +17,8 @@
 </template>
 
 <script>
-    import ApiTokenManager from './ApiTokenManager'
-    import AppLayout from '@/Layouts/AppLayout'
+    import ApiTokenManager from './ApiTokenManager.vue'
+    import AppLayout from '@/Layouts/AppLayout.vue'
 
     export default {
         props: [

--- a/stubs/inertia/resources/js/Pages/Auth/ConfirmPassword.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/ConfirmPassword.vue
@@ -26,12 +26,12 @@
 </template>
 
 <script>
-    import JetAuthenticationCard from '@/Jetstream/AuthenticationCard'
-    import JetAuthenticationCardLogo from '@/Jetstream/AuthenticationCardLogo'
-    import JetButton from '@/Jetstream/Button'
-    import JetInput from '@/Jetstream/Input'
-    import JetLabel from '@/Jetstream/Label'
-    import JetValidationErrors from '@/Jetstream/ValidationErrors'
+    import JetAuthenticationCard from '@/Jetstream/AuthenticationCard.vue'
+    import JetAuthenticationCardLogo from '@/Jetstream/AuthenticationCardLogo.vue'
+    import JetButton from '@/Jetstream/Button.vue'
+    import JetInput from '@/Jetstream/Input.vue'
+    import JetLabel from '@/Jetstream/Label.vue'
+    import JetValidationErrors from '@/Jetstream/ValidationErrors.vue'
 
     export default {
         components: {

--- a/stubs/inertia/resources/js/Pages/Auth/ForgotPassword.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/ForgotPassword.vue
@@ -30,12 +30,12 @@
 </template>
 
 <script>
-    import JetAuthenticationCard from '@/Jetstream/AuthenticationCard'
-    import JetAuthenticationCardLogo from '@/Jetstream/AuthenticationCardLogo'
-    import JetButton from '@/Jetstream/Button'
-    import JetInput from '@/Jetstream/Input'
-    import JetLabel from '@/Jetstream/Label'
-    import JetValidationErrors from '@/Jetstream/ValidationErrors'
+    import JetAuthenticationCard from '@/Jetstream/AuthenticationCard.vue'
+    import JetAuthenticationCardLogo from '@/Jetstream/AuthenticationCardLogo.vue'
+    import JetButton from '@/Jetstream/Button.vue'
+    import JetInput from '@/Jetstream/Input.vue'
+    import JetLabel from '@/Jetstream/Label.vue'
+    import JetValidationErrors from '@/Jetstream/ValidationErrors.vue'
 
     export default {
         components: {

--- a/stubs/inertia/resources/js/Pages/Auth/Login.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/Login.vue
@@ -42,13 +42,13 @@
 </template>
 
 <script>
-    import JetAuthenticationCard from '@/Jetstream/AuthenticationCard'
-    import JetAuthenticationCardLogo from '@/Jetstream/AuthenticationCardLogo'
-    import JetButton from '@/Jetstream/Button'
-    import JetInput from '@/Jetstream/Input'
-    import JetCheckbox from '@/Jetstream/Checkbox'
-    import JetLabel from '@/Jetstream/Label'
-    import JetValidationErrors from '@/Jetstream/ValidationErrors'
+    import JetAuthenticationCard from '@/Jetstream/AuthenticationCard.vue'
+    import JetAuthenticationCardLogo from '@/Jetstream/AuthenticationCardLogo.vue'
+    import JetButton from '@/Jetstream/Button.vue'
+    import JetInput from '@/Jetstream/Input.vue'
+    import JetCheckbox from '@/Jetstream/Checkbox.vue'
+    import JetLabel from '@/Jetstream/Label.vue'
+    import JetValidationErrors from '@/Jetstream/ValidationErrors.vue'
 
     export default {
         components: {

--- a/stubs/inertia/resources/js/Pages/Auth/Register.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/Register.vue
@@ -53,13 +53,13 @@
 </template>
 
 <script>
-    import JetAuthenticationCard from '@/Jetstream/AuthenticationCard'
-    import JetAuthenticationCardLogo from '@/Jetstream/AuthenticationCardLogo'
-    import JetButton from '@/Jetstream/Button'
-    import JetInput from '@/Jetstream/Input'
-    import JetCheckbox from "@/Jetstream/Checkbox";
-    import JetLabel from '@/Jetstream/Label'
-    import JetValidationErrors from '@/Jetstream/ValidationErrors'
+    import JetAuthenticationCard from '@/Jetstream/AuthenticationCard.vue'
+    import JetAuthenticationCardLogo from '@/Jetstream/AuthenticationCardLogo.vue'
+    import JetButton from '@/Jetstream/Button.vue'
+    import JetInput from '@/Jetstream/Input.vue'
+    import JetCheckbox from '@/Jetstream/Checkbox.vue'
+    import JetLabel from '@/Jetstream/Label.vue'
+    import JetValidationErrors from '@/Jetstream/ValidationErrors.vue'
 
     export default {
         components: {

--- a/stubs/inertia/resources/js/Pages/Auth/ResetPassword.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/ResetPassword.vue
@@ -32,12 +32,12 @@
 </template>
 
 <script>
-    import JetAuthenticationCard from '@/Jetstream/AuthenticationCard'
-    import JetAuthenticationCardLogo from '@/Jetstream/AuthenticationCardLogo'
-    import JetButton from '@/Jetstream/Button'
-    import JetInput from '@/Jetstream/Input'
-    import JetLabel from '@/Jetstream/Label'
-    import JetValidationErrors from '@/Jetstream/ValidationErrors'
+    import JetAuthenticationCard from '@/Jetstream/AuthenticationCard.vue'
+    import JetAuthenticationCardLogo from '@/Jetstream/AuthenticationCardLogo.vue'
+    import JetButton from '@/Jetstream/Button.vue'
+    import JetInput from '@/Jetstream/Input.vue'
+    import JetLabel from '@/Jetstream/Label.vue'
+    import JetValidationErrors from '@/Jetstream/ValidationErrors.vue'
 
     export default {
         components: {

--- a/stubs/inertia/resources/js/Pages/Auth/TwoFactorChallenge.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/TwoFactorChallenge.vue
@@ -47,12 +47,12 @@
 </template>
 
 <script>
-    import JetAuthenticationCard from '@/Jetstream/AuthenticationCard'
-    import JetAuthenticationCardLogo from '@/Jetstream/AuthenticationCardLogo'
-    import JetButton from '@/Jetstream/Button'
-    import JetInput from '@/Jetstream/Input'
-    import JetLabel from '@/Jetstream/Label'
-    import JetValidationErrors from '@/Jetstream/ValidationErrors'
+    import JetAuthenticationCard from '@/Jetstream/AuthenticationCard.vue'
+    import JetAuthenticationCardLogo from '@/Jetstream/AuthenticationCardLogo.vue'
+    import JetButton from '@/Jetstream/Button.vue'
+    import JetInput from '@/Jetstream/Input.vue'
+    import JetLabel from '@/Jetstream/Label.vue'
+    import JetValidationErrors from '@/Jetstream/ValidationErrors.vue'
 
     export default {
         components: {

--- a/stubs/inertia/resources/js/Pages/Auth/VerifyEmail.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/VerifyEmail.vue
@@ -25,9 +25,9 @@
 </template>
 
 <script>
-    import JetAuthenticationCard from '@/Jetstream/AuthenticationCard'
-    import JetAuthenticationCardLogo from '@/Jetstream/AuthenticationCardLogo'
-    import JetButton from '@/Jetstream/Button'
+    import JetAuthenticationCard from '@/Jetstream/AuthenticationCard.vue'
+    import JetAuthenticationCardLogo from '@/Jetstream/AuthenticationCardLogo.vue'
+    import JetButton from '@/Jetstream/Button.vue'
 
     export default {
         components: {

--- a/stubs/inertia/resources/js/Pages/Dashboard.vue
+++ b/stubs/inertia/resources/js/Pages/Dashboard.vue
@@ -17,8 +17,8 @@
 </template>
 
 <script>
-    import AppLayout from '@/Layouts/AppLayout'
-    import Welcome from '@/Jetstream/Welcome'
+    import AppLayout from '@/Layouts/AppLayout.vue'
+    import Welcome from '@/Jetstream/Welcome.vue'
 
     export default {
         components: {

--- a/stubs/inertia/resources/js/Pages/PrivacyPolicy.vue
+++ b/stubs/inertia/resources/js/Pages/PrivacyPolicy.vue
@@ -14,7 +14,7 @@
 </template>
 
 <script>
-import JetAuthenticationCardLogo from '@/Jetstream/AuthenticationCardLogo'
+import JetAuthenticationCardLogo from '@/Jetstream/AuthenticationCardLogo.vue'
 
 export default {
     props: ['policy'],

--- a/stubs/inertia/resources/js/Pages/Profile/DeleteUserForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/DeleteUserForm.vue
@@ -53,12 +53,12 @@
 </template>
 
 <script>
-    import JetActionSection from '@/Jetstream/ActionSection'
-    import JetDialogModal from '@/Jetstream/DialogModal'
-    import JetDangerButton from '@/Jetstream/DangerButton'
-    import JetInput from '@/Jetstream/Input'
-    import JetInputError from '@/Jetstream/InputError'
-    import JetSecondaryButton from '@/Jetstream/SecondaryButton'
+    import JetActionSection from '@/Jetstream/ActionSection.vue'
+    import JetDialogModal from '@/Jetstream/DialogModal.vue'
+    import JetDangerButton from '@/Jetstream/DangerButton.vue'
+    import JetInput from '@/Jetstream/Input.vue'
+    import JetInputError from '@/Jetstream/InputError.vue'
+    import JetSecondaryButton from '@/Jetstream/SecondaryButton.vue'
 
     export default {
         components: {

--- a/stubs/inertia/resources/js/Pages/Profile/LogoutOtherBrowserSessionsForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/LogoutOtherBrowserSessionsForm.vue
@@ -87,13 +87,13 @@
 </template>
 
 <script>
-    import JetActionMessage from '@/Jetstream/ActionMessage'
-    import JetActionSection from '@/Jetstream/ActionSection'
-    import JetButton from '@/Jetstream/Button'
-    import JetDialogModal from '@/Jetstream/DialogModal'
-    import JetInput from '@/Jetstream/Input'
-    import JetInputError from '@/Jetstream/InputError'
-    import JetSecondaryButton from '@/Jetstream/SecondaryButton'
+    import JetActionMessage from '@/Jetstream/ActionMessage.vue'
+    import JetActionSection from '@/Jetstream/ActionSection.vue'
+    import JetButton from '@/Jetstream/Button.vue'
+    import JetDialogModal from '@/Jetstream/DialogModal.vue'
+    import JetInput from '@/Jetstream/Input.vue'
+    import JetInputError from '@/Jetstream/InputError.vue'
+    import JetSecondaryButton from '@/Jetstream/SecondaryButton.vue'
 
     export default {
         props: ['sessions'],

--- a/stubs/inertia/resources/js/Pages/Profile/Show.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/Show.vue
@@ -39,13 +39,13 @@
 </template>
 
 <script>
-    import AppLayout from '@/Layouts/AppLayout'
-    import DeleteUserForm from './DeleteUserForm'
-    import JetSectionBorder from '@/Jetstream/SectionBorder'
-    import LogoutOtherBrowserSessionsForm from './LogoutOtherBrowserSessionsForm'
-    import TwoFactorAuthenticationForm from './TwoFactorAuthenticationForm'
-    import UpdatePasswordForm from './UpdatePasswordForm'
-    import UpdateProfileInformationForm from './UpdateProfileInformationForm'
+    import AppLayout from '@/Layouts/AppLayout.vue'
+    import DeleteUserForm from './DeleteUserForm.vue'
+    import JetSectionBorder from '@/Jetstream/SectionBorder.vue'
+    import LogoutOtherBrowserSessionsForm from './LogoutOtherBrowserSessionsForm.vue'
+    import TwoFactorAuthenticationForm from './TwoFactorAuthenticationForm.vue'
+    import UpdatePasswordForm from './UpdatePasswordForm.vue'
+    import UpdateProfileInformationForm from './UpdateProfileInformationForm.vue'
 
     export default {
         props: ['sessions'],

--- a/stubs/inertia/resources/js/Pages/Profile/TwoFactorAuthenticationForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/TwoFactorAuthenticationForm.vue
@@ -87,11 +87,11 @@
 </template>
 
 <script>
-    import JetActionSection from '@/Jetstream/ActionSection'
-    import JetButton from '@/Jetstream/Button'
-    import JetConfirmsPassword from '@/Jetstream/ConfirmsPassword'
-    import JetDangerButton from '@/Jetstream/DangerButton'
-    import JetSecondaryButton from '@/Jetstream/SecondaryButton'
+    import JetActionSection from '@/Jetstream/ActionSection.vue'
+    import JetButton from '@/Jetstream/Button.vue'
+    import JetConfirmsPassword from '@/Jetstream/ConfirmsPassword.vue'
+    import JetDangerButton from '@/Jetstream/DangerButton.vue'
+    import JetSecondaryButton from '@/Jetstream/SecondaryButton.vue'
 
     export default {
         components: {

--- a/stubs/inertia/resources/js/Pages/Profile/UpdatePasswordForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/UpdatePasswordForm.vue
@@ -41,12 +41,12 @@
 </template>
 
 <script>
-    import JetActionMessage from '@/Jetstream/ActionMessage'
-    import JetButton from '@/Jetstream/Button'
-    import JetFormSection from '@/Jetstream/FormSection'
-    import JetInput from '@/Jetstream/Input'
-    import JetInputError from '@/Jetstream/InputError'
-    import JetLabel from '@/Jetstream/Label'
+    import JetActionMessage from '@/Jetstream/ActionMessage.vue'
+    import JetButton from '@/Jetstream/Button.vue'
+    import JetFormSection from '@/Jetstream/FormSection.vue'
+    import JetInput from '@/Jetstream/Input.vue'
+    import JetInputError from '@/Jetstream/InputError.vue'
+    import JetLabel from '@/Jetstream/Label.vue'
 
     export default {
         components: {

--- a/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/UpdateProfileInformationForm.vue
@@ -69,13 +69,13 @@
 </template>
 
 <script>
-    import JetButton from '@/Jetstream/Button'
-    import JetFormSection from '@/Jetstream/FormSection'
-    import JetInput from '@/Jetstream/Input'
-    import JetInputError from '@/Jetstream/InputError'
-    import JetLabel from '@/Jetstream/Label'
-    import JetActionMessage from '@/Jetstream/ActionMessage'
-    import JetSecondaryButton from '@/Jetstream/SecondaryButton'
+    import JetButton from '@/Jetstream/Button.vue'
+    import JetFormSection from '@/Jetstream/FormSection.vue'
+    import JetInput from '@/Jetstream/Input.vue'
+    import JetInputError from '@/Jetstream/InputError.vue'
+    import JetLabel from '@/Jetstream/Label.vue'
+    import JetActionMessage from '@/Jetstream/ActionMessage.vue'
+    import JetSecondaryButton from '@/Jetstream/SecondaryButton.vue'
 
     export default {
         components: {

--- a/stubs/inertia/resources/js/Pages/Teams/Create.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/Create.vue
@@ -15,8 +15,8 @@
 </template>
 
 <script>
-    import AppLayout from '@/Layouts/AppLayout'
-    import CreateTeamForm from './CreateTeamForm'
+    import AppLayout from '@/Layouts/AppLayout.vue'
+    import CreateTeamForm from './CreateTeamForm.vue'
 
     export default {
         components: {

--- a/stubs/inertia/resources/js/Pages/Teams/CreateTeamForm.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/CreateTeamForm.vue
@@ -38,11 +38,11 @@
 </template>
 
 <script>
-    import JetButton from '@/Jetstream/Button'
-    import JetFormSection from '@/Jetstream/FormSection'
-    import JetInput from '@/Jetstream/Input'
-    import JetInputError from '@/Jetstream/InputError'
-    import JetLabel from '@/Jetstream/Label'
+    import JetButton from '@/Jetstream/Button.vue'
+    import JetFormSection from '@/Jetstream/FormSection.vue'
+    import JetInput from '@/Jetstream/Input.vue'
+    import JetInputError from '@/Jetstream/InputError.vue'
+    import JetLabel from '@/Jetstream/Label.vue'
 
     export default {
         components: {

--- a/stubs/inertia/resources/js/Pages/Teams/DeleteTeamForm.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/DeleteTeamForm.vue
@@ -44,10 +44,10 @@
 </template>
 
 <script>
-    import JetActionSection from '@/Jetstream/ActionSection'
-    import JetConfirmationModal from '@/Jetstream/ConfirmationModal'
-    import JetDangerButton from '@/Jetstream/DangerButton'
-    import JetSecondaryButton from '@/Jetstream/SecondaryButton'
+    import JetActionSection from '@/Jetstream/ActionSection.vue'
+    import JetConfirmationModal from '@/Jetstream/ConfirmationModal.vue'
+    import JetDangerButton from '@/Jetstream/DangerButton.vue'
+    import JetSecondaryButton from '@/Jetstream/SecondaryButton.vue'
 
     export default {
         props: ['team'],

--- a/stubs/inertia/resources/js/Pages/Teams/Show.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/Show.vue
@@ -26,11 +26,11 @@
 </template>
 
 <script>
-    import TeamMemberManager from './TeamMemberManager'
-    import AppLayout from '@/Layouts/AppLayout'
-    import DeleteTeamForm from './DeleteTeamForm'
-    import JetSectionBorder from '@/Jetstream/SectionBorder'
-    import UpdateTeamNameForm from './UpdateTeamNameForm'
+    import TeamMemberManager from './TeamMemberManager.vue'
+    import AppLayout from '@/Layouts/AppLayout.vue'
+    import DeleteTeamForm from './DeleteTeamForm.vue'
+    import JetSectionBorder from '@/Jetstream/SectionBorder.vue'
+    import UpdateTeamNameForm from './UpdateTeamNameForm.vue'
 
     export default {
         props: [

--- a/stubs/inertia/resources/js/Pages/Teams/TeamMemberManager.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/TeamMemberManager.vue
@@ -247,18 +247,18 @@
 </template>
 
 <script>
-    import JetActionMessage from '@/Jetstream/ActionMessage'
-    import JetActionSection from '@/Jetstream/ActionSection'
-    import JetButton from '@/Jetstream/Button'
-    import JetConfirmationModal from '@/Jetstream/ConfirmationModal'
-    import JetDangerButton from '@/Jetstream/DangerButton'
-    import JetDialogModal from '@/Jetstream/DialogModal'
-    import JetFormSection from '@/Jetstream/FormSection'
-    import JetInput from '@/Jetstream/Input'
-    import JetInputError from '@/Jetstream/InputError'
-    import JetLabel from '@/Jetstream/Label'
-    import JetSecondaryButton from '@/Jetstream/SecondaryButton'
-    import JetSectionBorder from '@/Jetstream/SectionBorder'
+    import JetActionMessage from '@/Jetstream/ActionMessage.vue'
+    import JetActionSection from '@/Jetstream/ActionSection.vue'
+    import JetButton from '@/Jetstream/Button.vue'
+    import JetConfirmationModal from '@/Jetstream/ConfirmationModal.vue'
+    import JetDangerButton from '@/Jetstream/DangerButton.vue'
+    import JetDialogModal from '@/Jetstream/DialogModal.vue'
+    import JetFormSection from '@/Jetstream/FormSection.vue'
+    import JetInput from '@/Jetstream/Input.vue'
+    import JetInputError from '@/Jetstream/InputError.vue'
+    import JetLabel from '@/Jetstream/Label.vue'
+    import JetSecondaryButton from '@/Jetstream/SecondaryButton.vue'
+    import JetSectionBorder from '@/Jetstream/SectionBorder.vue'
 
     export default {
         components: {

--- a/stubs/inertia/resources/js/Pages/TermsOfService.vue
+++ b/stubs/inertia/resources/js/Pages/TermsOfService.vue
@@ -14,7 +14,7 @@
 </template>
 
 <script>
-import JetAuthenticationCardLogo from '@/Jetstream/AuthenticationCardLogo'
+import JetAuthenticationCardLogo from '@/Jetstream/AuthenticationCardLogo.vue'
 
 export default {
     props: ['terms'],

--- a/stubs/inertia/resources/js/app.js
+++ b/stubs/inertia/resources/js/app.js
@@ -11,7 +11,7 @@ createApp({
     render: () =>
         h(InertiaApp, {
             initialPage: JSON.parse(el.dataset.page),
-            resolveComponent: (name) => require(`./Pages/${name}`).default,
+            resolveComponent: (name) => require(`./Pages/${name}.vue`).default,
         }),
 })
     .mixin({ methods: { route } })


### PR DESCRIPTION
This PR adds the `.vue` extension to all Jetstream imports.

This will become useful when someone want to switch from Laravel Mix to ViteJS because Vite does not support extension-less Vue imports. You can take a look here (https://github.com/vitejs/vite/issues/178#issuecomment-630138450)