### PR TITLE
[2.x] Defer to Fortify for password confirmation

### DIFF
--- a/src/Http/Controllers/Inertia/CurrentUserController.php
+++ b/src/Http/Controllers/Inertia/CurrentUserController.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
 use Laravel\Jetstream\Contracts\DeletesUsers;
+use Laravel\Fortify\Actions\ConfirmPassword;
 
 class CurrentUserController extends Controller
 {
@@ -16,18 +17,23 @@ class CurrentUserController extends Controller
      * Delete the current user.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  \Illuminate\Contracts\Auth\StatefulGuard  $auth
+     * @param  \Illuminate\Contracts\Auth\StatefulGuard  $guard
      * @return \Illuminate\Http\Response
      */
-    public function destroy(Request $request, StatefulGuard $auth)
+    public function destroy(Request $request, StatefulGuard $guard)
     {
-        $request->validate([
-            'password' => 'required|string|password',
-        ]);
+        $confirmed = app(ConfirmPassword::class)(
+            $guard, $request->user(), $request->password
+        );
+
+        if (! $confirmed)
+            throw new ValidationException::withMessages([
+                "password" => _('The password is incorrect..')
+            ]);
 
         app(DeletesUsers::class)->delete($request->user()->fresh());
 
-        $auth->logout();
+        $guard->logout();
 
         $request->session()->invalidate();
         $request->session()->regenerateToken();

--- a/src/Http/Controllers/Inertia/CurrentUserController.php
+++ b/src/Http/Controllers/Inertia/CurrentUserController.php
@@ -8,8 +8,8 @@ use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
-use Laravel\Jetstream\Contracts\DeletesUsers;
 use Laravel\Fortify\Actions\ConfirmPassword;
+use Laravel\Jetstream\Contracts\DeletesUsers;
 
 class CurrentUserController extends Controller
 {

--- a/src/Http/Controllers/Inertia/CurrentUserController.php
+++ b/src/Http/Controllers/Inertia/CurrentUserController.php
@@ -10,7 +10,6 @@ use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
 use Laravel\Jetstream\Contracts\DeletesUsers;
 use Laravel\Fortify\Actions\ConfirmPassword;
-use function _;
 
 class CurrentUserController extends Controller
 {
@@ -27,10 +26,11 @@ class CurrentUserController extends Controller
             $guard, $request->user(), $request->password
         );
 
-        if (! $confirmed)
+        if (! $confirmed) {
             throw ValidationException::withMessages([
-                "password" => "The password is incorrect."
+                'password' => 'The password is incorrect.'
             ]);
+        }
 
         app(DeletesUsers::class)->delete($request->user()->fresh());
 

--- a/src/Http/Controllers/Inertia/CurrentUserController.php
+++ b/src/Http/Controllers/Inertia/CurrentUserController.php
@@ -28,7 +28,7 @@ class CurrentUserController extends Controller
 
         if (! $confirmed) {
             throw ValidationException::withMessages([
-                'password' => 'The password is incorrect.'
+                'password' => 'The password is incorrect.',
             ]);
         }
 

--- a/src/Http/Controllers/Inertia/CurrentUserController.php
+++ b/src/Http/Controllers/Inertia/CurrentUserController.php
@@ -10,6 +10,7 @@ use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
 use Laravel\Jetstream\Contracts\DeletesUsers;
 use Laravel\Fortify\Actions\ConfirmPassword;
+use function _;
 
 class CurrentUserController extends Controller
 {
@@ -27,8 +28,8 @@ class CurrentUserController extends Controller
         );
 
         if (! $confirmed)
-            throw new ValidationException::withMessages([
-                "password" => _('The password is incorrect..')
+            throw ValidationException::withMessages([
+                "password" => "The password is incorrect."
             ]);
 
         app(DeletesUsers::class)->delete($request->user()->fresh());

--- a/src/Http/Controllers/Inertia/OtherBrowserSessionsController.php
+++ b/src/Http/Controllers/Inertia/OtherBrowserSessionsController.php
@@ -8,6 +8,7 @@ use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\ValidationException;
+use Laravel\Fortify\Actions\ConfirmPassword;
 
 class OtherBrowserSessionsController extends Controller
 {
@@ -20,9 +21,14 @@ class OtherBrowserSessionsController extends Controller
      */
     public function destroy(Request $request, StatefulGuard $guard)
     {
-        $request->validate([
-            'password' => 'required|string|password',
-        ]);
+        $confirmed = app(ConfirmPassword::class)(
+            $guard, $request->user(), $request->password
+        );
+
+        if (! $confirmed)
+            throw new ValidationException::withMessages([
+                "password" => _('The password is incorrect..')
+            ]);
 
         $guard->logoutOtherDevices($request->password);
 

--- a/src/Http/Controllers/Inertia/OtherBrowserSessionsController.php
+++ b/src/Http/Controllers/Inertia/OtherBrowserSessionsController.php
@@ -26,8 +26,8 @@ class OtherBrowserSessionsController extends Controller
         );
 
         if (! $confirmed)
-            throw new ValidationException::withMessages([
-                "password" => _('The password is incorrect..')
+            throw ValidationException::withMessages([
+                "password" => "The password is incorrect."
             ]);
 
         $guard->logoutOtherDevices($request->password);

--- a/src/Http/Controllers/Inertia/OtherBrowserSessionsController.php
+++ b/src/Http/Controllers/Inertia/OtherBrowserSessionsController.php
@@ -27,7 +27,7 @@ class OtherBrowserSessionsController extends Controller
 
         if (! $confirmed) {
             throw ValidationException::withMessages([
-                'password' => 'The password is incorrect.'
+                'password' => 'The password is incorrect.',
             ]);
         }
 

--- a/src/Http/Controllers/Inertia/OtherBrowserSessionsController.php
+++ b/src/Http/Controllers/Inertia/OtherBrowserSessionsController.php
@@ -25,10 +25,11 @@ class OtherBrowserSessionsController extends Controller
             $guard, $request->user(), $request->password
         );
 
-        if (! $confirmed)
+        if (! $confirmed) {
             throw ValidationException::withMessages([
-                "password" => "The password is incorrect."
+                'password' => 'The password is incorrect.'
             ]);
+        }
 
         $guard->logoutOtherDevices($request->password);
 


### PR DESCRIPTION
**Problem**: Password confirmation within Jetstream (Inertia) is not consistent. This breaks certain key features when using custom handling for confirming passwords e.g. when using a non-standard guard or user provider. 

- Password confirmation for enabling 2FA uses Fortify's `ConfirmPassword` action and can be customized by hooking into `confirmPasswordUsing`. This feature is working.
```
$confirmed = app(ConfirmPassword::class)(
    $this->guard, $request->user(), $request->input('password')
);
```
- **Password confirmation for account deletion** and **signing out other browser sessions** use Laravel's password validation rule and can't be customized (easily). Password validation fails and these features don't work.
```
$request->validate([
    'password' => 'required|string|password',
]);
```

**Solution**: Defer to Fortify for password confirmation during account deletion and signing out other browser sessions.

@driesvints I did see your comment on #831 and I'm not trying to be spammy with this. I did try asking around in the community about this and got zero feedback. Nevertheless, I do believe this is an actual bug (or incomplete feature) and more than a question about implementation. Accounts can't be deleted without hacking Laravel's password validation rule.
