### PR TITLE
Missing localization for owner role name

### DIFF
--- a/src/OwnerRole.php
+++ b/src/OwnerRole.php
@@ -11,6 +11,6 @@ class OwnerRole extends Role
      */
     public function __construct()
     {
-        parent::__construct('owner', 'Owner', ['*']);
+        parent::__construct('owner', __('Owner'), ['*']);
     }
 }


### PR DESCRIPTION
Working on with my issue (#833), I've seen that `OwnerRole` was missing of the localization.
