### PR TITLE
Fix for League\commonmark 2.0 breaking Terms of Service / Privacy Policy feature

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "ext-json": "*",
         "illuminate/support": "^8.0",
         "jenssegers/agent": "^2.6",
-        "league/commonmark": "^2.0",
+        "league/commonmark": "^1.3|^2.0",
         "laravel/fortify": "^1.6.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "ext-json": "*",
         "illuminate/support": "^8.0",
         "jenssegers/agent": "^2.6",
-        "league/commonmark": "^1.3|^2.0",
+        "league/commonmark": "^2.0",
         "laravel/fortify": "^1.6.1"
     },
     "require-dev": {

--- a/src/Http/Controllers/Inertia/PrivacyPolicyController.php
+++ b/src/Http/Controllers/Inertia/PrivacyPolicyController.php
@@ -6,9 +6,7 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Inertia\Inertia;
 use Laravel\Jetstream\Jetstream;
-use League\CommonMark\CommonMarkConverter;
-use League\CommonMark\Environment;
-use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
+use League\CommonMark\GithubFlavoredMarkdownConverter;
 
 class PrivacyPolicyController extends Controller
 {
@@ -22,11 +20,8 @@ class PrivacyPolicyController extends Controller
     {
         $policyFile = Jetstream::localizedMarkdownPath('policy.md');
 
-        $environment = Environment::createCommonMarkEnvironment();
-        $environment->addExtension(new GithubFlavoredMarkdownExtension());
-
         return Inertia::render('PrivacyPolicy', [
-            'policy' => (new CommonMarkConverter([], $environment))->convertToHtml(file_get_contents($policyFile)),
+            'policy' => (new GithubFlavoredMarkdownConverter())->convertToHtml(file_get_contents($policyFile)),
         ]);
     }
 }

--- a/src/Http/Controllers/Inertia/TermsOfServiceController.php
+++ b/src/Http/Controllers/Inertia/TermsOfServiceController.php
@@ -6,9 +6,7 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Inertia\Inertia;
 use Laravel\Jetstream\Jetstream;
-use League\CommonMark\CommonMarkConverter;
-use League\CommonMark\Environment;
-use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
+use League\CommonMark\GithubFlavoredMarkdownConverter;
 
 class TermsOfServiceController extends Controller
 {
@@ -22,11 +20,8 @@ class TermsOfServiceController extends Controller
     {
         $termsFile = Jetstream::localizedMarkdownPath('terms.md');
 
-        $environment = Environment::createCommonMarkEnvironment();
-        $environment->addExtension(new GithubFlavoredMarkdownExtension());
-
         return Inertia::render('TermsOfService', [
-            'terms' => (new CommonMarkConverter([], $environment))->convertToHtml(file_get_contents($termsFile)),
+            'terms' => (new GithubFlavoredMarkdownConverter())->convertToHtml(file_get_contents($termsFile)),
         ]);
     }
 }

--- a/src/Http/Controllers/Livewire/PrivacyPolicyController.php
+++ b/src/Http/Controllers/Livewire/PrivacyPolicyController.php
@@ -5,9 +5,7 @@ namespace Laravel\Jetstream\Http\Controllers\Livewire;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Laravel\Jetstream\Jetstream;
-use League\CommonMark\CommonMarkConverter;
-use League\CommonMark\Environment;
-use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
+use League\CommonMark\GithubFlavoredMarkdownConverter;
 
 class PrivacyPolicyController extends Controller
 {
@@ -21,11 +19,8 @@ class PrivacyPolicyController extends Controller
     {
         $policyFile = Jetstream::localizedMarkdownPath('policy.md');
 
-        $environment = Environment::createCommonMarkEnvironment();
-        $environment->addExtension(new GithubFlavoredMarkdownExtension());
-
         return view('policy', [
-            'policy' => (new CommonMarkConverter([], $environment))->convertToHtml(file_get_contents($policyFile)),
+            'policy' => (new GithubFlavoredMarkdownConverter())->convertToHtml(file_get_contents($policyFile)),
         ]);
     }
 }

--- a/src/Http/Controllers/Livewire/TermsOfServiceController.php
+++ b/src/Http/Controllers/Livewire/TermsOfServiceController.php
@@ -5,9 +5,7 @@ namespace Laravel\Jetstream\Http\Controllers\Livewire;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Laravel\Jetstream\Jetstream;
-use League\CommonMark\CommonMarkConverter;
-use League\CommonMark\Environment;
-use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
+use League\CommonMark\GithubFlavoredMarkdownConverter;
 
 class TermsOfServiceController extends Controller
 {
@@ -21,11 +19,8 @@ class TermsOfServiceController extends Controller
     {
         $termsFile = Jetstream::localizedMarkdownPath('terms.md');
 
-        $environment = Environment::createCommonMarkEnvironment();
-        $environment->addExtension(new GithubFlavoredMarkdownExtension());
-
         return view('terms', [
-            'terms' => (new CommonMarkConverter([], $environment))->convertToHtml(file_get_contents($termsFile)),
+            'terms' => (new GithubFlavoredMarkdownConverter())->convertToHtml(file_get_contents($termsFile)),
         ]);
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

If you change the behavior of the Inertia stack you're expected to update the Livewire stack as well and vice versa.
-->

A couple days ago commonmark was updated to 2.0 with deprecated features and changes. 

See https://commonmark.thephpleague.com/2.0/upgrading/developers/

Recently the composer.json for jetstream was updated to allow the 2.0 version of commonmark to be used. 
When you create a new laravel project and install jetstream the 2.0 version gets installed. This breaks the TOS/Privacy Policy feature since the class League\CommonMark\Environment has been renamed League\CommonMark\Environment\Environment.

This PR is to update to the commonmark 2.0 method of calling the GithubFlavoredMarkdownConverter. 

Thank you.
