### PR TITLE
[2.x] Support both CommonMark v1 & v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "ext-json": "*",
         "illuminate/support": "^8.0",
         "jenssegers/agent": "^2.6",
-        "league/commonmark": "^2.0",
+        "league/commonmark": "^1.3|^2.0",
         "laravel/fortify": "^1.6.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "ext-json": "*",
         "illuminate/support": "^8.0",
         "jenssegers/agent": "^2.6",
-        "league/commonmark": "^1.3|^2.0",
+        "league/commonmark": "^2.0",
         "laravel/fortify": "^1.6.1"
     },
     "require-dev": {

--- a/src/Http/Controllers/Inertia/PrivacyPolicyController.php
+++ b/src/Http/Controllers/Inertia/PrivacyPolicyController.php
@@ -4,9 +4,9 @@ namespace Laravel\Jetstream\Http\Controllers\Inertia;
 
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Str;
 use Inertia\Inertia;
 use Laravel\Jetstream\Jetstream;
-use League\CommonMark\GithubFlavoredMarkdownConverter;
 
 class PrivacyPolicyController extends Controller
 {
@@ -21,7 +21,7 @@ class PrivacyPolicyController extends Controller
         $policyFile = Jetstream::localizedMarkdownPath('policy.md');
 
         return Inertia::render('PrivacyPolicy', [
-            'policy' => (new GithubFlavoredMarkdownConverter())->convertToHtml(file_get_contents($policyFile)),
+            'policy' => Str::markdown(file_get_contents($policyFile)),
         ]);
     }
 }

--- a/src/Http/Controllers/Inertia/PrivacyPolicyController.php
+++ b/src/Http/Controllers/Inertia/PrivacyPolicyController.php
@@ -6,9 +6,7 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Inertia\Inertia;
 use Laravel\Jetstream\Jetstream;
-use League\CommonMark\CommonMarkConverter;
-use League\CommonMark\Environment;
-use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
+use League\CommonMark\GithubFlavoredMarkdownConverter;
 
 class PrivacyPolicyController extends Controller
 {
@@ -22,11 +20,8 @@ class PrivacyPolicyController extends Controller
     {
         $policyFile = Jetstream::localizedMarkdownPath('policy.md');
 
-        $environment = Environment::createCommonMarkEnvironment();
-        $environment->addExtension(new GithubFlavoredMarkdownExtension());
-
         return Inertia::render('PrivacyPolicy', [
-            'policy' => (new CommonMarkConverter([], $environment))->convertToHtml(file_get_contents($policyFile)),
+            'policy' => (new GithubFlavoredMarkdownConverter())->convertToHtml(file_get_contents($policyFile)),
         ]);
     }
 }

--- a/src/Http/Controllers/Inertia/TermsOfServiceController.php
+++ b/src/Http/Controllers/Inertia/TermsOfServiceController.php
@@ -4,9 +4,9 @@ namespace Laravel\Jetstream\Http\Controllers\Inertia;
 
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Str;
 use Inertia\Inertia;
 use Laravel\Jetstream\Jetstream;
-use League\CommonMark\GithubFlavoredMarkdownConverter;
 
 class TermsOfServiceController extends Controller
 {
@@ -21,7 +21,7 @@ class TermsOfServiceController extends Controller
         $termsFile = Jetstream::localizedMarkdownPath('terms.md');
 
         return Inertia::render('TermsOfService', [
-            'terms' => (new GithubFlavoredMarkdownConverter())->convertToHtml(file_get_contents($termsFile)),
+            'terms' => Str::markdown(file_get_contents($termsFile)),
         ]);
     }
 }

--- a/src/Http/Controllers/Inertia/TermsOfServiceController.php
+++ b/src/Http/Controllers/Inertia/TermsOfServiceController.php
@@ -6,9 +6,7 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Inertia\Inertia;
 use Laravel\Jetstream\Jetstream;
-use League\CommonMark\CommonMarkConverter;
-use League\CommonMark\Environment;
-use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
+use League\CommonMark\GithubFlavoredMarkdownConverter;
 
 class TermsOfServiceController extends Controller
 {
@@ -22,11 +20,8 @@ class TermsOfServiceController extends Controller
     {
         $termsFile = Jetstream::localizedMarkdownPath('terms.md');
 
-        $environment = Environment::createCommonMarkEnvironment();
-        $environment->addExtension(new GithubFlavoredMarkdownExtension());
-
         return Inertia::render('TermsOfService', [
-            'terms' => (new CommonMarkConverter([], $environment))->convertToHtml(file_get_contents($termsFile)),
+            'terms' => (new GithubFlavoredMarkdownConverter())->convertToHtml(file_get_contents($termsFile)),
         ]);
     }
 }

--- a/src/Http/Controllers/Livewire/PrivacyPolicyController.php
+++ b/src/Http/Controllers/Livewire/PrivacyPolicyController.php
@@ -5,9 +5,7 @@ namespace Laravel\Jetstream\Http\Controllers\Livewire;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Laravel\Jetstream\Jetstream;
-use League\CommonMark\CommonMarkConverter;
-use League\CommonMark\Environment;
-use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
+use League\CommonMark\GithubFlavoredMarkdownConverter;
 
 class PrivacyPolicyController extends Controller
 {
@@ -21,11 +19,8 @@ class PrivacyPolicyController extends Controller
     {
         $policyFile = Jetstream::localizedMarkdownPath('policy.md');
 
-        $environment = Environment::createCommonMarkEnvironment();
-        $environment->addExtension(new GithubFlavoredMarkdownExtension());
-
         return view('policy', [
-            'policy' => (new CommonMarkConverter([], $environment))->convertToHtml(file_get_contents($policyFile)),
+            'policy' => (new GithubFlavoredMarkdownConverter())->convertToHtml(file_get_contents($policyFile)),
         ]);
     }
 }

--- a/src/Http/Controllers/Livewire/PrivacyPolicyController.php
+++ b/src/Http/Controllers/Livewire/PrivacyPolicyController.php
@@ -4,8 +4,8 @@ namespace Laravel\Jetstream\Http\Controllers\Livewire;
 
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Str;
 use Laravel\Jetstream\Jetstream;
-use League\CommonMark\GithubFlavoredMarkdownConverter;
 
 class PrivacyPolicyController extends Controller
 {
@@ -20,7 +20,7 @@ class PrivacyPolicyController extends Controller
         $policyFile = Jetstream::localizedMarkdownPath('policy.md');
 
         return view('policy', [
-            'policy' => (new GithubFlavoredMarkdownConverter())->convertToHtml(file_get_contents($policyFile)),
+            'policy' => Str::markdown(file_get_contents($policyFile)),
         ]);
     }
 }

--- a/src/Http/Controllers/Livewire/TermsOfServiceController.php
+++ b/src/Http/Controllers/Livewire/TermsOfServiceController.php
@@ -5,9 +5,7 @@ namespace Laravel\Jetstream\Http\Controllers\Livewire;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Laravel\Jetstream\Jetstream;
-use League\CommonMark\CommonMarkConverter;
-use League\CommonMark\Environment;
-use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
+use League\CommonMark\GithubFlavoredMarkdownConverter;
 
 class TermsOfServiceController extends Controller
 {
@@ -21,11 +19,8 @@ class TermsOfServiceController extends Controller
     {
         $termsFile = Jetstream::localizedMarkdownPath('terms.md');
 
-        $environment = Environment::createCommonMarkEnvironment();
-        $environment->addExtension(new GithubFlavoredMarkdownExtension());
-
         return view('terms', [
-            'terms' => (new CommonMarkConverter([], $environment))->convertToHtml(file_get_contents($termsFile)),
+            'terms' => (new GithubFlavoredMarkdownConverter())->convertToHtml(file_get_contents($termsFile)),
         ]);
     }
 }

--- a/src/Http/Controllers/Livewire/TermsOfServiceController.php
+++ b/src/Http/Controllers/Livewire/TermsOfServiceController.php
@@ -4,8 +4,8 @@ namespace Laravel\Jetstream\Http\Controllers\Livewire;
 
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Str;
 use Laravel\Jetstream\Jetstream;
-use League\CommonMark\GithubFlavoredMarkdownConverter;
 
 class TermsOfServiceController extends Controller
 {
@@ -20,7 +20,7 @@ class TermsOfServiceController extends Controller
         $termsFile = Jetstream::localizedMarkdownPath('terms.md');
 
         return view('terms', [
-            'terms' => (new GithubFlavoredMarkdownConverter())->convertToHtml(file_get_contents($termsFile)),
+            'terms' => Str::markdown(file_get_contents($termsFile)),
         ]);
     }
 }


### PR DESCRIPTION
Use `Str::markdown` to support both CommonMark v1 and v2.

Fixes https://github.com/laravel/jetstream/issues/844