### PR TITLE
remove unused dependency from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
         "ext-json": "*",
         "illuminate/support": "^8.0",
         "jenssegers/agent": "^2.6",
-        "league/commonmark": "^1.3|^2.0",
         "laravel/fortify": "^1.6.1"
     },
     "require-dev": {


### PR DESCRIPTION
#845 
Now we use Laravel's `\Str::markdown` instead of this dependency and we don't need it.