### PR TITLE
added check for if developer has disabled TwoFactor and update Profil…

### DIFF
--- a/stubs/tests/inertia/ProfileInformationTest.php
+++ b/stubs/tests/inertia/ProfileInformationTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Fortify\Features;
 use Tests\TestCase;
 
 class ProfileInformationTest extends TestCase
@@ -12,6 +13,10 @@ class ProfileInformationTest extends TestCase
 
     public function test_profile_information_can_be_updated()
     {
+        if (! Features::enabled(Features::canUpdateProfileInformation())) {
+            return $this->markTestSkipped('Profile Information Update support is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->create());
 
         $response = $this->put('/user/profile-information', [

--- a/stubs/tests/inertia/TwoFactorAuthenticationSettingsTest.php
+++ b/stubs/tests/inertia/TwoFactorAuthenticationSettingsTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Fortify\Features;
 use Tests\TestCase;
 
 class TwoFactorAuthenticationSettingsTest extends TestCase
@@ -12,6 +13,10 @@ class TwoFactorAuthenticationSettingsTest extends TestCase
 
     public function test_two_factor_authentication_can_be_enabled()
     {
+        if (! Features::enabled(Features::twoFactorAuthentication())) {
+            return $this->markTestSkipped('Two Factor Suppport is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->create());
 
         $this->withSession(['auth.password_confirmed_at' => time()]);
@@ -24,6 +29,10 @@ class TwoFactorAuthenticationSettingsTest extends TestCase
 
     public function test_recovery_codes_can_be_regenerated()
     {
+        if (! Features::enabled(Features::twoFactorAuthentication())) {
+            return $this->markTestSkipped('Two Factor Suppport is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->create());
 
         $this->withSession(['auth.password_confirmed_at' => time()]);
@@ -41,6 +50,10 @@ class TwoFactorAuthenticationSettingsTest extends TestCase
 
     public function test_two_factor_authentication_can_be_disabled()
     {
+        if (! Features::enabled(Features::twoFactorAuthentication())) {
+            return $this->markTestSkipped('Two Factor Suppport is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->create());
 
         $this->withSession(['auth.password_confirmed_at' => time()]);

--- a/stubs/tests/livewire/ProfileInformationTest.php
+++ b/stubs/tests/livewire/ProfileInformationTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Fortify\Features;
 use Laravel\Jetstream\Http\Livewire\UpdateProfileInformationForm;
 use Livewire\Livewire;
 use Tests\TestCase;
@@ -14,6 +15,10 @@ class ProfileInformationTest extends TestCase
 
     public function test_current_profile_information_is_available()
     {
+        if (! Features::enabled(Features::canUpdateProfileInformation())) {
+            return $this->markTestSkipped('Profile Information Update support is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->create());
 
         $component = Livewire::test(UpdateProfileInformationForm::class);
@@ -24,6 +29,10 @@ class ProfileInformationTest extends TestCase
 
     public function test_profile_information_can_be_updated()
     {
+        if (! Features::enabled(Features::canUpdateProfileInformation())) {
+            return $this->markTestSkipped('Profile Information Update support is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->create());
 
         Livewire::test(UpdateProfileInformationForm::class)

--- a/stubs/tests/livewire/TwoFactorAuthenticationSettingsTest.php
+++ b/stubs/tests/livewire/TwoFactorAuthenticationSettingsTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Fortify\Features;
 use Laravel\Jetstream\Http\Livewire\TwoFactorAuthenticationForm;
 use Livewire\Livewire;
 use Tests\TestCase;
@@ -14,6 +15,10 @@ class TwoFactorAuthenticationSettingsTest extends TestCase
 
     public function test_two_factor_authentication_can_be_enabled()
     {
+        if (! Features::enabled(Features::twoFactorAuthentication())) {
+            return $this->markTestSkipped('Two Factor Suppport is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->create());
 
         $this->withSession(['auth.password_confirmed_at' => time()]);
@@ -29,6 +34,10 @@ class TwoFactorAuthenticationSettingsTest extends TestCase
 
     public function test_recovery_codes_can_be_regenerated()
     {
+        if (! Features::enabled(Features::twoFactorAuthentication())) {
+            return $this->markTestSkipped('Two Factor Suppport is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->create());
 
         $this->withSession(['auth.password_confirmed_at' => time()]);
@@ -47,6 +56,10 @@ class TwoFactorAuthenticationSettingsTest extends TestCase
 
     public function test_two_factor_authentication_can_be_disabled()
     {
+        if (! Features::enabled(Features::twoFactorAuthentication())) {
+            return $this->markTestSkipped('Two Factor Suppport is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->create());
 
         $this->withSession(['auth.password_confirmed_at' => time()]);


### PR DESCRIPTION
This will make the Two-factor stubs tests generated for both of stacks respect the configurations as per developer toggles