### PR TITLE
make string constants a translation strings

### DIFF
--- a/src/Http/Controllers/Inertia/CurrentUserController.php
+++ b/src/Http/Controllers/Inertia/CurrentUserController.php
@@ -28,7 +28,7 @@ class CurrentUserController extends Controller
 
         if (! $confirmed) {
             throw ValidationException::withMessages([
-                'password' => 'The password is incorrect.',
+                'password' => __('The password is incorrect.'),
             ]);
         }
 

--- a/src/Http/Controllers/Inertia/OtherBrowserSessionsController.php
+++ b/src/Http/Controllers/Inertia/OtherBrowserSessionsController.php
@@ -27,7 +27,7 @@ class OtherBrowserSessionsController extends Controller
 
         if (! $confirmed) {
             throw ValidationException::withMessages([
-                'password' => 'The password is incorrect.',
+                'password' => __('The password is incorrect.'),
             ]);
         }
 


### PR DESCRIPTION
Some strings in Inertia controllers were not translatable. This PR fixes this. 
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

If you change the behavior of the Inertia stack you're expected to update the Livewire stack as well and vice versa.
-->
