### PR TITLE
Remove unneeded tailwind config variant definitions

### DIFF
--- a/stubs/inertia/tailwind.config.js
+++ b/stubs/inertia/tailwind.config.js
@@ -18,11 +18,5 @@ module.exports = {
         },
     },
 
-    variants: {
-        extend: {
-            opacity: ['disabled'],
-        },
-    },
-
     plugins: [require('@tailwindcss/forms'), require('@tailwindcss/typography')],
 };

--- a/stubs/livewire/tailwind.config.js
+++ b/stubs/livewire/tailwind.config.js
@@ -17,11 +17,5 @@ module.exports = {
         },
     },
 
-    variants: {
-        extend: {
-            opacity: ['disabled'],
-        },
-    },
-
     plugins: [require('@tailwindcss/forms'), require('@tailwindcss/typography')],
 };


### PR DESCRIPTION
Because of Tailwind JIT mode (#810), [defining extra variants in the config is not needed anymore](https://tailwindcss.com/docs/just-in-time-mode#all-variants-are-enabled).

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

If you change the behavior of the Inertia stack you're expected to update the Livewire stack as well and vice versa.
-->
