### PR TITLE
Bumped doc links to v2 links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 Laravel Jetstream is a beautifully designed application scaffolding for Laravel. Jetstream provides the perfect starting point for your next Laravel application and includes login, registration, email verification, two-factor authentication, session management, API support via [Laravel Sanctum](https://github.com/laravel/sanctum), and optional team management.
 
-Jetstream is designed using [Tailwind CSS](https://tailwindcss.com) and offers your choice of [Livewire](https://jetstream.laravel.com/1.x/stacks/livewire.html) or [Inertia](https://jetstream.laravel.com/1.x/stacks/inertia.html) scaffolding.
+Jetstream is designed using [Tailwind CSS](https://tailwindcss.com) and offers your choice of [Livewire](https://jetstream.laravel.com/2.x/stacks/livewire.html) or [Inertia](https://jetstream.laravel.com/2.x/stacks/inertia.html) scaffolding.
 
 ## Official Documentation
 


### PR DESCRIPTION
Links were going to 1.x in the 2.x branch.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

If you change the behavior of the Inertia stack you're expected to update the Livewire stack as well and vice versa.
-->
