### PR TITLE
Add link button to banner component

### DIFF
--- a/resources/views/components/banner.blade.php
+++ b/resources/views/components/banner.blade.php
@@ -30,7 +30,7 @@
             
             @if ($linkUrl)
                 <div class="order-3 mt-2 flex-shrink-0 w-full sm:order-2 sm:mt-0 sm:w-auto">
-                    <a href="{{ $linkUrl }}" class="flex items-center justify-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-indigo-600 bg-white hover:bg-indigo-50">
+                    <a href="{{ $linkUrl }}" class="inline-flex items-center px-4 py-2 bg-white border border-gray-300 rounded-md font-semibold text-xs text-gray-700 uppercase tracking-widest shadow-sm hover:text-gray-500 focus:outline-none focus:border-blue-300 focus:ring focus:ring-blue-200 active:text-gray-800 active:bg-gray-50 disabled:opacity-25 transition">
                         {{ $linkText ?? __('Read more') }}
                     </a>
                 </div>

--- a/resources/views/components/banner.blade.php
+++ b/resources/views/components/banner.blade.php
@@ -1,4 +1,9 @@
-@props(['style' => session('flash.bannerStyle', 'success'), 'message' => session('flash.banner')])
+@props([
+    'style' => session('flash.bannerStyle', 'success'),
+    'message' => session('flash.banner'),
+    'linkUrl' => session('flash.bannerLinkUrl'),
+    'linkText' => session('flash.bannerLinkText'),
+])
 
 <div x-data="{{ json_encode(['show' => true, 'style' => $style, 'message' => $message]) }}"
             :class="{ 'bg-indigo-500': style == 'success', 'bg-red-700': style == 'danger' }"
@@ -22,8 +27,16 @@
 
                 <p class="ml-3 font-medium text-sm text-white truncate" x-text="message"></p>
             </div>
+            
+            @if ($linkUrl)
+                <div class="order-3 mt-2 flex-shrink-0 w-full sm:order-2 sm:mt-0 sm:w-auto">
+                    <a href="{{ $linkUrl }}" class="flex items-center justify-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-indigo-600 bg-white hover:bg-indigo-50">
+                        {{ $linkText ?? __('Read more') }}
+                    </a>
+                </div>
+            @endif
 
-            <div class="flex-shrink-0 sm:ml-3">
+            <div class="order-2 flex-shrink-0 sm:ml-3">
                 <button
                     type="button"
                     class="-mr-1 flex p-2 rounded-md focus:outline-none sm:-mr-2 transition"


### PR DESCRIPTION
This PR makes it possible to easily add a link button to the banner component. This is useful for example to redirecting unsubscribed users to the billing page.


## Example

See "Signup" button that has been added to the top right corner.

<img width="1424" alt="Screenshot 2021-08-16 at 10 07 22" src="https://user-images.githubusercontent.com/30228807/129533140-af90f10c-5733-4407-9490-c1db53ae4983.png">
