### PR TITLE
[2.x] Use PHPDoc comments from base class in models

### DIFF
--- a/stubs/app/Models/Team.php
+++ b/stubs/app/Models/Team.php
@@ -13,7 +13,7 @@ class Team extends JetstreamTeam
     use HasFactory;
 
     /**
-     * The attributes that should be cast to native types.
+     * The attributes that should be cast.
      *
      * @var array
      */
@@ -24,7 +24,7 @@ class Team extends JetstreamTeam
     /**
      * The attributes that are mass assignable.
      *
-     * @var array
+     * @var string[]
      */
     protected $fillable = [
         'name',
@@ -33,6 +33,8 @@ class Team extends JetstreamTeam
 
     /**
      * The event map for the model.
+     *
+     * Allows for object-based events for native Eloquent events.
      *
      * @var array
      */

--- a/stubs/app/Models/Team.php
+++ b/stubs/app/Models/Team.php
@@ -34,8 +34,6 @@ class Team extends JetstreamTeam
     /**
      * The event map for the model.
      *
-     * Allows for object-based events for native Eloquent events.
-     *
      * @var array
      */
     protected $dispatchesEvents = [

--- a/stubs/app/Models/TeamInvitation.php
+++ b/stubs/app/Models/TeamInvitation.php
@@ -10,7 +10,7 @@ class TeamInvitation extends JetstreamTeamInvitation
     /**
      * The attributes that are mass assignable.
      *
-     * @var array
+     * @var string[]
      */
     protected $fillable = [
         'email',

--- a/stubs/app/Models/User.php
+++ b/stubs/app/Models/User.php
@@ -21,7 +21,7 @@ class User extends Authenticatable
     /**
      * The attributes that are mass assignable.
      *
-     * @var array
+     * @var string[]
      */
     protected $fillable = [
         'name',
@@ -30,7 +30,7 @@ class User extends Authenticatable
     ];
 
     /**
-     * The attributes that should be hidden for arrays.
+     * The attributes that should be hidden for serialization.
      *
      * @var array
      */
@@ -42,7 +42,7 @@ class User extends Authenticatable
     ];
 
     /**
-     * The attributes that should be cast to native types.
+     * The attributes that should be cast.
      *
      * @var array
      */

--- a/stubs/app/Models/UserWithTeams.php
+++ b/stubs/app/Models/UserWithTeams.php
@@ -23,14 +23,14 @@ class User extends Authenticatable
     /**
      * The attributes that are mass assignable.
      *
-     * @var array
+     * @var string[]
      */
     protected $fillable = [
         'name', 'email', 'password',
     ];
 
     /**
-     * The attributes that should be hidden for arrays.
+     * The attributes that should be hidden for serialization.
      *
      * @var array
      */
@@ -42,7 +42,7 @@ class User extends Authenticatable
     ];
 
     /**
-     * The attributes that should be cast to native types.
+     * The attributes that should be cast.
      *
      * @var array
      */


### PR DESCRIPTION
Use PHPDoc comments from base class to stay consequent.