### PR TITLE
[2.x] Added "text-left" class to team role descriptions

### DIFF
--- a/stubs/inertia/resources/js/Pages/Teams/Partials/TeamMemberManager.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/Partials/TeamMemberManager.vue
@@ -49,7 +49,7 @@
                                     </div>
 
                                     <!-- Role Description -->
-                                    <div class="mt-2 text-xs text-gray-600">
+                                    <div class="mt-2 text-xs text-gray-600 text-left">
                                         {{ role.description }}
                                     </div>
                                 </div>

--- a/stubs/livewire/resources/views/teams/team-member-manager.blade.php
+++ b/stubs/livewire/resources/views/teams/team-member-manager.blade.php
@@ -50,7 +50,7 @@
                                             </div>
 
                                             <!-- Role Description -->
-                                            <div class="mt-2 text-xs text-gray-600">
+                                            <div class="mt-2 text-xs text-gray-600 text-left">
                                                 {{ $role->description }}
                                             </div>
                                         </div>


### PR DESCRIPTION
Previously, for some reason, longer role descriptions would be centrally aligned (despite short ones being aligned to the left??!). See screenshots below:

## Before
![Screenshot 2021-08-26 at 01 03 33](https://user-images.githubusercontent.com/7163152/130880134-ae8c45ed-2b28-4328-94ce-427fbacd7610.png)

## After
![Screenshot 2021-08-26 at 01 11 38](https://user-images.githubusercontent.com/7163152/130880196-1603bf5b-7849-4f9a-ab53-a5c24ab54eb6.png)

