### PR TITLE
[2.x] Adds support for Pest

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -17,6 +17,7 @@ class InstallCommand extends Command
      */
     protected $signature = 'jetstream:install {stack : The development stack that should be installed}
                                               {--teams : Indicates if team support should be installed}
+                                              {--pest : Indicate that Pest should be installed}
                                               {--composer=global : Absolute path to the Composer binary which should be used to install packages}';
 
     /**
@@ -70,11 +71,19 @@ class InstallCommand extends Command
         }
 
         // Tests...
-        copy(__DIR__.'/../../stubs/tests/AuthenticationTest.php', base_path('tests/Feature/AuthenticationTest.php'));
-        copy(__DIR__.'/../../stubs/tests/EmailVerificationTest.php', base_path('tests/Feature/EmailVerificationTest.php'));
-        copy(__DIR__.'/../../stubs/tests/PasswordConfirmationTest.php', base_path('tests/Feature/PasswordConfirmationTest.php'));
-        copy(__DIR__.'/../../stubs/tests/PasswordResetTest.php', base_path('tests/Feature/PasswordResetTest.php'));
-        copy(__DIR__.'/../../stubs/tests/RegistrationTest.php', base_path('tests/Feature/RegistrationTest.php'));
+        $stubs = $this->getTestStubsPath();
+
+        if ($this->option('pest')) {
+            $this->requireComposerPackages('pestphp/pest:^1.16', 'pestphp/pest-plugin-laravel:^1.1');
+
+            copy($stubs.'/Pest.php', base_path('tests/Pest.php'));
+        }
+
+        copy($stubs.'/AuthenticationTest.php', base_path('tests/Feature/AuthenticationTest.php'));
+        copy($stubs.'/EmailVerificationTest.php', base_path('tests/Feature/EmailVerificationTest.php'));
+        copy($stubs.'/PasswordConfirmationTest.php', base_path('tests/Feature/PasswordConfirmationTest.php'));
+        copy($stubs.'/PasswordResetTest.php', base_path('tests/Feature/PasswordResetTest.php'));
+        copy($stubs.'/RegistrationTest.php', base_path('tests/Feature/RegistrationTest.php'));
     }
 
     /**
@@ -197,14 +206,16 @@ class InstallCommand extends Command
         copy(__DIR__.'/../../stubs/livewire/resources/js/app.js', resource_path('js/app.js'));
 
         // Tests...
-        copy(__DIR__.'/../../stubs/tests/livewire/ApiTokenPermissionsTest.php', base_path('tests/Feature/ApiTokenPermissionsTest.php'));
-        copy(__DIR__.'/../../stubs/tests/livewire/BrowserSessionsTest.php', base_path('tests/Feature/BrowserSessionsTest.php'));
-        copy(__DIR__.'/../../stubs/tests/livewire/CreateApiTokenTest.php', base_path('tests/Feature/CreateApiTokenTest.php'));
-        copy(__DIR__.'/../../stubs/tests/livewire/DeleteAccountTest.php', base_path('tests/Feature/DeleteAccountTest.php'));
-        copy(__DIR__.'/../../stubs/tests/livewire/DeleteApiTokenTest.php', base_path('tests/Feature/DeleteApiTokenTest.php'));
-        copy(__DIR__.'/../../stubs/tests/livewire/ProfileInformationTest.php', base_path('tests/Feature/ProfileInformationTest.php'));
-        copy(__DIR__.'/../../stubs/tests/livewire/TwoFactorAuthenticationSettingsTest.php', base_path('tests/Feature/TwoFactorAuthenticationSettingsTest.php'));
-        copy(__DIR__.'/../../stubs/tests/livewire/UpdatePasswordTest.php', base_path('tests/Feature/UpdatePasswordTest.php'));
+        $stubs = $this->getTestStubsPath();
+
+        copy($stubs.'/livewire/ApiTokenPermissionsTest.php', base_path('tests/Feature/ApiTokenPermissionsTest.php'));
+        copy($stubs.'/livewire/BrowserSessionsTest.php', base_path('tests/Feature/BrowserSessionsTest.php'));
+        copy($stubs.'/livewire/CreateApiTokenTest.php', base_path('tests/Feature/CreateApiTokenTest.php'));
+        copy($stubs.'/livewire/DeleteAccountTest.php', base_path('tests/Feature/DeleteAccountTest.php'));
+        copy($stubs.'/livewire/DeleteApiTokenTest.php', base_path('tests/Feature/DeleteApiTokenTest.php'));
+        copy($stubs.'/livewire/ProfileInformationTest.php', base_path('tests/Feature/ProfileInformationTest.php'));
+        copy($stubs.'/livewire/TwoFactorAuthenticationSettingsTest.php', base_path('tests/Feature/TwoFactorAuthenticationSettingsTest.php'));
+        copy($stubs.'/livewire/UpdatePasswordTest.php', base_path('tests/Feature/UpdatePasswordTest.php'));
 
         // Teams...
         if ($this->option('teams')) {
@@ -230,13 +241,15 @@ class InstallCommand extends Command
         (new Filesystem)->copyDirectory(__DIR__.'/../../stubs/livewire/resources/views/teams', resource_path('views/teams'));
 
         // Tests...
-        copy(__DIR__.'/../../stubs/tests/livewire/CreateTeamTest.php', base_path('tests/Feature/CreateTeamTest.php'));
-        copy(__DIR__.'/../../stubs/tests/livewire/DeleteTeamTest.php', base_path('tests/Feature/DeleteTeamTest.php'));
-        copy(__DIR__.'/../../stubs/tests/livewire/InviteTeamMemberTest.php', base_path('tests/Feature/InviteTeamMemberTest.php'));
-        copy(__DIR__.'/../../stubs/tests/livewire/LeaveTeamTest.php', base_path('tests/Feature/LeaveTeamTest.php'));
-        copy(__DIR__.'/../../stubs/tests/livewire/RemoveTeamMemberTest.php', base_path('tests/Feature/RemoveTeamMemberTest.php'));
-        copy(__DIR__.'/../../stubs/tests/livewire/UpdateTeamMemberRoleTest.php', base_path('tests/Feature/UpdateTeamMemberRoleTest.php'));
-        copy(__DIR__.'/../../stubs/tests/livewire/UpdateTeamNameTest.php', base_path('tests/Feature/UpdateTeamNameTest.php'));
+        $stubs = $this->getTestStubsPath();
+
+        copy($stubs.'/livewire/CreateTeamTest.php', base_path('tests/Feature/CreateTeamTest.php'));
+        copy($stubs.'/livewire/DeleteTeamTest.php', base_path('tests/Feature/DeleteTeamTest.php'));
+        copy($stubs.'/livewire/InviteTeamMemberTest.php', base_path('tests/Feature/InviteTeamMemberTest.php'));
+        copy($stubs.'/livewire/LeaveTeamTest.php', base_path('tests/Feature/LeaveTeamTest.php'));
+        copy($stubs.'/livewire/RemoveTeamMemberTest.php', base_path('tests/Feature/RemoveTeamMemberTest.php'));
+        copy($stubs.'/livewire/UpdateTeamMemberRoleTest.php', base_path('tests/Feature/UpdateTeamMemberRoleTest.php'));
+        copy($stubs.'/livewire/UpdateTeamNameTest.php', base_path('tests/Feature/UpdateTeamNameTest.php'));
 
         $this->ensureApplicationIsTeamCompatible();
     }
@@ -373,14 +386,16 @@ EOF;
         // static::flushNodeModules();
 
         // Tests...
-        copy(__DIR__.'/../../stubs/tests/inertia/ApiTokenPermissionsTest.php', base_path('tests/Feature/ApiTokenPermissionsTest.php'));
-        copy(__DIR__.'/../../stubs/tests/inertia/BrowserSessionsTest.php', base_path('tests/Feature/BrowserSessionsTest.php'));
-        copy(__DIR__.'/../../stubs/tests/inertia/CreateApiTokenTest.php', base_path('tests/Feature/CreateApiTokenTest.php'));
-        copy(__DIR__.'/../../stubs/tests/inertia/DeleteAccountTest.php', base_path('tests/Feature/DeleteAccountTest.php'));
-        copy(__DIR__.'/../../stubs/tests/inertia/DeleteApiTokenTest.php', base_path('tests/Feature/DeleteApiTokenTest.php'));
-        copy(__DIR__.'/../../stubs/tests/inertia/ProfileInformationTest.php', base_path('tests/Feature/ProfileInformationTest.php'));
-        copy(__DIR__.'/../../stubs/tests/inertia/TwoFactorAuthenticationSettingsTest.php', base_path('tests/Feature/TwoFactorAuthenticationSettingsTest.php'));
-        copy(__DIR__.'/../../stubs/tests/inertia/UpdatePasswordTest.php', base_path('tests/Feature/UpdatePasswordTest.php'));
+        $stubs = $this->getTestStubsPath();
+
+        copy($stubs.'/inertia/ApiTokenPermissionsTest.php', base_path('tests/Feature/ApiTokenPermissionsTest.php'));
+        copy($stubs.'/inertia/BrowserSessionsTest.php', base_path('tests/Feature/BrowserSessionsTest.php'));
+        copy($stubs.'/inertia/CreateApiTokenTest.php', base_path('tests/Feature/CreateApiTokenTest.php'));
+        copy($stubs.'/inertia/DeleteAccountTest.php', base_path('tests/Feature/DeleteAccountTest.php'));
+        copy($stubs.'/inertia/DeleteApiTokenTest.php', base_path('tests/Feature/DeleteApiTokenTest.php'));
+        copy($stubs.'/inertia/ProfileInformationTest.php', base_path('tests/Feature/ProfileInformationTest.php'));
+        copy($stubs.'/inertia/TwoFactorAuthenticationSettingsTest.php', base_path('tests/Feature/TwoFactorAuthenticationSettingsTest.php'));
+        copy($stubs.'/inertia/UpdatePasswordTest.php', base_path('tests/Feature/UpdatePasswordTest.php'));
 
         // Teams...
         if ($this->option('teams')) {
@@ -406,13 +421,15 @@ EOF;
         (new Filesystem)->copyDirectory(__DIR__.'/../../stubs/inertia/resources/js/Pages/Teams', resource_path('js/Pages/Teams'));
 
         // Tests...
-        copy(__DIR__.'/../../stubs/tests/inertia/CreateTeamTest.php', base_path('tests/Feature/CreateTeamTest.php'));
-        copy(__DIR__.'/../../stubs/tests/inertia/DeleteTeamTest.php', base_path('tests/Feature/DeleteTeamTest.php'));
-        copy(__DIR__.'/../../stubs/tests/inertia/InviteTeamMemberTest.php', base_path('tests/Feature/InviteTeamMemberTest.php'));
-        copy(__DIR__.'/../../stubs/tests/inertia/LeaveTeamTest.php', base_path('tests/Feature/LeaveTeamTest.php'));
-        copy(__DIR__.'/../../stubs/tests/inertia/RemoveTeamMemberTest.php', base_path('tests/Feature/RemoveTeamMemberTest.php'));
-        copy(__DIR__.'/../../stubs/tests/inertia/UpdateTeamMemberRoleTest.php', base_path('tests/Feature/UpdateTeamMemberRoleTest.php'));
-        copy(__DIR__.'/../../stubs/tests/inertia/UpdateTeamNameTest.php', base_path('tests/Feature/UpdateTeamNameTest.php'));
+        $stubs = $this->getTestStubsPath();
+
+        copy($stubs.'/inertia/CreateTeamTest.php', base_path('tests/Feature/CreateTeamTest.php'));
+        copy($stubs.'/inertia/DeleteTeamTest.php', base_path('tests/Feature/DeleteTeamTest.php'));
+        copy($stubs.'/inertia/InviteTeamMemberTest.php', base_path('tests/Feature/InviteTeamMemberTest.php'));
+        copy($stubs.'/inertia/LeaveTeamTest.php', base_path('tests/Feature/LeaveTeamTest.php'));
+        copy($stubs.'/inertia/RemoveTeamMemberTest.php', base_path('tests/Feature/RemoveTeamMemberTest.php'));
+        copy($stubs.'/inertia/UpdateTeamMemberRoleTest.php', base_path('tests/Feature/UpdateTeamMemberRoleTest.php'));
+        copy($stubs.'/inertia/UpdateTeamNameTest.php', base_path('tests/Feature/UpdateTeamNameTest.php'));
 
         $this->ensureApplicationIsTeamCompatible();
     }
@@ -510,6 +527,18 @@ EOF;
                 $httpKernel
             ));
         }
+    }
+
+    /**
+     * Returns the path to the correct test stubs.
+     *
+     * @return string
+     */
+    protected function getTestStubsPath()
+    {
+        return $this->option('pest')
+            ? __DIR__.'/../../stubs/pest-tests'
+            : __DIR__.'/../../stubs/tests';
     }
 
     /**

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -77,6 +77,8 @@ class InstallCommand extends Command
             $this->requireComposerPackages('pestphp/pest:^1.16', 'pestphp/pest-plugin-laravel:^1.1');
 
             copy($stubs.'/Pest.php', base_path('tests/Pest.php'));
+            copy($stubs.'/ExampleTest.php', base_path('tests/Feature/ExampleTest.php'));
+            copy($stubs.'/ExampleUnitTest.php', base_path('tests/Unit/ExampleTest.php'));
         }
 
         copy($stubs.'/AuthenticationTest.php', base_path('tests/Feature/AuthenticationTest.php'));

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -17,7 +17,7 @@ class InstallCommand extends Command
      */
     protected $signature = 'jetstream:install {stack : The development stack that should be installed}
                                               {--teams : Indicates if team support should be installed}
-                                              {--pest : Indicate that Pest should be installed}
+                                              {--pest : Indicates if Pest should be installed}
                                               {--composer=global : Absolute path to the Composer binary which should be used to install packages}';
 
     /**

--- a/stubs/pest-tests/AuthenticationTest.php
+++ b/stubs/pest-tests/AuthenticationTest.php
@@ -3,13 +3,13 @@
 use App\Models\User;
 use App\Providers\RouteServiceProvider;
 
-test('login_screen_can_be_rendered', function () {
+test('login screen can be rendered', function () {
     $response = $this->get('/login');
 
     $response->assertStatus(200);
 });
 
-test('users_can_authenticate_using_the_login_screen', function () {
+test('users can authenticate using the login screen', function () {
     $user = User::factory()->create();
 
     $response = $this->post('/login', [
@@ -21,7 +21,7 @@ test('users_can_authenticate_using_the_login_screen', function () {
     $response->assertRedirect(RouteServiceProvider::HOME);
 });
 
-test('users_can_not_authenticate_with_invalid_password', function () {
+test('users can not authenticate with invalid_password', function () {
     $user = User::factory()->create();
 
     $this->post('/login', [

--- a/stubs/pest-tests/AuthenticationTest.php
+++ b/stubs/pest-tests/AuthenticationTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use App\Models\User;
+use App\Providers\RouteServiceProvider;
+
+test('login_screen_can_be_rendered', function () {
+    $response = $this->get('/login');
+
+    $response->assertStatus(200);
+});
+
+test('users_can_authenticate_using_the_login_screen', function () {
+    $user = User::factory()->create();
+
+    $response = $this->post('/login', [
+        'email' => $user->email,
+        'password' => 'password',
+    ]);
+
+    $this->assertAuthenticated();
+    $response->assertRedirect(RouteServiceProvider::HOME);
+});
+
+test('users_can_not_authenticate_with_invalid_password', function () {
+    $user = User::factory()->create();
+
+    $this->post('/login', [
+        'email' => $user->email,
+        'password' => 'wrong-password',
+    ]);
+
+    $this->assertGuest();
+});

--- a/stubs/pest-tests/EmailVerificationTest.php
+++ b/stubs/pest-tests/EmailVerificationTest.php
@@ -17,7 +17,7 @@ test('email verification screen can be rendered', function () {
     $response->assertStatus(200);
 })->skip(function() {
     return ! Features::enabled(Features::emailVerification());
-}, 'Email verification not enabled.');;
+}, 'Email verification not enabled.');
 
 test('email can be verified', function () {
     Event::fake();
@@ -40,7 +40,7 @@ test('email can be verified', function () {
     $response->assertRedirect(RouteServiceProvider::HOME.'?verified=1');
 })->skip(function() {
     return ! Features::enabled(Features::emailVerification());
-}, 'Email verification not enabled.');;
+}, 'Email verification not enabled.');
 
 test('email can not verified with invalid hash', function () {
     $user = User::factory()->create([
@@ -58,4 +58,4 @@ test('email can not verified with invalid hash', function () {
     expect($user->fresh()->hasVerifiedEmail())->toBeFalse();
 })->skip(function() {
     return ! Features::enabled(Features::emailVerification());
-}, 'Email verification not enabled.');;
+}, 'Email verification not enabled.');

--- a/stubs/pest-tests/EmailVerificationTest.php
+++ b/stubs/pest-tests/EmailVerificationTest.php
@@ -42,7 +42,7 @@ test('email can be verified', function () {
 
     Event::assertDispatched(Verified::class);
 
-    $this->assertTrue($user->fresh()->hasVerifiedEmail());
+    expect($user->fresh()->hasVerifiedEmail())->toBeTrue();
     $response->assertRedirect(RouteServiceProvider::HOME.'?verified=1');
 });
 
@@ -63,5 +63,5 @@ test('email can not verified with invalid hash', function () {
 
     $this->actingAs($user)->get($verificationUrl);
 
-    $this->assertFalse($user->fresh()->hasVerifiedEmail());
+    expect($user->fresh()->hasVerifiedEmail())->toBeFalse();
 });

--- a/stubs/pest-tests/EmailVerificationTest.php
+++ b/stubs/pest-tests/EmailVerificationTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use App\Models\User;
+use App\Providers\RouteServiceProvider;
+use Illuminate\Auth\Events\Verified;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\URL;
+use Laravel\Fortify\Features;
+
+test('email verification screen can be rendered', function () {
+    if (! Features::enabled(Features::emailVerification())) {
+        return $this->markTestSkipped('Email verification not enabled.');
+    }
+
+    $user = User::factory()->withPersonalTeam()->create([
+        'email_verified_at' => null,
+    ]);
+
+    $response = $this->actingAs($user)->get('/email/verify');
+
+    $response->assertStatus(200);
+});
+
+test('email can be verified', function () {
+    if (! Features::enabled(Features::emailVerification())) {
+        return $this->markTestSkipped('Email verification not enabled.');
+    }
+
+    Event::fake();
+
+    $user = User::factory()->create([
+        'email_verified_at' => null,
+    ]);
+
+    $verificationUrl = URL::temporarySignedRoute(
+        'verification.verify',
+        now()->addMinutes(60),
+        ['id' => $user->id, 'hash' => sha1($user->email)]
+    );
+
+    $response = $this->actingAs($user)->get($verificationUrl);
+
+    Event::assertDispatched(Verified::class);
+
+    $this->assertTrue($user->fresh()->hasVerifiedEmail());
+    $response->assertRedirect(RouteServiceProvider::HOME.'?verified=1');
+});
+
+test('email can not verified with invalid hash', function () {
+    if (! Features::enabled(Features::emailVerification())) {
+        return $this->markTestSkipped('Email verification not enabled.');
+    }
+
+    $user = User::factory()->create([
+        'email_verified_at' => null,
+    ]);
+
+    $verificationUrl = URL::temporarySignedRoute(
+        'verification.verify',
+        now()->addMinutes(60),
+        ['id' => $user->id, 'hash' => sha1('wrong-email')]
+    );
+
+    $this->actingAs($user)->get($verificationUrl);
+
+    $this->assertFalse($user->fresh()->hasVerifiedEmail());
+});

--- a/stubs/pest-tests/EmailVerificationTest.php
+++ b/stubs/pest-tests/EmailVerificationTest.php
@@ -15,7 +15,7 @@ test('email verification screen can be rendered', function () {
     $response = $this->actingAs($user)->get('/email/verify');
 
     $response->assertStatus(200);
-})->skip(function() {
+})->skip(function () {
     return ! Features::enabled(Features::emailVerification());
 }, 'Email verification not enabled.');
 
@@ -38,7 +38,7 @@ test('email can be verified', function () {
 
     expect($user->fresh()->hasVerifiedEmail())->toBeTrue();
     $response->assertRedirect(RouteServiceProvider::HOME.'?verified=1');
-})->skip(function() {
+})->skip(function () {
     return ! Features::enabled(Features::emailVerification());
 }, 'Email verification not enabled.');
 
@@ -56,6 +56,6 @@ test('email can not verified with invalid hash', function () {
     $this->actingAs($user)->get($verificationUrl);
 
     expect($user->fresh()->hasVerifiedEmail())->toBeFalse();
-})->skip(function() {
+})->skip(function () {
     return ! Features::enabled(Features::emailVerification());
 }, 'Email verification not enabled.');

--- a/stubs/pest-tests/EmailVerificationTest.php
+++ b/stubs/pest-tests/EmailVerificationTest.php
@@ -8,10 +8,6 @@ use Illuminate\Support\Facades\URL;
 use Laravel\Fortify\Features;
 
 test('email verification screen can be rendered', function () {
-    if (! Features::enabled(Features::emailVerification())) {
-        return $this->markTestSkipped('Email verification not enabled.');
-    }
-
     $user = User::factory()->withPersonalTeam()->create([
         'email_verified_at' => null,
     ]);
@@ -19,13 +15,11 @@ test('email verification screen can be rendered', function () {
     $response = $this->actingAs($user)->get('/email/verify');
 
     $response->assertStatus(200);
-});
+})->skip(function() {
+    return ! Features::enabled(Features::emailVerification());
+}, 'Email verification not enabled.');;
 
 test('email can be verified', function () {
-    if (! Features::enabled(Features::emailVerification())) {
-        return $this->markTestSkipped('Email verification not enabled.');
-    }
-
     Event::fake();
 
     $user = User::factory()->create([
@@ -44,13 +38,11 @@ test('email can be verified', function () {
 
     expect($user->fresh()->hasVerifiedEmail())->toBeTrue();
     $response->assertRedirect(RouteServiceProvider::HOME.'?verified=1');
-});
+})->skip(function() {
+    return ! Features::enabled(Features::emailVerification());
+}, 'Email verification not enabled.');;
 
 test('email can not verified with invalid hash', function () {
-    if (! Features::enabled(Features::emailVerification())) {
-        return $this->markTestSkipped('Email verification not enabled.');
-    }
-
     $user = User::factory()->create([
         'email_verified_at' => null,
     ]);
@@ -64,4 +56,6 @@ test('email can not verified with invalid hash', function () {
     $this->actingAs($user)->get($verificationUrl);
 
     expect($user->fresh()->hasVerifiedEmail())->toBeFalse();
-});
+})->skip(function() {
+    return ! Features::enabled(Features::emailVerification());
+}, 'Email verification not enabled.');;

--- a/stubs/pest-tests/ExampleTest.php
+++ b/stubs/pest-tests/ExampleTest.php
@@ -1,0 +1,7 @@
+<?php
+
+test('example', function () {
+    $response = $this->get('/');
+
+    $response->assertStatus(200);
+});

--- a/stubs/pest-tests/ExampleUnitTest.php
+++ b/stubs/pest-tests/ExampleUnitTest.php
@@ -1,0 +1,5 @@
+<?php
+
+test('example', function () {
+    expect(true)->toBeTrue();
+});

--- a/stubs/pest-tests/PasswordConfirmationTest.php
+++ b/stubs/pest-tests/PasswordConfirmationTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use App\Models\User;
+use Laravel\Jetstream\Features;
+
+test('confirm password screen can be rendered', function () {
+    $user = Features::hasTeamFeatures()
+                    ? User::factory()->withPersonalTeam()->create()
+                    : User::factory()->create();
+
+    $response = $this->actingAs($user)->get('/user/confirm-password');
+
+    $response->assertStatus(200);
+});
+
+test('password can be confirmed', function () {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user)->post('/user/confirm-password', [
+        'password' => 'password',
+    ]);
+
+    $response->assertRedirect();
+    $response->assertSessionHasNoErrors();
+});
+
+test('password is not confirmed with invalid password', function () {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user)->post('/user/confirm-password', [
+        'password' => 'wrong-password',
+    ]);
+
+    $response->assertSessionHasErrors();
+});

--- a/stubs/pest-tests/PasswordResetTest.php
+++ b/stubs/pest-tests/PasswordResetTest.php
@@ -1,0 +1,81 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Auth\Notifications\ResetPassword;
+use Illuminate\Support\Facades\Notification;
+use Laravel\Fortify\Features;
+
+test('reset_password_link_screen_can_be_rendered', function () {
+    if (! Features::enabled(Features::updatePasswords())) {
+        return $this->markTestSkipped('Password updates are not enabled.');
+    }
+
+    $response = $this->get('/forgot-password');
+
+    $response->assertStatus(200);
+});
+
+test('reset_password_link_can_be_requested', function () {
+    if (! Features::enabled(Features::updatePasswords())) {
+        return $this->markTestSkipped('Password updates are not enabled.');
+    }
+
+    Notification::fake();
+
+    $user = User::factory()->create();
+
+    $response = $this->post('/forgot-password', [
+        'email' => $user->email,
+    ]);
+
+    Notification::assertSentTo($user, ResetPassword::class);
+});
+
+test('reset_password_screen_can_be_rendered', function () {
+    if (! Features::enabled(Features::updatePasswords())) {
+        return $this->markTestSkipped('Password updates are not enabled.');
+    }
+
+    Notification::fake();
+
+    $user = User::factory()->create();
+
+    $response = $this->post('/forgot-password', [
+        'email' => $user->email,
+    ]);
+
+    Notification::assertSentTo($user, ResetPassword::class, function ($notification) {
+        $response = $this->get('/reset-password/'.$notification->token);
+
+        $response->assertStatus(200);
+
+        return true;
+    });
+});
+
+test('password_can_be_reset_with_valid_token', function () {
+    if (! Features::enabled(Features::updatePasswords())) {
+        return $this->markTestSkipped('Password updates are not enabled.');
+    }
+
+    Notification::fake();
+
+    $user = User::factory()->create();
+
+    $response = $this->post('/forgot-password', [
+        'email' => $user->email,
+    ]);
+
+    Notification::assertSentTo($user, ResetPassword::class, function ($notification) use ($user) {
+        $response = $this->post('/reset-password', [
+            'token' => $notification->token,
+            'email' => $user->email,
+            'password' => 'password',
+            'password_confirmation' => 'password',
+        ]);
+
+        $response->assertSessionHasNoErrors();
+
+        return true;
+    });
+});

--- a/stubs/pest-tests/PasswordResetTest.php
+++ b/stubs/pest-tests/PasswordResetTest.php
@@ -6,20 +6,14 @@ use Illuminate\Support\Facades\Notification;
 use Laravel\Fortify\Features;
 
 test('reset password link screen can be rendered', function () {
-    if (! Features::enabled(Features::updatePasswords())) {
-        return $this->markTestSkipped('Password updates are not enabled.');
-    }
-
     $response = $this->get('/forgot-password');
 
     $response->assertStatus(200);
-});
+})->skip(function() {
+    return ! Features::enabled(Features::updatePasswords());
+}, 'Password updates are not enabled.');
 
 test('reset password link can be requested', function () {
-    if (! Features::enabled(Features::updatePasswords())) {
-        return $this->markTestSkipped('Password updates are not enabled.');
-    }
-
     Notification::fake();
 
     $user = User::factory()->create();
@@ -29,13 +23,11 @@ test('reset password link can be requested', function () {
     ]);
 
     Notification::assertSentTo($user, ResetPassword::class);
-});
+})->skip(function() {
+    return ! Features::enabled(Features::updatePasswords());
+}, 'Password updates are not enabled.');
 
 test('reset password screen can be rendered', function () {
-    if (! Features::enabled(Features::updatePasswords())) {
-        return $this->markTestSkipped('Password updates are not enabled.');
-    }
-
     Notification::fake();
 
     $user = User::factory()->create();
@@ -51,13 +43,11 @@ test('reset password screen can be rendered', function () {
 
         return true;
     });
-});
+})->skip(function() {
+    return ! Features::enabled(Features::updatePasswords());
+}, 'Password updates are not enabled.');
 
 test('password can be reset with valid token', function () {
-    if (! Features::enabled(Features::updatePasswords())) {
-        return $this->markTestSkipped('Password updates are not enabled.');
-    }
-
     Notification::fake();
 
     $user = User::factory()->create();
@@ -78,4 +68,6 @@ test('password can be reset with valid token', function () {
 
         return true;
     });
-});
+})->skip(function() {
+    return ! Features::enabled(Features::updatePasswords());
+}, 'Password updates are not enabled.');

--- a/stubs/pest-tests/PasswordResetTest.php
+++ b/stubs/pest-tests/PasswordResetTest.php
@@ -9,7 +9,7 @@ test('reset password link screen can be rendered', function () {
     $response = $this->get('/forgot-password');
 
     $response->assertStatus(200);
-})->skip(function() {
+})->skip(function () {
     return ! Features::enabled(Features::updatePasswords());
 }, 'Password updates are not enabled.');
 
@@ -23,7 +23,7 @@ test('reset password link can be requested', function () {
     ]);
 
     Notification::assertSentTo($user, ResetPassword::class);
-})->skip(function() {
+})->skip(function () {
     return ! Features::enabled(Features::updatePasswords());
 }, 'Password updates are not enabled.');
 
@@ -43,7 +43,7 @@ test('reset password screen can be rendered', function () {
 
         return true;
     });
-})->skip(function() {
+})->skip(function () {
     return ! Features::enabled(Features::updatePasswords());
 }, 'Password updates are not enabled.');
 
@@ -68,6 +68,6 @@ test('password can be reset with valid token', function () {
 
         return true;
     });
-})->skip(function() {
+})->skip(function () {
     return ! Features::enabled(Features::updatePasswords());
 }, 'Password updates are not enabled.');

--- a/stubs/pest-tests/PasswordResetTest.php
+++ b/stubs/pest-tests/PasswordResetTest.php
@@ -5,7 +5,7 @@ use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Support\Facades\Notification;
 use Laravel\Fortify\Features;
 
-test('reset_password_link_screen_can_be_rendered', function () {
+test('reset password link screen can be rendered', function () {
     if (! Features::enabled(Features::updatePasswords())) {
         return $this->markTestSkipped('Password updates are not enabled.');
     }
@@ -15,7 +15,7 @@ test('reset_password_link_screen_can_be_rendered', function () {
     $response->assertStatus(200);
 });
 
-test('reset_password_link_can_be_requested', function () {
+test('reset password link can be requested', function () {
     if (! Features::enabled(Features::updatePasswords())) {
         return $this->markTestSkipped('Password updates are not enabled.');
     }
@@ -31,7 +31,7 @@ test('reset_password_link_can_be_requested', function () {
     Notification::assertSentTo($user, ResetPassword::class);
 });
 
-test('reset_password_screen_can_be_rendered', function () {
+test('reset password screen can be rendered', function () {
     if (! Features::enabled(Features::updatePasswords())) {
         return $this->markTestSkipped('Password updates are not enabled.');
     }
@@ -53,7 +53,7 @@ test('reset_password_screen_can_be_rendered', function () {
     });
 });
 
-test('password_can_be_reset_with_valid_token', function () {
+test('password can be reset with valid token', function () {
     if (! Features::enabled(Features::updatePasswords())) {
         return $this->markTestSkipped('Password updates are not enabled.');
     }

--- a/stubs/pest-tests/Pest.php
+++ b/stubs/pest-tests/Pest.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/*
+|--------------------------------------------------------------------------
+| Test Case
+|--------------------------------------------------------------------------
+|
+| The closure you provide to your test functions is always bound to a specific PHPUnit test
+| case class. By default, that class is "PHPUnit\Framework\TestCase". Of course, you may
+| need to change it using the "uses()" function to bind a different classes or traits.
+|
+*/
+
+uses(TestCase::class, RefreshDatabase::class)->in('Feature');
+
+/*
+|--------------------------------------------------------------------------
+| Expectations
+|--------------------------------------------------------------------------
+|
+| When you're writing tests, you often need to check that values meet certain conditions. The
+| "expect()" function gives you access to a set of "expectations" methods that you can use
+| to assert different things. Of course, you may extend the Expectation API at any time.
+|
+*/
+
+expect()->extend('toBeOne', function () {
+    return $this->toBe(1);
+});
+
+/*
+|--------------------------------------------------------------------------
+| Functions
+|--------------------------------------------------------------------------
+|
+| While Pest is very powerful out-of-the-box, you may have some testing code specific to your
+| project that you don't want to repeat in every file. Here you can also expose helpers as
+| global functions to help you to reduce the number of lines of code in your test files.
+|
+*/
+
+function something()
+{
+    // ..
+}

--- a/stubs/pest-tests/RegistrationTest.php
+++ b/stubs/pest-tests/RegistrationTest.php
@@ -17,8 +17,8 @@ test('registration screen cannot be rendered if support is disabled', function (
 
     $response->assertStatus(404);
 })->skip(function() {
-    return ! Features::enabled(Features::registration());
-}, 'Registration support is not enabled.');
+    return Features::enabled(Features::registration());
+}, 'Registration support is enabled.');
 
 test('new users can register', function () {
     $response = $this->post('/register', [

--- a/stubs/pest-tests/RegistrationTest.php
+++ b/stubs/pest-tests/RegistrationTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use App\Providers\RouteServiceProvider;
+use Laravel\Fortify\Features;
+use Laravel\Jetstream\Jetstream;
+
+test('registration_screen_can_be_rendered', function () {
+    if (! Features::enabled(Features::registration())) {
+        return $this->markTestSkipped('Registration support is not enabled.');
+    }
+
+    $response = $this->get('/register');
+
+    $response->assertStatus(200);
+});
+
+test('registration_screen_cannot_be_rendered_if_support_is_disabled', function () {
+    if (Features::enabled(Features::registration())) {
+        return $this->markTestSkipped('Registration support is enabled.');
+    }
+
+    $response = $this->get('/register');
+
+    $response->assertStatus(404);
+});
+
+test('new_users_can_register', function () {
+    if (! Features::enabled(Features::registration())) {
+        return $this->markTestSkipped('Registration support is not enabled.');
+    }
+
+    $response = $this->post('/register', [
+        'name' => 'Test User',
+        'email' => 'test@example.com',
+        'password' => 'password',
+        'password_confirmation' => 'password',
+        'terms' => Jetstream::hasTermsAndPrivacyPolicyFeature(),
+    ]);
+
+    $this->assertAuthenticated();
+    $response->assertRedirect(RouteServiceProvider::HOME);
+});

--- a/stubs/pest-tests/RegistrationTest.php
+++ b/stubs/pest-tests/RegistrationTest.php
@@ -5,30 +5,22 @@ use Laravel\Fortify\Features;
 use Laravel\Jetstream\Jetstream;
 
 test('registration screen can be rendered', function () {
-    if (! Features::enabled(Features::registration())) {
-        return $this->markTestSkipped('Registration support is not enabled.');
-    }
-
     $response = $this->get('/register');
 
     $response->assertStatus(200);
-});
+})->skip(function() {
+    return ! Features::enabled(Features::registration());
+}, 'Registration support is not enabled.');
 
 test('registration screen cannot be rendered if support is disabled', function () {
-    if (Features::enabled(Features::registration())) {
-        return $this->markTestSkipped('Registration support is enabled.');
-    }
-
     $response = $this->get('/register');
 
     $response->assertStatus(404);
-});
+})->skip(function() {
+    return ! Features::enabled(Features::registration());
+}, 'Registration support is not enabled.');
 
 test('new users can register', function () {
-    if (! Features::enabled(Features::registration())) {
-        return $this->markTestSkipped('Registration support is not enabled.');
-    }
-
     $response = $this->post('/register', [
         'name' => 'Test User',
         'email' => 'test@example.com',
@@ -39,4 +31,6 @@ test('new users can register', function () {
 
     $this->assertAuthenticated();
     $response->assertRedirect(RouteServiceProvider::HOME);
-});
+})->skip(function() {
+    return ! Features::enabled(Features::registration());
+}, 'Registration support is not enabled.');

--- a/stubs/pest-tests/RegistrationTest.php
+++ b/stubs/pest-tests/RegistrationTest.php
@@ -8,7 +8,7 @@ test('registration screen can be rendered', function () {
     $response = $this->get('/register');
 
     $response->assertStatus(200);
-})->skip(function() {
+})->skip(function () {
     return ! Features::enabled(Features::registration());
 }, 'Registration support is not enabled.');
 
@@ -16,7 +16,7 @@ test('registration screen cannot be rendered if support is disabled', function (
     $response = $this->get('/register');
 
     $response->assertStatus(404);
-})->skip(function() {
+})->skip(function () {
     return Features::enabled(Features::registration());
 }, 'Registration support is enabled.');
 
@@ -31,6 +31,6 @@ test('new users can register', function () {
 
     $this->assertAuthenticated();
     $response->assertRedirect(RouteServiceProvider::HOME);
-})->skip(function() {
+})->skip(function () {
     return ! Features::enabled(Features::registration());
 }, 'Registration support is not enabled.');

--- a/stubs/pest-tests/RegistrationTest.php
+++ b/stubs/pest-tests/RegistrationTest.php
@@ -4,7 +4,7 @@ use App\Providers\RouteServiceProvider;
 use Laravel\Fortify\Features;
 use Laravel\Jetstream\Jetstream;
 
-test('registration_screen_can_be_rendered', function () {
+test('registration screen can be rendered', function () {
     if (! Features::enabled(Features::registration())) {
         return $this->markTestSkipped('Registration support is not enabled.');
     }
@@ -14,7 +14,7 @@ test('registration_screen_can_be_rendered', function () {
     $response->assertStatus(200);
 });
 
-test('registration_screen_cannot_be_rendered_if_support_is_disabled', function () {
+test('registration screen cannot be rendered if support is disabled', function () {
     if (Features::enabled(Features::registration())) {
         return $this->markTestSkipped('Registration support is enabled.');
     }
@@ -24,7 +24,7 @@ test('registration_screen_cannot_be_rendered_if_support_is_disabled', function (
     $response->assertStatus(404);
 });
 
-test('new_users_can_register', function () {
+test('new users can register', function () {
     if (! Features::enabled(Features::registration())) {
         return $this->markTestSkipped('Registration support is not enabled.');
     }

--- a/stubs/pest-tests/inertia/ApiTokenPermissionsTest.php
+++ b/stubs/pest-tests/inertia/ApiTokenPermissionsTest.php
@@ -29,6 +29,6 @@ test('api token permissions can be updated', function () {
         ->can('delete')->toBeTrue()
         ->can('read')->toBeFalse()
         ->can('missing-permission')->toBeFalse();
-})->skip(function() {
+})->skip(function () {
     return ! Features::hasApiFeatures();
 }, 'API support is not enabled.');

--- a/stubs/pest-tests/inertia/ApiTokenPermissionsTest.php
+++ b/stubs/pest-tests/inertia/ApiTokenPermissionsTest.php
@@ -5,10 +5,6 @@ use Illuminate\Support\Str;
 use Laravel\Jetstream\Features;
 
 test('api token permissions can be updated', function () {
-    if (! Features::hasApiFeatures()) {
-        return $this->markTestSkipped('API support is not enabled.');
-    }
-
     if (Features::hasTeamFeatures()) {
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
     } else {
@@ -32,4 +28,6 @@ test('api token permissions can be updated', function () {
     expect($user->fresh()->tokens->first()->can('delete'))->toBeTrue();
     expect($user->fresh()->tokens->first()->can('read'))->toBeFalse();
     expect($user->fresh()->tokens->first()->can('missing-permission'))->toBeFalse();
-});
+})->skip(function() {
+    return ! Features::hasApiFeatures();
+}, 'API support is not enabled.');

--- a/stubs/pest-tests/inertia/ApiTokenPermissionsTest.php
+++ b/stubs/pest-tests/inertia/ApiTokenPermissionsTest.php
@@ -25,9 +25,10 @@ test('api token permissions can be updated', function () {
         ],
     ]);
 
-    expect($user->fresh()->tokens->first()->can('delete'))->toBeTrue();
-    expect($user->fresh()->tokens->first()->can('read'))->toBeFalse();
-    expect($user->fresh()->tokens->first()->can('missing-permission'))->toBeFalse();
+    expect($user->fresh()->tokens->first())
+        ->can('delete')->toBeTrue()
+        ->can('read')->toBeFalse()
+        ->can('missing-permission')->toBeFalse();
 })->skip(function() {
     return ! Features::hasApiFeatures();
 }, 'API support is not enabled.');

--- a/stubs/pest-tests/inertia/ApiTokenPermissionsTest.php
+++ b/stubs/pest-tests/inertia/ApiTokenPermissionsTest.php
@@ -29,7 +29,7 @@ test('api token permissions can be updated', function () {
         ],
     ]);
 
-    $this->assertTrue($user->fresh()->tokens->first()->can('delete'));
-    $this->assertFalse($user->fresh()->tokens->first()->can('read'));
-    $this->assertFalse($user->fresh()->tokens->first()->can('missing-permission'));
+    expect($user->fresh()->tokens->first()->can('delete'))->toBeTrue();
+    expect($user->fresh()->tokens->first()->can('read'))->toBeFalse();
+    expect($user->fresh()->tokens->first()->can('missing-permission'))->toBeFalse();
 });

--- a/stubs/pest-tests/inertia/ApiTokenPermissionsTest.php
+++ b/stubs/pest-tests/inertia/ApiTokenPermissionsTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Support\Str;
+use Laravel\Jetstream\Features;
+
+test('api token permissions can be updated', function () {
+    if (! Features::hasApiFeatures()) {
+        return $this->markTestSkipped('API support is not enabled.');
+    }
+
+    if (Features::hasTeamFeatures()) {
+        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+    } else {
+        $this->actingAs($user = User::factory()->create());
+    }
+
+    $token = $user->tokens()->create([
+        'name' => 'Test Token',
+        'token' => Str::random(40),
+        'abilities' => ['create', 'read'],
+    ]);
+
+    $response = $this->put('/user/api-tokens/'.$token->id, [
+        'name' => $token->name,
+        'permissions' => [
+            'delete',
+            'missing-permission',
+        ],
+    ]);
+
+    $this->assertTrue($user->fresh()->tokens->first()->can('delete'));
+    $this->assertFalse($user->fresh()->tokens->first()->can('read'));
+    $this->assertFalse($user->fresh()->tokens->first()->can('missing-permission'));
+});

--- a/stubs/pest-tests/inertia/BrowserSessionsTest.php
+++ b/stubs/pest-tests/inertia/BrowserSessionsTest.php
@@ -1,0 +1,13 @@
+<?php
+
+use App\Models\User;
+
+test('other browser sessions can be logged out', function () {
+    $this->actingAs($user = User::factory()->create());
+
+    $response = $this->delete('/user/other-browser-sessions', [
+        'password' => 'password',
+    ]);
+
+    $response->assertSessionHasNoErrors();
+});

--- a/stubs/pest-tests/inertia/CreateApiTokenTest.php
+++ b/stubs/pest-tests/inertia/CreateApiTokenTest.php
@@ -4,10 +4,6 @@ use App\Models\User;
 use Laravel\Jetstream\Features;
 
 test('api tokens can be created', function () {
-    if (! Features::hasApiFeatures()) {
-        return $this->markTestSkipped('API support is not enabled.');
-    }
-
     if (Features::hasTeamFeatures()) {
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
     } else {
@@ -26,4 +22,6 @@ test('api tokens can be created', function () {
     expect($user->fresh()->tokens->first()->name)->toEqual('Test Token');
     expect($user->fresh()->tokens->first()->can('read'))->toBeTrue();
     expect($user->fresh()->tokens->first()->can('delete'))->toBeFalse();
-});
+})->skip(function() {
+    return ! Features::hasApiFeatures();
+}, 'API support is not enabled.');

--- a/stubs/pest-tests/inertia/CreateApiTokenTest.php
+++ b/stubs/pest-tests/inertia/CreateApiTokenTest.php
@@ -19,9 +19,10 @@ test('api tokens can be created', function () {
     ]);
 
     expect($user->fresh()->tokens)->toHaveCount(1);
-    expect($user->fresh()->tokens->first()->name)->toEqual('Test Token');
-    expect($user->fresh()->tokens->first()->can('read'))->toBeTrue();
-    expect($user->fresh()->tokens->first()->can('delete'))->toBeFalse();
+    expect($user->fresh()->tokens->first())
+        ->name->toEqual('Test Token')
+        ->can('read')->toBeTrue()
+        ->can('delete')->toBeFalse();
 })->skip(function() {
     return ! Features::hasApiFeatures();
 }, 'API support is not enabled.');

--- a/stubs/pest-tests/inertia/CreateApiTokenTest.php
+++ b/stubs/pest-tests/inertia/CreateApiTokenTest.php
@@ -22,8 +22,8 @@ test('api tokens can be created', function () {
         ],
     ]);
 
-    $this->assertCount(1, $user->fresh()->tokens);
-    $this->assertEquals('Test Token', $user->fresh()->tokens->first()->name);
-    $this->assertTrue($user->fresh()->tokens->first()->can('read'));
-    $this->assertFalse($user->fresh()->tokens->first()->can('delete'));
+    expect($user->fresh()->tokens)->toHaveCount(1);
+    expect($user->fresh()->tokens->first()->name)->toEqual('Test Token');
+    expect($user->fresh()->tokens->first()->can('read'))->toBeTrue();
+    expect($user->fresh()->tokens->first()->can('delete'))->toBeFalse();
 });

--- a/stubs/pest-tests/inertia/CreateApiTokenTest.php
+++ b/stubs/pest-tests/inertia/CreateApiTokenTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use App\Models\User;
+use Laravel\Jetstream\Features;
+
+test('api tokens can be created', function () {
+    if (! Features::hasApiFeatures()) {
+        return $this->markTestSkipped('API support is not enabled.');
+    }
+
+    if (Features::hasTeamFeatures()) {
+        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+    } else {
+        $this->actingAs($user = User::factory()->create());
+    }
+
+    $response = $this->post('/user/api-tokens', [
+        'name' => 'Test Token',
+        'permissions' => [
+            'read',
+            'update',
+        ],
+    ]);
+
+    $this->assertCount(1, $user->fresh()->tokens);
+    $this->assertEquals('Test Token', $user->fresh()->tokens->first()->name);
+    $this->assertTrue($user->fresh()->tokens->first()->can('read'));
+    $this->assertFalse($user->fresh()->tokens->first()->can('delete'));
+});

--- a/stubs/pest-tests/inertia/CreateApiTokenTest.php
+++ b/stubs/pest-tests/inertia/CreateApiTokenTest.php
@@ -23,6 +23,6 @@ test('api tokens can be created', function () {
         ->name->toEqual('Test Token')
         ->can('read')->toBeTrue()
         ->can('delete')->toBeFalse();
-})->skip(function() {
+})->skip(function () {
     return ! Features::hasApiFeatures();
 }, 'API support is not enabled.');

--- a/stubs/pest-tests/inertia/CreateTeamTest.php
+++ b/stubs/pest-tests/inertia/CreateTeamTest.php
@@ -1,0 +1,14 @@
+<?php
+
+use App\Models\User;
+
+test('teams can be created', function () {
+    $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+
+    $response = $this->post('/teams', [
+        'name' => 'Test Team',
+    ]);
+
+    $this->assertCount(2, $user->fresh()->ownedTeams);
+    $this->assertEquals('Test Team', $user->fresh()->ownedTeams()->latest('id')->first()->name);
+});

--- a/stubs/pest-tests/inertia/CreateTeamTest.php
+++ b/stubs/pest-tests/inertia/CreateTeamTest.php
@@ -9,6 +9,6 @@ test('teams can be created', function () {
         'name' => 'Test Team',
     ]);
 
-    $this->assertCount(2, $user->fresh()->ownedTeams);
-    $this->assertEquals('Test Team', $user->fresh()->ownedTeams()->latest('id')->first()->name);
+    expect($user->fresh()->ownedTeams)->toHaveCount(2);
+    expect($user->fresh()->ownedTeams()->latest('id')->first()->name)->toEqual('Test Team');
 });

--- a/stubs/pest-tests/inertia/DeleteAccountTest.php
+++ b/stubs/pest-tests/inertia/DeleteAccountTest.php
@@ -14,7 +14,7 @@ test('user accounts can be deleted', function () {
         'password' => 'password',
     ]);
 
-    $this->assertNull($user->fresh());
+    expect($user->fresh())->toBeNull();
 });
 
 test('correct password must be provided before account can be deleted', function () {
@@ -28,5 +28,5 @@ test('correct password must be provided before account can be deleted', function
         'password' => 'wrong-password',
     ]);
 
-    $this->assertNotNull($user->fresh());
+    expect($user->fresh())->not->toBeNull();
 });

--- a/stubs/pest-tests/inertia/DeleteAccountTest.php
+++ b/stubs/pest-tests/inertia/DeleteAccountTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use App\Models\User;
+use Laravel\Jetstream\Features;
+
+test('user accounts can be deleted', function () {
+    if (! Features::hasAccountDeletionFeatures()) {
+        return $this->markTestSkipped('Account deletion is not enabled.');
+    }
+
+    $this->actingAs($user = User::factory()->create());
+
+    $response = $this->delete('/user', [
+        'password' => 'password',
+    ]);
+
+    $this->assertNull($user->fresh());
+});
+
+test('correct password must be provided before account can be deleted', function () {
+    if (! Features::hasAccountDeletionFeatures()) {
+        return $this->markTestSkipped('Account deletion is not enabled.');
+    }
+
+    $this->actingAs($user = User::factory()->create());
+
+    $response = $this->delete('/user', [
+        'password' => 'wrong-password',
+    ]);
+
+    $this->assertNotNull($user->fresh());
+});

--- a/stubs/pest-tests/inertia/DeleteAccountTest.php
+++ b/stubs/pest-tests/inertia/DeleteAccountTest.php
@@ -4,10 +4,6 @@ use App\Models\User;
 use Laravel\Jetstream\Features;
 
 test('user accounts can be deleted', function () {
-    if (! Features::hasAccountDeletionFeatures()) {
-        return $this->markTestSkipped('Account deletion is not enabled.');
-    }
-
     $this->actingAs($user = User::factory()->create());
 
     $response = $this->delete('/user', [
@@ -15,13 +11,11 @@ test('user accounts can be deleted', function () {
     ]);
 
     expect($user->fresh())->toBeNull();
-});
+})->skip(function() {
+    return ! Features::hasAccountDeletionFeatures();
+}, 'Account deletion is not enabled.');
 
 test('correct password must be provided before account can be deleted', function () {
-    if (! Features::hasAccountDeletionFeatures()) {
-        return $this->markTestSkipped('Account deletion is not enabled.');
-    }
-
     $this->actingAs($user = User::factory()->create());
 
     $response = $this->delete('/user', [
@@ -29,4 +23,6 @@ test('correct password must be provided before account can be deleted', function
     ]);
 
     expect($user->fresh())->not->toBeNull();
-});
+})->skip(function() {
+    return ! Features::hasAccountDeletionFeatures();
+}, 'Account deletion is not enabled.');

--- a/stubs/pest-tests/inertia/DeleteAccountTest.php
+++ b/stubs/pest-tests/inertia/DeleteAccountTest.php
@@ -11,7 +11,7 @@ test('user accounts can be deleted', function () {
     ]);
 
     expect($user->fresh())->toBeNull();
-})->skip(function() {
+})->skip(function () {
     return ! Features::hasAccountDeletionFeatures();
 }, 'Account deletion is not enabled.');
 
@@ -23,6 +23,6 @@ test('correct password must be provided before account can be deleted', function
     ]);
 
     expect($user->fresh())->not->toBeNull();
-})->skip(function() {
+})->skip(function () {
     return ! Features::hasAccountDeletionFeatures();
 }, 'Account deletion is not enabled.');

--- a/stubs/pest-tests/inertia/DeleteApiTokenTest.php
+++ b/stubs/pest-tests/inertia/DeleteApiTokenTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Support\Str;
+use Laravel\Jetstream\Features;
+
+test('api_tokens_can_be_deleted', function () {
+    if (! Features::hasApiFeatures()) {
+        return $this->markTestSkipped('API support is not enabled.');
+    }
+
+    if (Features::hasTeamFeatures()) {
+        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+    } else {
+        $this->actingAs($user = User::factory()->create());
+    }
+
+    $token = $user->tokens()->create([
+        'name' => 'Test Token',
+        'token' => Str::random(40),
+        'abilities' => ['create', 'read'],
+    ]);
+
+    $response = $this->delete('/user/api-tokens/'.$token->id);
+
+    $this->assertCount(0, $user->fresh()->tokens);
+});

--- a/stubs/pest-tests/inertia/DeleteApiTokenTest.php
+++ b/stubs/pest-tests/inertia/DeleteApiTokenTest.php
@@ -4,7 +4,7 @@ use App\Models\User;
 use Illuminate\Support\Str;
 use Laravel\Jetstream\Features;
 
-test('api_tokens_can_be_deleted', function () {
+test('api tokens can be deleted', function () {
     if (! Features::hasApiFeatures()) {
         return $this->markTestSkipped('API support is not enabled.');
     }

--- a/stubs/pest-tests/inertia/DeleteApiTokenTest.php
+++ b/stubs/pest-tests/inertia/DeleteApiTokenTest.php
@@ -5,10 +5,6 @@ use Illuminate\Support\Str;
 use Laravel\Jetstream\Features;
 
 test('api tokens can be deleted', function () {
-    if (! Features::hasApiFeatures()) {
-        return $this->markTestSkipped('API support is not enabled.');
-    }
-
     if (Features::hasTeamFeatures()) {
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
     } else {
@@ -24,4 +20,6 @@ test('api tokens can be deleted', function () {
     $response = $this->delete('/user/api-tokens/'.$token->id);
 
     expect($user->fresh()->tokens)->toHaveCount(0);
-});
+})->skip(function() {
+    return ! Features::hasApiFeatures();
+}, 'API support is not enabled.');

--- a/stubs/pest-tests/inertia/DeleteApiTokenTest.php
+++ b/stubs/pest-tests/inertia/DeleteApiTokenTest.php
@@ -23,5 +23,5 @@ test('api tokens can be deleted', function () {
 
     $response = $this->delete('/user/api-tokens/'.$token->id);
 
-    $this->assertCount(0, $user->fresh()->tokens);
+    expect($user->fresh()->tokens)->toHaveCount(0);
 });

--- a/stubs/pest-tests/inertia/DeleteApiTokenTest.php
+++ b/stubs/pest-tests/inertia/DeleteApiTokenTest.php
@@ -20,6 +20,6 @@ test('api tokens can be deleted', function () {
     $response = $this->delete('/user/api-tokens/'.$token->id);
 
     expect($user->fresh()->tokens)->toHaveCount(0);
-})->skip(function() {
+})->skip(function () {
     return ! Features::hasApiFeatures();
 }, 'API support is not enabled.');

--- a/stubs/pest-tests/inertia/DeleteTeamTest.php
+++ b/stubs/pest-tests/inertia/DeleteTeamTest.php
@@ -16,8 +16,8 @@ test('teams can be deleted', function () {
 
     $response = $this->delete('/teams/'.$team->id);
 
-    $this->assertNull($team->fresh());
-    $this->assertCount(0, $otherUser->fresh()->teams);
+    expect($team->fresh())->toBeNull();
+    expect($otherUser->fresh()->teams)->toHaveCount(0);
 });
 
 test('personal teams cant be deleted', function ()
@@ -26,5 +26,5 @@ test('personal teams cant be deleted', function ()
 
     $response = $this->delete('/teams/'.$user->currentTeam->id);
 
-    $this->assertNotNull($user->currentTeam->fresh());
+    expect($user->currentTeam->fresh())->not->toBeNull();
 });

--- a/stubs/pest-tests/inertia/DeleteTeamTest.php
+++ b/stubs/pest-tests/inertia/DeleteTeamTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use App\Models\Team;
+use App\Models\User;
+
+test('teams can be deleted', function () {
+    $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+
+    $user->ownedTeams()->save($team = Team::factory()->make([
+        'personal_team' => false,
+    ]));
+
+    $team->users()->attach(
+        $otherUser = User::factory()->create(), ['role' => 'test-role']
+    );
+
+    $response = $this->delete('/teams/'.$team->id);
+
+    $this->assertNull($team->fresh());
+    $this->assertCount(0, $otherUser->fresh()->teams);
+});
+
+test('personal teams cant be deleted', function ()
+{
+    $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+
+    $response = $this->delete('/teams/'.$user->currentTeam->id);
+
+    $this->assertNotNull($user->currentTeam->fresh());
+});

--- a/stubs/pest-tests/inertia/DeleteTeamTest.php
+++ b/stubs/pest-tests/inertia/DeleteTeamTest.php
@@ -20,8 +20,7 @@ test('teams can be deleted', function () {
     expect($otherUser->fresh()->teams)->toHaveCount(0);
 });
 
-test('personal teams cant be deleted', function ()
-{
+test('personal teams cant be deleted', function () {
     $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
     $response = $this->delete('/teams/'.$user->currentTeam->id);

--- a/stubs/pest-tests/inertia/InviteTeamMemberTest.php
+++ b/stubs/pest-tests/inertia/InviteTeamMemberTest.php
@@ -16,7 +16,7 @@ test('team members can be invited to team', function () {
 
     Mail::assertSent(TeamInvitation::class);
 
-    $this->assertCount(1, $user->currentTeam->fresh()->teamInvitations);
+    expect($user->currentTeam->fresh()->teamInvitations)->toHaveCount(1);
 });
 
 test('team member invitations can be cancelled', function () {
@@ -29,5 +29,5 @@ test('team member invitations can be cancelled', function () {
 
     $response = $this->delete('/team-invitations/'.$invitation->id);
 
-    $this->assertCount(0, $user->currentTeam->fresh()->teamInvitations);
+    expect($user->currentTeam->fresh()->teamInvitations)->toHaveCount(0);
 });

--- a/stubs/pest-tests/inertia/InviteTeamMemberTest.php
+++ b/stubs/pest-tests/inertia/InviteTeamMemberTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Support\Facades\Mail;
+use Laravel\Jetstream\Mail\TeamInvitation;
+
+test('team members can be invited to team', function () {
+    Mail::fake();
+
+    $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+
+    $response = $this->post('/teams/'.$user->currentTeam->id.'/members', [
+        'email' => 'test@example.com',
+        'role' => 'admin',
+    ]);
+
+    Mail::assertSent(TeamInvitation::class);
+
+    $this->assertCount(1, $user->currentTeam->fresh()->teamInvitations);
+});
+
+test('team member invitations can be cancelled', function () {
+    $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+
+    $invitation = $user->currentTeam->teamInvitations()->create([
+        'email' => 'test@example.com',
+        'role' => 'admin',
+    ]);
+
+    $response = $this->delete('/team-invitations/'.$invitation->id);
+
+    $this->assertCount(0, $user->currentTeam->fresh()->teamInvitations);
+});

--- a/stubs/pest-tests/inertia/LeaveTeamTest.php
+++ b/stubs/pest-tests/inertia/LeaveTeamTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use App\Models\User;
+
+test('users can leave teams', function () {
+    $user = User::factory()->withPersonalTeam()->create();
+
+    $user->currentTeam->users()->attach(
+        $otherUser = User::factory()->create(), ['role' => 'admin']
+    );
+
+    $this->actingAs($otherUser);
+
+    $response = $this->delete('/teams/'.$user->currentTeam->id.'/members/'.$otherUser->id);
+
+    $this->assertCount(0, $user->currentTeam->fresh()->users);
+});
+
+test('team owners cant leave their own team', function () {
+    $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+
+    $response = $this->delete('/teams/'.$user->currentTeam->id.'/members/'.$user->id);
+
+    $response->assertSessionHasErrorsIn('removeTeamMember', ['team']);
+
+    $this->assertNotNull($user->currentTeam->fresh());
+});

--- a/stubs/pest-tests/inertia/LeaveTeamTest.php
+++ b/stubs/pest-tests/inertia/LeaveTeamTest.php
@@ -13,7 +13,7 @@ test('users can leave teams', function () {
 
     $response = $this->delete('/teams/'.$user->currentTeam->id.'/members/'.$otherUser->id);
 
-    $this->assertCount(0, $user->currentTeam->fresh()->users);
+    expect($user->currentTeam->fresh()->users)->toHaveCount(0);
 });
 
 test('team owners cant leave their own team', function () {
@@ -23,5 +23,5 @@ test('team owners cant leave their own team', function () {
 
     $response->assertSessionHasErrorsIn('removeTeamMember', ['team']);
 
-    $this->assertNotNull($user->currentTeam->fresh());
+    expect($user->currentTeam->fresh())->not->toBeNull();
 });

--- a/stubs/pest-tests/inertia/ProfileInformationTest.php
+++ b/stubs/pest-tests/inertia/ProfileInformationTest.php
@@ -1,0 +1,15 @@
+<?php
+
+use App\Models\User;
+
+test('profile_information_can_be_updated', function () {
+    $this->actingAs($user = User::factory()->create());
+
+    $response = $this->put('/user/profile-information', [
+        'name' => 'Test Name',
+        'email' => 'test@example.com',
+    ]);
+
+    $this->assertEquals('Test Name', $user->fresh()->name);
+    $this->assertEquals('test@example.com', $user->fresh()->email);
+});

--- a/stubs/pest-tests/inertia/ProfileInformationTest.php
+++ b/stubs/pest-tests/inertia/ProfileInformationTest.php
@@ -10,6 +10,6 @@ test('profile information can be updated', function () {
         'email' => 'test@example.com',
     ]);
 
-    $this->assertEquals('Test Name', $user->fresh()->name);
-    $this->assertEquals('test@example.com', $user->fresh()->email);
+    expect($user->fresh()->name)->toEqual('Test Name');
+    expect($user->fresh()->email)->toEqual('test@example.com');
 });

--- a/stubs/pest-tests/inertia/ProfileInformationTest.php
+++ b/stubs/pest-tests/inertia/ProfileInformationTest.php
@@ -2,7 +2,7 @@
 
 use App\Models\User;
 
-test('profile_information_can_be_updated', function () {
+test('profile information can be updated', function () {
     $this->actingAs($user = User::factory()->create());
 
     $response = $this->put('/user/profile-information', [

--- a/stubs/pest-tests/inertia/ProfileInformationTest.php
+++ b/stubs/pest-tests/inertia/ProfileInformationTest.php
@@ -10,6 +10,7 @@ test('profile information can be updated', function () {
         'email' => 'test@example.com',
     ]);
 
-    expect($user->fresh()->name)->toEqual('Test Name');
-    expect($user->fresh()->email)->toEqual('test@example.com');
+    expect($user->fresh())
+        ->name->toEqual('Test Name')
+        ->email->toEqual('test@example.com');
 });

--- a/stubs/pest-tests/inertia/RemoveTeamMemberTest.php
+++ b/stubs/pest-tests/inertia/RemoveTeamMemberTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use App\Models\User;
+
+test('team members can be removed from teams', function () {
+    $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+
+    $user->currentTeam->users()->attach(
+        $otherUser = User::factory()->create(), ['role' => 'admin']
+    );
+
+    $response = $this->delete('/teams/'.$user->currentTeam->id.'/members/'.$otherUser->id);
+
+    $this->assertCount(0, $user->currentTeam->fresh()->users);
+});
+
+test('only team owner can remove team members', function () {
+    $user = User::factory()->withPersonalTeam()->create();
+
+    $user->currentTeam->users()->attach(
+        $otherUser = User::factory()->create(), ['role' => 'admin']
+    );
+
+    $this->actingAs($otherUser);
+
+    $response = $this->delete('/teams/'.$user->currentTeam->id.'/members/'.$user->id);
+
+    $response->assertStatus(403);
+});

--- a/stubs/pest-tests/inertia/RemoveTeamMemberTest.php
+++ b/stubs/pest-tests/inertia/RemoveTeamMemberTest.php
@@ -11,7 +11,7 @@ test('team members can be removed from teams', function () {
 
     $response = $this->delete('/teams/'.$user->currentTeam->id.'/members/'.$otherUser->id);
 
-    $this->assertCount(0, $user->currentTeam->fresh()->users);
+    expect($user->currentTeam->fresh()->users)->toHaveCount(0);
 });
 
 test('only team owner can remove team members', function () {

--- a/stubs/pest-tests/inertia/TwoFactorAuthenticationSettingsTest.php
+++ b/stubs/pest-tests/inertia/TwoFactorAuthenticationSettingsTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use App\Models\User;
+
+test('two factor authentication can be enabled', function () {
+    $this->actingAs($user = User::factory()->create());
+
+    $this->withSession(['auth.password_confirmed_at' => time()]);
+
+    $response = $this->post('/user/two-factor-authentication');
+
+    $this->assertNotNull($user->fresh()->two_factor_secret);
+    $this->assertCount(8, $user->fresh()->recoveryCodes());
+});
+
+test('recovery codes can be regenerated', function () {
+    $this->actingAs($user = User::factory()->create());
+
+    $this->withSession(['auth.password_confirmed_at' => time()]);
+
+    $this->post('/user/two-factor-authentication');
+    $this->post('/user/two-factor-recovery-codes');
+
+    $user = $user->fresh();
+
+    $this->post('/user/two-factor-recovery-codes');
+
+    $this->assertCount(8, $user->recoveryCodes());
+    $this->assertCount(8, array_diff($user->recoveryCodes(), $user->fresh()->recoveryCodes()));
+});
+
+test('two factor authentication can be disabled', function () {
+    $this->actingAs($user = User::factory()->create());
+
+    $this->withSession(['auth.password_confirmed_at' => time()]);
+
+    $this->post('/user/two-factor-authentication');
+
+    $this->assertNotNull($user->fresh()->two_factor_secret);
+
+    $this->delete('/user/two-factor-authentication');
+
+    $this->assertNull($user->fresh()->two_factor_secret);
+});

--- a/stubs/pest-tests/inertia/TwoFactorAuthenticationSettingsTest.php
+++ b/stubs/pest-tests/inertia/TwoFactorAuthenticationSettingsTest.php
@@ -9,8 +9,8 @@ test('two factor authentication can be enabled', function () {
 
     $response = $this->post('/user/two-factor-authentication');
 
-    $this->assertNotNull($user->fresh()->two_factor_secret);
-    $this->assertCount(8, $user->fresh()->recoveryCodes());
+    expect($user->fresh()->two_factor_secret)->not->toBeNull();
+    expect($user->fresh()->recoveryCodes())->toHaveCount(8);
 });
 
 test('recovery codes can be regenerated', function () {
@@ -25,8 +25,8 @@ test('recovery codes can be regenerated', function () {
 
     $this->post('/user/two-factor-recovery-codes');
 
-    $this->assertCount(8, $user->recoveryCodes());
-    $this->assertCount(8, array_diff($user->recoveryCodes(), $user->fresh()->recoveryCodes()));
+    expect($user->recoveryCodes())->toHaveCount(8);
+    expect(array_diff($user->recoveryCodes(), $user->fresh()->recoveryCodes()))->toHaveCount(8);
 });
 
 test('two factor authentication can be disabled', function () {
@@ -40,5 +40,5 @@ test('two factor authentication can be disabled', function () {
 
     $this->delete('/user/two-factor-authentication');
 
-    $this->assertNull($user->fresh()->two_factor_secret);
+    expect($user->fresh()->two_factor_secret)->toBeNull();
 });

--- a/stubs/pest-tests/inertia/UpdatePasswordTest.php
+++ b/stubs/pest-tests/inertia/UpdatePasswordTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+
+test('password can be updated', function () {
+    $this->actingAs($user = User::factory()->create());
+
+    $response = $this->put('/user/password', [
+        'current_password' => 'password',
+        'password' => 'new-password',
+        'password_confirmation' => 'new-password',
+    ]);
+
+    $this->assertTrue(Hash::check('new-password', $user->fresh()->password));
+});
+
+test('current password must be correct', function () {
+    $this->actingAs($user = User::factory()->create());
+
+    $response = $this->put('/user/password', [
+        'current_password' => 'wrong-password',
+        'password' => 'new-password',
+        'password_confirmation' => 'new-password',
+    ]);
+
+    $response->assertSessionHasErrors();
+
+    $this->assertTrue(Hash::check('password', $user->fresh()->password));
+});
+
+test('new passwords must match', function () {
+    $this->actingAs($user = User::factory()->create());
+
+    $response = $this->put('/user/password', [
+        'current_password' => 'password',
+        'password' => 'new-password',
+        'password_confirmation' => 'wrong-password',
+    ]);
+
+    $response->assertSessionHasErrors();
+
+    $this->assertTrue(Hash::check('password', $user->fresh()->password));
+});

--- a/stubs/pest-tests/inertia/UpdatePasswordTest.php
+++ b/stubs/pest-tests/inertia/UpdatePasswordTest.php
@@ -12,7 +12,7 @@ test('password can be updated', function () {
         'password_confirmation' => 'new-password',
     ]);
 
-    $this->assertTrue(Hash::check('new-password', $user->fresh()->password));
+    expect(Hash::check('new-password', $user->fresh()->password))->toBeTrue();
 });
 
 test('current password must be correct', function () {
@@ -26,7 +26,7 @@ test('current password must be correct', function () {
 
     $response->assertSessionHasErrors();
 
-    $this->assertTrue(Hash::check('password', $user->fresh()->password));
+    expect(Hash::check('password', $user->fresh()->password))->toBeTrue();
 });
 
 test('new passwords must match', function () {
@@ -40,5 +40,5 @@ test('new passwords must match', function () {
 
     $response->assertSessionHasErrors();
 
-    $this->assertTrue(Hash::check('password', $user->fresh()->password));
+    expect(Hash::check('password', $user->fresh()->password))->toBeTrue();
 });

--- a/stubs/pest-tests/inertia/UpdateTeamMemberRoleTest.php
+++ b/stubs/pest-tests/inertia/UpdateTeamMemberRoleTest.php
@@ -13,9 +13,9 @@ test('team member roles can be updated', function () {
         'role' => 'editor',
     ]);
 
-    $this->assertTrue($otherUser->fresh()->hasTeamRole(
+    expect($otherUser->fresh()->hasTeamRole(
         $user->currentTeam->fresh(), 'editor'
-    ));
+    ))->toBeTrue();
 });
 
 test('only team owner can update team member roles', function () {
@@ -31,7 +31,7 @@ test('only team owner can update team member roles', function () {
         'role' => 'editor',
     ]);
 
-    $this->assertTrue($otherUser->fresh()->hasTeamRole(
+    expect($otherUser->fresh()->hasTeamRole(
         $user->currentTeam->fresh(), 'admin'
-    ));
+    ))->toBeTrue();
 });

--- a/stubs/pest-tests/inertia/UpdateTeamMemberRoleTest.php
+++ b/stubs/pest-tests/inertia/UpdateTeamMemberRoleTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use App\Models\User;
+
+test('team member roles can be updated', function () {
+    $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+
+    $user->currentTeam->users()->attach(
+        $otherUser = User::factory()->create(), ['role' => 'admin']
+    );
+
+    $response = $this->put('/teams/'.$user->currentTeam->id.'/members/'.$otherUser->id, [
+        'role' => 'editor',
+    ]);
+
+    $this->assertTrue($otherUser->fresh()->hasTeamRole(
+        $user->currentTeam->fresh(), 'editor'
+    ));
+});
+
+test('only team owner can update team member roles', function () {
+    $user = User::factory()->withPersonalTeam()->create();
+
+    $user->currentTeam->users()->attach(
+        $otherUser = User::factory()->create(), ['role' => 'admin']
+    );
+
+    $this->actingAs($otherUser);
+
+    $response = $this->put('/teams/'.$user->currentTeam->id.'/members/'.$otherUser->id, [
+        'role' => 'editor',
+    ]);
+
+    $this->assertTrue($otherUser->fresh()->hasTeamRole(
+        $user->currentTeam->fresh(), 'admin'
+    ));
+});

--- a/stubs/pest-tests/inertia/UpdateTeamNameTest.php
+++ b/stubs/pest-tests/inertia/UpdateTeamNameTest.php
@@ -9,6 +9,6 @@ test('team names can be updated', function () {
         'name' => 'Test Team',
     ]);
 
-    $this->assertCount(1, $user->fresh()->ownedTeams);
-    $this->assertEquals('Test Team', $user->currentTeam->fresh()->name);
+    expect($user->fresh()->ownedTeams)->toHaveCount(1);
+    expect($user->currentTeam->fresh()->name)->toEqual('Test Team');
 });

--- a/stubs/pest-tests/inertia/UpdateTeamNameTest.php
+++ b/stubs/pest-tests/inertia/UpdateTeamNameTest.php
@@ -1,0 +1,14 @@
+<?php
+
+use App\Models\User;
+
+test('team names can be updated', function () {
+    $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+
+    $response = $this->put('/teams/'.$user->currentTeam->id, [
+        'name' => 'Test Team',
+    ]);
+
+    $this->assertCount(1, $user->fresh()->ownedTeams);
+    $this->assertEquals('Test Team', $user->currentTeam->fresh()->name);
+});

--- a/stubs/pest-tests/livewire/ApiTokenPermissionsTest.php
+++ b/stubs/pest-tests/livewire/ApiTokenPermissionsTest.php
@@ -7,10 +7,6 @@ use Laravel\Jetstream\Http\Livewire\ApiTokenManager;
 use Livewire\Livewire;
 
 test('api token permissions can be updated', function () {
-    if (! Features::hasApiFeatures()) {
-        return $this->markTestSkipped('API support is not enabled.');
-    }
-
     if (Features::hasTeamFeatures()) {
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
     } else {
@@ -36,4 +32,6 @@ test('api token permissions can be updated', function () {
     expect($user->fresh()->tokens->first()->can('delete'))->toBeTrue();
     expect($user->fresh()->tokens->first()->can('read'))->toBeFalse();
     expect($user->fresh()->tokens->first()->can('missing-permission'))->toBeFalse();
-});
+})->skip(function() {
+    return ! Features::hasApiFeatures();
+}, 'API support is not enabled.');

--- a/stubs/pest-tests/livewire/ApiTokenPermissionsTest.php
+++ b/stubs/pest-tests/livewire/ApiTokenPermissionsTest.php
@@ -29,9 +29,10 @@ test('api token permissions can be updated', function () {
                 ]])
                 ->call('updateApiToken');
 
-    expect($user->fresh()->tokens->first()->can('delete'))->toBeTrue();
-    expect($user->fresh()->tokens->first()->can('read'))->toBeFalse();
-    expect($user->fresh()->tokens->first()->can('missing-permission'))->toBeFalse();
+    expect($user->fresh()->tokens->first())
+        ->can('delete')->toBeTrue()
+        ->can('read')->toBeFalse()
+        ->can('missing-permission')->toBeFalse();
 })->skip(function() {
     return ! Features::hasApiFeatures();
 }, 'API support is not enabled.');

--- a/stubs/pest-tests/livewire/ApiTokenPermissionsTest.php
+++ b/stubs/pest-tests/livewire/ApiTokenPermissionsTest.php
@@ -33,7 +33,7 @@ test('api token permissions can be updated', function () {
                 ]])
                 ->call('updateApiToken');
 
-    $this->assertTrue($user->fresh()->tokens->first()->can('delete'));
-    $this->assertFalse($user->fresh()->tokens->first()->can('read'));
-    $this->assertFalse($user->fresh()->tokens->first()->can('missing-permission'));
+    expect($user->fresh()->tokens->first()->can('delete'))->toBeTrue();
+    expect($user->fresh()->tokens->first()->can('read'))->toBeFalse();
+    expect($user->fresh()->tokens->first()->can('missing-permission'))->toBeFalse();
 });

--- a/stubs/pest-tests/livewire/ApiTokenPermissionsTest.php
+++ b/stubs/pest-tests/livewire/ApiTokenPermissionsTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Support\Str;
+use Laravel\Jetstream\Features;
+use Laravel\Jetstream\Http\Livewire\ApiTokenManager;
+use Livewire\Livewire;
+
+test('api token permissions can be updated', function () {
+    if (! Features::hasApiFeatures()) {
+        return $this->markTestSkipped('API support is not enabled.');
+    }
+
+    if (Features::hasTeamFeatures()) {
+        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+    } else {
+        $this->actingAs($user = User::factory()->create());
+    }
+
+    $token = $user->tokens()->create([
+        'name' => 'Test Token',
+        'token' => Str::random(40),
+        'abilities' => ['create', 'read'],
+    ]);
+
+    Livewire::test(ApiTokenManager::class)
+                ->set(['managingPermissionsFor' => $token])
+                ->set(['updateApiTokenForm' => [
+                    'permissions' => [
+                        'delete',
+                        'missing-permission',
+                    ],
+                ]])
+                ->call('updateApiToken');
+
+    $this->assertTrue($user->fresh()->tokens->first()->can('delete'));
+    $this->assertFalse($user->fresh()->tokens->first()->can('read'));
+    $this->assertFalse($user->fresh()->tokens->first()->can('missing-permission'));
+});

--- a/stubs/pest-tests/livewire/ApiTokenPermissionsTest.php
+++ b/stubs/pest-tests/livewire/ApiTokenPermissionsTest.php
@@ -33,6 +33,6 @@ test('api token permissions can be updated', function () {
         ->can('delete')->toBeTrue()
         ->can('read')->toBeFalse()
         ->can('missing-permission')->toBeFalse();
-})->skip(function() {
+})->skip(function () {
     return ! Features::hasApiFeatures();
 }, 'API support is not enabled.');

--- a/stubs/pest-tests/livewire/BrowserSessionsTest.php
+++ b/stubs/pest-tests/livewire/BrowserSessionsTest.php
@@ -1,0 +1,13 @@
+<?php
+
+use App\Models\User;
+use Laravel\Jetstream\Http\Livewire\LogoutOtherBrowserSessionsForm;
+use Livewire\Livewire;
+
+test('other browser sessions can be logged out', function () {
+    $this->actingAs($user = User::factory()->create());
+
+    Livewire::test(LogoutOtherBrowserSessionsForm::class)
+            ->set('password', 'password')
+            ->call('logoutOtherBrowserSessions');
+});

--- a/stubs/pest-tests/livewire/CreateApiTokenTest.php
+++ b/stubs/pest-tests/livewire/CreateApiTokenTest.php
@@ -26,8 +26,8 @@ test('api tokens can be created', function () {
                 ]])
                 ->call('createApiToken');
 
-    $this->assertCount(1, $user->fresh()->tokens);
-    $this->assertEquals('Test Token', $user->fresh()->tokens->first()->name);
-    $this->assertTrue($user->fresh()->tokens->first()->can('read'));
-    $this->assertFalse($user->fresh()->tokens->first()->can('delete'));
+    expect($user->fresh()->tokens)->toHaveCount(1);
+    expect($user->fresh()->tokens->first()->name)->toEqual('Test Token');
+    expect($user->fresh()->tokens->first()->can('read'))->toBeTrue();
+    expect($user->fresh()->tokens->first()->can('delete'))->toBeFalse();
 });

--- a/stubs/pest-tests/livewire/CreateApiTokenTest.php
+++ b/stubs/pest-tests/livewire/CreateApiTokenTest.php
@@ -6,10 +6,6 @@ use Laravel\Jetstream\Http\Livewire\ApiTokenManager;
 use Livewire\Livewire;
 
 test('api tokens can be created', function () {
-    if (! Features::hasApiFeatures()) {
-        return $this->markTestSkipped('API support is not enabled.');
-    }
-
     if (Features::hasTeamFeatures()) {
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
     } else {
@@ -30,4 +26,6 @@ test('api tokens can be created', function () {
     expect($user->fresh()->tokens->first()->name)->toEqual('Test Token');
     expect($user->fresh()->tokens->first()->can('read'))->toBeTrue();
     expect($user->fresh()->tokens->first()->can('delete'))->toBeFalse();
-});
+})->skip(function() {
+    return ! Features::hasApiFeatures();
+}, 'API support is not enabled.');

--- a/stubs/pest-tests/livewire/CreateApiTokenTest.php
+++ b/stubs/pest-tests/livewire/CreateApiTokenTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use App\Models\User;
+use Laravel\Jetstream\Features;
+use Laravel\Jetstream\Http\Livewire\ApiTokenManager;
+use Livewire\Livewire;
+
+test('api tokens can be created', function () {
+    if (! Features::hasApiFeatures()) {
+        return $this->markTestSkipped('API support is not enabled.');
+    }
+
+    if (Features::hasTeamFeatures()) {
+        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+    } else {
+        $this->actingAs($user = User::factory()->create());
+    }
+
+    Livewire::test(ApiTokenManager::class)
+                ->set(['createApiTokenForm' => [
+                    'name' => 'Test Token',
+                    'permissions' => [
+                        'read',
+                        'update',
+                    ],
+                ]])
+                ->call('createApiToken');
+
+    $this->assertCount(1, $user->fresh()->tokens);
+    $this->assertEquals('Test Token', $user->fresh()->tokens->first()->name);
+    $this->assertTrue($user->fresh()->tokens->first()->can('read'));
+    $this->assertFalse($user->fresh()->tokens->first()->can('delete'));
+});

--- a/stubs/pest-tests/livewire/CreateApiTokenTest.php
+++ b/stubs/pest-tests/livewire/CreateApiTokenTest.php
@@ -27,6 +27,6 @@ test('api tokens can be created', function () {
         ->name->toEqual('Test Token')
         ->can('read')->toBeTrue()
         ->can('delete')->toBeFalse();
-})->skip(function() {
+})->skip(function () {
     return ! Features::hasApiFeatures();
 }, 'API support is not enabled.');

--- a/stubs/pest-tests/livewire/CreateApiTokenTest.php
+++ b/stubs/pest-tests/livewire/CreateApiTokenTest.php
@@ -23,9 +23,10 @@ test('api tokens can be created', function () {
                 ->call('createApiToken');
 
     expect($user->fresh()->tokens)->toHaveCount(1);
-    expect($user->fresh()->tokens->first()->name)->toEqual('Test Token');
-    expect($user->fresh()->tokens->first()->can('read'))->toBeTrue();
-    expect($user->fresh()->tokens->first()->can('delete'))->toBeFalse();
+    expect($user->fresh()->tokens->first())
+        ->name->toEqual('Test Token')
+        ->can('read')->toBeTrue()
+        ->can('delete')->toBeFalse();
 })->skip(function() {
     return ! Features::hasApiFeatures();
 }, 'API support is not enabled.');

--- a/stubs/pest-tests/livewire/CreateTeamTest.php
+++ b/stubs/pest-tests/livewire/CreateTeamTest.php
@@ -12,6 +12,6 @@ test('teams can be created', function ()
                 ->set(['state' => ['name' => 'Test Team']])
                 ->call('createTeam');
 
-    $this->assertCount(2, $user->fresh()->ownedTeams);
-    $this->assertEquals('Test Team', $user->fresh()->ownedTeams()->latest('id')->first()->name);
+    expect($user->fresh()->ownedTeams)->toHaveCount(2);
+    expect($user->fresh()->ownedTeams()->latest('id')->first()->name)->toEqual('Test Team');
 });

--- a/stubs/pest-tests/livewire/CreateTeamTest.php
+++ b/stubs/pest-tests/livewire/CreateTeamTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use App\Models\User;
+use Laravel\Jetstream\Http\Livewire\CreateTeamForm;
+use Livewire\Livewire;
+
+test('teams can be created', function ()
+{
+    $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+
+    Livewire::test(CreateTeamForm::class)
+                ->set(['state' => ['name' => 'Test Team']])
+                ->call('createTeam');
+
+    $this->assertCount(2, $user->fresh()->ownedTeams);
+    $this->assertEquals('Test Team', $user->fresh()->ownedTeams()->latest('id')->first()->name);
+});

--- a/stubs/pest-tests/livewire/CreateTeamTest.php
+++ b/stubs/pest-tests/livewire/CreateTeamTest.php
@@ -4,8 +4,7 @@ use App\Models\User;
 use Laravel\Jetstream\Http\Livewire\CreateTeamForm;
 use Livewire\Livewire;
 
-test('teams can be created', function ()
-{
+test('teams can be created', function () {
     $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
     Livewire::test(CreateTeamForm::class)

--- a/stubs/pest-tests/livewire/DeleteAccountTest.php
+++ b/stubs/pest-tests/livewire/DeleteAccountTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use App\Models\User;
+use Laravel\Jetstream\Features;
+use Laravel\Jetstream\Http\Livewire\DeleteUserForm;
+use Livewire\Livewire;
+
+test('user_accounts_can_be_deleted', function () {
+    if (! Features::hasAccountDeletionFeatures()) {
+        return $this->markTestSkipped('Account deletion is not enabled.');
+    }
+
+    $this->actingAs($user = User::factory()->create());
+
+    $component = Livewire::test(DeleteUserForm::class)
+                    ->set('password', 'password')
+                    ->call('deleteUser');
+
+    $this->assertNull($user->fresh());
+});
+
+test('correct_password_must_be_provided_before_account_can_be_deleted', function () {
+    if (! Features::hasAccountDeletionFeatures()) {
+        return $this->markTestSkipped('Account deletion is not enabled.');
+    }
+
+    $this->actingAs($user = User::factory()->create());
+
+    Livewire::test(DeleteUserForm::class)
+                    ->set('password', 'wrong-password')
+                    ->call('deleteUser')
+                    ->assertHasErrors(['password']);
+
+    $this->assertNotNull($user->fresh());
+});

--- a/stubs/pest-tests/livewire/DeleteAccountTest.php
+++ b/stubs/pest-tests/livewire/DeleteAccountTest.php
@@ -6,10 +6,6 @@ use Laravel\Jetstream\Http\Livewire\DeleteUserForm;
 use Livewire\Livewire;
 
 test('user accounts can be deleted', function () {
-    if (! Features::hasAccountDeletionFeatures()) {
-        return $this->markTestSkipped('Account deletion is not enabled.');
-    }
-
     $this->actingAs($user = User::factory()->create());
 
     $component = Livewire::test(DeleteUserForm::class)
@@ -17,13 +13,11 @@ test('user accounts can be deleted', function () {
                     ->call('deleteUser');
 
     expect($user->fresh())->toBeNull();
-});
+})->skip(function() {
+    return ! Features::hasAccountDeletionFeatures();
+}, 'Account deletion is not enabled.');
 
 test('correct_password_must_be_provided_before_account_can_be_deleted', function () {
-    if (! Features::hasAccountDeletionFeatures()) {
-        return $this->markTestSkipped('Account deletion is not enabled.');
-    }
-
     $this->actingAs($user = User::factory()->create());
 
     Livewire::test(DeleteUserForm::class)
@@ -32,4 +26,6 @@ test('correct_password_must_be_provided_before_account_can_be_deleted', function
                     ->assertHasErrors(['password']);
 
     expect($user->fresh())->not->toBeNull();
-});
+})->skip(function() {
+    return ! Features::hasAccountDeletionFeatures();
+}, 'Account deletion is not enabled.');

--- a/stubs/pest-tests/livewire/DeleteAccountTest.php
+++ b/stubs/pest-tests/livewire/DeleteAccountTest.php
@@ -13,7 +13,7 @@ test('user accounts can be deleted', function () {
                     ->call('deleteUser');
 
     expect($user->fresh())->toBeNull();
-})->skip(function() {
+})->skip(function () {
     return ! Features::hasAccountDeletionFeatures();
 }, 'Account deletion is not enabled.');
 
@@ -26,6 +26,6 @@ test('correct_password_must_be_provided_before_account_can_be_deleted', function
                     ->assertHasErrors(['password']);
 
     expect($user->fresh())->not->toBeNull();
-})->skip(function() {
+})->skip(function () {
     return ! Features::hasAccountDeletionFeatures();
 }, 'Account deletion is not enabled.');

--- a/stubs/pest-tests/livewire/DeleteAccountTest.php
+++ b/stubs/pest-tests/livewire/DeleteAccountTest.php
@@ -5,7 +5,7 @@ use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Http\Livewire\DeleteUserForm;
 use Livewire\Livewire;
 
-test('user_accounts_can_be_deleted', function () {
+test('user accounts can be deleted', function () {
     if (! Features::hasAccountDeletionFeatures()) {
         return $this->markTestSkipped('Account deletion is not enabled.');
     }

--- a/stubs/pest-tests/livewire/DeleteAccountTest.php
+++ b/stubs/pest-tests/livewire/DeleteAccountTest.php
@@ -16,7 +16,7 @@ test('user accounts can be deleted', function () {
                     ->set('password', 'password')
                     ->call('deleteUser');
 
-    $this->assertNull($user->fresh());
+    expect($user->fresh())->toBeNull();
 });
 
 test('correct_password_must_be_provided_before_account_can_be_deleted', function () {
@@ -31,5 +31,5 @@ test('correct_password_must_be_provided_before_account_can_be_deleted', function
                     ->call('deleteUser')
                     ->assertHasErrors(['password']);
 
-    $this->assertNotNull($user->fresh());
+    expect($user->fresh())->not->toBeNull();
 });

--- a/stubs/pest-tests/livewire/DeleteAccountTest.php
+++ b/stubs/pest-tests/livewire/DeleteAccountTest.php
@@ -17,7 +17,7 @@ test('user accounts can be deleted', function () {
     return ! Features::hasAccountDeletionFeatures();
 }, 'Account deletion is not enabled.');
 
-test('correct_password_must_be_provided_before_account_can_be_deleted', function () {
+test('correct password must be provided before account can be deleted', function () {
     $this->actingAs($user = User::factory()->create());
 
     Livewire::test(DeleteUserForm::class)

--- a/stubs/pest-tests/livewire/DeleteApiTokenTest.php
+++ b/stubs/pest-tests/livewire/DeleteApiTokenTest.php
@@ -28,5 +28,5 @@ test('api tokens can be deleted', function ()
                 ->set(['apiTokenIdBeingDeleted' => $token->id])
                 ->call('deleteApiToken');
 
-    $this->assertCount(0, $user->fresh()->tokens);
+    expect($user->fresh()->tokens)->toHaveCount(0);
 });

--- a/stubs/pest-tests/livewire/DeleteApiTokenTest.php
+++ b/stubs/pest-tests/livewire/DeleteApiTokenTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Support\Str;
+use Laravel\Jetstream\Features;
+use Laravel\Jetstream\Http\Livewire\ApiTokenManager;
+use Livewire\Livewire;
+
+test('api tokens can be deleted', function ()
+{
+    if (! Features::hasApiFeatures()) {
+        return $this->markTestSkipped('API support is not enabled.');
+    }
+
+    if (Features::hasTeamFeatures()) {
+        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+    } else {
+        $this->actingAs($user = User::factory()->create());
+    }
+
+    $token = $user->tokens()->create([
+        'name' => 'Test Token',
+        'token' => Str::random(40),
+        'abilities' => ['create', 'read'],
+    ]);
+
+    Livewire::test(ApiTokenManager::class)
+                ->set(['apiTokenIdBeingDeleted' => $token->id])
+                ->call('deleteApiToken');
+
+    $this->assertCount(0, $user->fresh()->tokens);
+});

--- a/stubs/pest-tests/livewire/DeleteApiTokenTest.php
+++ b/stubs/pest-tests/livewire/DeleteApiTokenTest.php
@@ -8,10 +8,6 @@ use Livewire\Livewire;
 
 test('api tokens can be deleted', function ()
 {
-    if (! Features::hasApiFeatures()) {
-        return $this->markTestSkipped('API support is not enabled.');
-    }
-
     if (Features::hasTeamFeatures()) {
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
     } else {
@@ -29,4 +25,6 @@ test('api tokens can be deleted', function ()
                 ->call('deleteApiToken');
 
     expect($user->fresh()->tokens)->toHaveCount(0);
-});
+})->skip(function() {
+    return ! Features::hasApiFeatures();
+}, 'API support is not enabled.');

--- a/stubs/pest-tests/livewire/DeleteApiTokenTest.php
+++ b/stubs/pest-tests/livewire/DeleteApiTokenTest.php
@@ -6,8 +6,7 @@ use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Http\Livewire\ApiTokenManager;
 use Livewire\Livewire;
 
-test('api tokens can be deleted', function ()
-{
+test('api tokens can be deleted', function () {
     if (Features::hasTeamFeatures()) {
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
     } else {

--- a/stubs/pest-tests/livewire/DeleteApiTokenTest.php
+++ b/stubs/pest-tests/livewire/DeleteApiTokenTest.php
@@ -25,6 +25,6 @@ test('api tokens can be deleted', function ()
                 ->call('deleteApiToken');
 
     expect($user->fresh()->tokens)->toHaveCount(0);
-})->skip(function() {
+})->skip(function () {
     return ! Features::hasApiFeatures();
 }, 'API support is not enabled.');

--- a/stubs/pest-tests/livewire/DeleteTeamTest.php
+++ b/stubs/pest-tests/livewire/DeleteTeamTest.php
@@ -19,8 +19,8 @@ test('teams can be deleted', function () {
     $component = Livewire::test(DeleteTeamForm::class, ['team' => $team->fresh()])
                             ->call('deleteTeam');
 
-    $this->assertNull($team->fresh());
-    $this->assertCount(0, $otherUser->fresh()->teams);
+    expect($team->fresh())->toBeNull();
+    expect($otherUser->fresh()->teams)->toHaveCount(0);
 });
 
 test('personal teams cant be deleted', function () {
@@ -30,5 +30,5 @@ test('personal teams cant be deleted', function () {
                             ->call('deleteTeam')
                             ->assertHasErrors(['team']);
 
-    $this->assertNotNull($user->currentTeam->fresh());
+    expect($user->currentTeam->fresh())->not->toBeNull();
 });

--- a/stubs/pest-tests/livewire/DeleteTeamTest.php
+++ b/stubs/pest-tests/livewire/DeleteTeamTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use App\Models\Team;
+use App\Models\User;
+use Laravel\Jetstream\Http\Livewire\DeleteTeamForm;
+use Livewire\Livewire;
+
+test('teams can be deleted', function () {
+    $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+
+    $user->ownedTeams()->save($team = Team::factory()->make([
+        'personal_team' => false,
+    ]));
+
+    $team->users()->attach(
+        $otherUser = User::factory()->create(), ['role' => 'test-role']
+    );
+
+    $component = Livewire::test(DeleteTeamForm::class, ['team' => $team->fresh()])
+                            ->call('deleteTeam');
+
+    $this->assertNull($team->fresh());
+    $this->assertCount(0, $otherUser->fresh()->teams);
+});
+
+test('personal teams cant be deleted', function () {
+    $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+
+    $component = Livewire::test(DeleteTeamForm::class, ['team' => $user->currentTeam])
+                            ->call('deleteTeam')
+                            ->assertHasErrors(['team']);
+
+    $this->assertNotNull($user->currentTeam->fresh());
+});

--- a/stubs/pest-tests/livewire/InviteTeamMemberTest.php
+++ b/stubs/pest-tests/livewire/InviteTeamMemberTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Support\Facades\Mail;
+use Laravel\Jetstream\Http\Livewire\TeamMemberManager;
+use Laravel\Jetstream\Mail\TeamInvitation;
+use Livewire\Livewire;
+
+test('team members can be invited to team', function () {
+    Mail::fake();
+
+    $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+
+    $component = Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])
+                    ->set('addTeamMemberForm', [
+                        'email' => 'test@example.com',
+                        'role' => 'admin',
+                    ])->call('addTeamMember');
+
+    Mail::assertSent(TeamInvitation::class);
+
+    $this->assertCount(1, $user->currentTeam->fresh()->teamInvitations);
+});
+
+test('team member invitations can be cancelled', function () {
+    $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+
+    // Add the team member...
+    $component = Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])
+                    ->set('addTeamMemberForm', [
+                        'email' => 'test@example.com',
+                        'role' => 'admin',
+                    ])->call('addTeamMember');
+
+    $invitationId = $user->currentTeam->fresh()->teamInvitations->first()->id;
+
+    // Cancel the team invitation...
+    $component->call('cancelTeamInvitation', $invitationId);
+
+    $this->assertCount(0, $user->currentTeam->fresh()->teamInvitations);
+});

--- a/stubs/pest-tests/livewire/InviteTeamMemberTest.php
+++ b/stubs/pest-tests/livewire/InviteTeamMemberTest.php
@@ -19,7 +19,7 @@ test('team members can be invited to team', function () {
 
     Mail::assertSent(TeamInvitation::class);
 
-    $this->assertCount(1, $user->currentTeam->fresh()->teamInvitations);
+    expect($user->currentTeam->fresh()->teamInvitations)->toHaveCount(1);
 });
 
 test('team member invitations can be cancelled', function () {
@@ -37,5 +37,5 @@ test('team member invitations can be cancelled', function () {
     // Cancel the team invitation...
     $component->call('cancelTeamInvitation', $invitationId);
 
-    $this->assertCount(0, $user->currentTeam->fresh()->teamInvitations);
+    expect($user->currentTeam->fresh()->teamInvitations)->toHaveCount(0);
 });

--- a/stubs/pest-tests/livewire/LeaveTeamTest.php
+++ b/stubs/pest-tests/livewire/LeaveTeamTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use App\Models\User;
+use Laravel\Jetstream\Http\Livewire\TeamMemberManager;
+use Livewire\Livewire;
+
+test('users_can_leave_teams', function () {
+    $user = User::factory()->withPersonalTeam()->create();
+
+    $user->currentTeam->users()->attach(
+        $otherUser = User::factory()->create(), ['role' => 'admin']
+    );
+
+    $this->actingAs($otherUser);
+
+    $component = Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])
+                    ->call('leaveTeam');
+
+    $this->assertCount(0, $user->currentTeam->fresh()->users);
+});
+
+test('team_owners_cant_leave_their_own_team', function () {
+    $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+
+    $component = Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])
+                    ->call('leaveTeam')
+                    ->assertHasErrors(['team']);
+
+    $this->assertNotNull($user->currentTeam->fresh());
+});

--- a/stubs/pest-tests/livewire/LeaveTeamTest.php
+++ b/stubs/pest-tests/livewire/LeaveTeamTest.php
@@ -16,7 +16,7 @@ test('users can leave teams', function () {
     $component = Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])
                     ->call('leaveTeam');
 
-    $this->assertCount(0, $user->currentTeam->fresh()->users);
+    expect($user->currentTeam->fresh()->users)->toHaveCount(0);
 });
 
 test('team owners cant leave their own team', function () {
@@ -26,5 +26,5 @@ test('team owners cant leave their own team', function () {
                     ->call('leaveTeam')
                     ->assertHasErrors(['team']);
 
-    $this->assertNotNull($user->currentTeam->fresh());
+    expect($user->currentTeam->fresh())->not->toBeNull();
 });

--- a/stubs/pest-tests/livewire/LeaveTeamTest.php
+++ b/stubs/pest-tests/livewire/LeaveTeamTest.php
@@ -4,7 +4,7 @@ use App\Models\User;
 use Laravel\Jetstream\Http\Livewire\TeamMemberManager;
 use Livewire\Livewire;
 
-test('users_can_leave_teams', function () {
+test('users can leave teams', function () {
     $user = User::factory()->withPersonalTeam()->create();
 
     $user->currentTeam->users()->attach(
@@ -19,7 +19,7 @@ test('users_can_leave_teams', function () {
     $this->assertCount(0, $user->currentTeam->fresh()->users);
 });
 
-test('team_owners_cant_leave_their_own_team', function () {
+test('team owners cant leave their own team', function () {
     $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
     $component = Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])

--- a/stubs/pest-tests/livewire/ProfileInformationTest.php
+++ b/stubs/pest-tests/livewire/ProfileInformationTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use App\Models\User;
+use Laravel\Jetstream\Http\Livewire\UpdateProfileInformationForm;
+use Livewire\Livewire;
+
+test('current profile information is available', function () {
+    $this->actingAs($user = User::factory()->create());
+
+    $component = Livewire::test(UpdateProfileInformationForm::class);
+
+    $this->assertEquals($user->name, $component->state['name']);
+    $this->assertEquals($user->email, $component->state['email']);
+});
+
+test('profile information can be updated', function () {
+    $this->actingAs($user = User::factory()->create());
+
+    Livewire::test(UpdateProfileInformationForm::class)
+            ->set('state', ['name' => 'Test Name', 'email' => 'test@example.com'])
+            ->call('updateProfileInformation');
+
+    $this->assertEquals('Test Name', $user->fresh()->name);
+    $this->assertEquals('test@example.com', $user->fresh()->email);
+});

--- a/stubs/pest-tests/livewire/ProfileInformationTest.php
+++ b/stubs/pest-tests/livewire/ProfileInformationTest.php
@@ -9,8 +9,8 @@ test('current profile information is available', function () {
 
     $component = Livewire::test(UpdateProfileInformationForm::class);
 
-    $this->assertEquals($user->name, $component->state['name']);
-    $this->assertEquals($user->email, $component->state['email']);
+    expect($component->state['name'])->toEqual($user->name);
+    expect($component->state['email'])->toEqual($user->email);
 });
 
 test('profile information can be updated', function () {
@@ -20,6 +20,6 @@ test('profile information can be updated', function () {
             ->set('state', ['name' => 'Test Name', 'email' => 'test@example.com'])
             ->call('updateProfileInformation');
 
-    $this->assertEquals('Test Name', $user->fresh()->name);
-    $this->assertEquals('test@example.com', $user->fresh()->email);
+    expect($user->fresh()->name)->toEqual('Test Name');
+    expect($user->fresh()->email)->toEqual('test@example.com');
 });

--- a/stubs/pest-tests/livewire/ProfileInformationTest.php
+++ b/stubs/pest-tests/livewire/ProfileInformationTest.php
@@ -20,6 +20,7 @@ test('profile information can be updated', function () {
             ->set('state', ['name' => 'Test Name', 'email' => 'test@example.com'])
             ->call('updateProfileInformation');
 
-    expect($user->fresh()->name)->toEqual('Test Name');
-    expect($user->fresh()->email)->toEqual('test@example.com');
+    expect($user->fresh())
+        ->name->toEqual('Test Name')
+        ->email->toEqual('test@example.com');
 });

--- a/stubs/pest-tests/livewire/RemoveTeamMemberTest.php
+++ b/stubs/pest-tests/livewire/RemoveTeamMemberTest.php
@@ -15,7 +15,7 @@ test('team members can be removed from teams', function () {
                     ->set('teamMemberIdBeingRemoved', $otherUser->id)
                     ->call('removeTeamMember');
 
-    $this->assertCount(0, $user->currentTeam->fresh()->users);
+    expect($user->currentTeam->fresh()->users)->toHaveCount(0);
 });
 
 test('only team owner can remove team members', function () {

--- a/stubs/pest-tests/livewire/RemoveTeamMemberTest.php
+++ b/stubs/pest-tests/livewire/RemoveTeamMemberTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use App\Models\User;
+use Laravel\Jetstream\Http\Livewire\TeamMemberManager;
+use Livewire\Livewire;
+
+test('team members can be removed from teams', function () {
+    $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+
+    $user->currentTeam->users()->attach(
+        $otherUser = User::factory()->create(), ['role' => 'admin']
+    );
+
+    $component = Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])
+                    ->set('teamMemberIdBeingRemoved', $otherUser->id)
+                    ->call('removeTeamMember');
+
+    $this->assertCount(0, $user->currentTeam->fresh()->users);
+});
+
+test('only team owner can remove team members', function () {
+    $user = User::factory()->withPersonalTeam()->create();
+
+    $user->currentTeam->users()->attach(
+        $otherUser = User::factory()->create(), ['role' => 'admin']
+    );
+
+    $this->actingAs($otherUser);
+
+    $component = Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])
+                    ->set('teamMemberIdBeingRemoved', $user->id)
+                    ->call('removeTeamMember')
+                    ->assertStatus(403);
+});

--- a/stubs/pest-tests/livewire/TwoFactorAuthenticationSettingsTest.php
+++ b/stubs/pest-tests/livewire/TwoFactorAuthenticationSettingsTest.php
@@ -31,8 +31,8 @@ test('recovery codes can be regenerated', function () {
 
     $component->call('regenerateRecoveryCodes');
 
-    expect(8, $user->recoveryCodes())->toHaveCount(8);
-    expect(8, array_diff($user->recoveryCodes(), $user->fresh()->recoveryCodes()))->toHaveCount(8);
+    expect($user->recoveryCodes())->toHaveCount(8);
+    expect(array_diff($user->recoveryCodes(), $user->fresh()->recoveryCodes()))->toHaveCount(8);
 });
 
 test('two factor authentication can be disabled', function () {

--- a/stubs/pest-tests/livewire/TwoFactorAuthenticationSettingsTest.php
+++ b/stubs/pest-tests/livewire/TwoFactorAuthenticationSettingsTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use App\Models\User;
+use Laravel\Jetstream\Http\Livewire\TwoFactorAuthenticationForm;
+use Livewire\Livewire;
+
+test('two factor authentication can be enabled', function () {
+    $this->actingAs($user = User::factory()->create());
+
+    $this->withSession(['auth.password_confirmed_at' => time()]);
+
+    Livewire::test(TwoFactorAuthenticationForm::class)
+            ->call('enableTwoFactorAuthentication');
+
+    $user = $user->fresh();
+
+    $this->assertNotNull($user->two_factor_secret);
+    $this->assertCount(8, $user->recoveryCodes());
+});
+
+test('recovery codes can be regenerated', function () {
+    $this->actingAs($user = User::factory()->create());
+
+    $this->withSession(['auth.password_confirmed_at' => time()]);
+
+    $component = Livewire::test(TwoFactorAuthenticationForm::class)
+            ->call('enableTwoFactorAuthentication')
+            ->call('regenerateRecoveryCodes');
+
+    $user = $user->fresh();
+
+    $component->call('regenerateRecoveryCodes');
+
+    $this->assertCount(8, $user->recoveryCodes());
+    $this->assertCount(8, array_diff($user->recoveryCodes(), $user->fresh()->recoveryCodes()));
+});
+
+test('two factor authentication can be disabled', function () {
+    $this->actingAs($user = User::factory()->create());
+
+    $this->withSession(['auth.password_confirmed_at' => time()]);
+
+    $component = Livewire::test(TwoFactorAuthenticationForm::class)
+            ->call('enableTwoFactorAuthentication');
+
+    $this->assertNotNull($user->fresh()->two_factor_secret);
+
+    $component->call('disableTwoFactorAuthentication');
+
+    $this->assertNull($user->fresh()->two_factor_secret);
+});

--- a/stubs/pest-tests/livewire/TwoFactorAuthenticationSettingsTest.php
+++ b/stubs/pest-tests/livewire/TwoFactorAuthenticationSettingsTest.php
@@ -14,8 +14,8 @@ test('two factor authentication can be enabled', function () {
 
     $user = $user->fresh();
 
-    $this->assertNotNull($user->two_factor_secret);
-    $this->assertCount(8, $user->recoveryCodes());
+    expect($user->two_factor_secret)->not->toBeNull();
+    expect($user->recoveryCodes())->toHaveCount(8);
 });
 
 test('recovery codes can be regenerated', function () {
@@ -31,8 +31,8 @@ test('recovery codes can be regenerated', function () {
 
     $component->call('regenerateRecoveryCodes');
 
-    $this->assertCount(8, $user->recoveryCodes());
-    $this->assertCount(8, array_diff($user->recoveryCodes(), $user->fresh()->recoveryCodes()));
+    expect(8, $user->recoveryCodes())->toHaveCount(8);
+    expect(8, array_diff($user->recoveryCodes(), $user->fresh()->recoveryCodes()))->toHaveCount(8);
 });
 
 test('two factor authentication can be disabled', function () {
@@ -47,5 +47,5 @@ test('two factor authentication can be disabled', function () {
 
     $component->call('disableTwoFactorAuthentication');
 
-    $this->assertNull($user->fresh()->two_factor_secret);
+    expect($user->fresh()->two_factor_secret)->toBeNull();
 });

--- a/stubs/pest-tests/livewire/UpdatePasswordTest.php
+++ b/stubs/pest-tests/livewire/UpdatePasswordTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Jetstream\Http\Livewire\UpdatePasswordForm;
+use Livewire\Livewire;
+
+test('password can be updated', function () {
+    $this->actingAs($user = User::factory()->create());
+
+    Livewire::test(UpdatePasswordForm::class)
+            ->set('state', [
+                'current_password' => 'password',
+                'password' => 'new-password',
+                'password_confirmation' => 'new-password',
+            ])
+            ->call('updatePassword');
+
+    $this->assertTrue(Hash::check('new-password', $user->fresh()->password));
+});
+
+test('current password must be correct', function () {
+    $this->actingAs($user = User::factory()->create());
+
+    Livewire::test(UpdatePasswordForm::class)
+            ->set('state', [
+                'current_password' => 'wrong-password',
+                'password' => 'new-password',
+                'password_confirmation' => 'new-password',
+            ])
+            ->call('updatePassword')
+            ->assertHasErrors(['current_password']);
+
+    $this->assertTrue(Hash::check('password', $user->fresh()->password));
+});
+
+test('new passwords must match', function () {
+    $this->actingAs($user = User::factory()->create());
+
+    Livewire::test(UpdatePasswordForm::class)
+            ->set('state', [
+                'current_password' => 'password',
+                'password' => 'new-password',
+                'password_confirmation' => 'wrong-password',
+            ])
+            ->call('updatePassword')
+            ->assertHasErrors(['password']);
+
+    $this->assertTrue(Hash::check('password', $user->fresh()->password));
+});

--- a/stubs/pest-tests/livewire/UpdatePasswordTest.php
+++ b/stubs/pest-tests/livewire/UpdatePasswordTest.php
@@ -16,7 +16,7 @@ test('password can be updated', function () {
             ])
             ->call('updatePassword');
 
-    $this->assertTrue(Hash::check('new-password', $user->fresh()->password));
+    expect(Hash::check('new-password', $user->fresh()->password))->toBeTrue();
 });
 
 test('current password must be correct', function () {
@@ -31,7 +31,7 @@ test('current password must be correct', function () {
             ->call('updatePassword')
             ->assertHasErrors(['current_password']);
 
-    $this->assertTrue(Hash::check('password', $user->fresh()->password));
+    expect(Hash::check('password', $user->fresh()->password))->toBeTrue();
 });
 
 test('new passwords must match', function () {
@@ -46,5 +46,5 @@ test('new passwords must match', function () {
             ->call('updatePassword')
             ->assertHasErrors(['password']);
 
-    $this->assertTrue(Hash::check('password', $user->fresh()->password));
+    expect(Hash::check('password', $user->fresh()->password))->toBeTrue();
 });

--- a/stubs/pest-tests/livewire/UpdateTeamMemberRoleTest.php
+++ b/stubs/pest-tests/livewire/UpdateTeamMemberRoleTest.php
@@ -16,9 +16,9 @@ test('team member roles can be updated', function () {
                     ->set('currentRole', 'editor')
                     ->call('updateRole');
 
-    $this->assertTrue($otherUser->fresh()->hasTeamRole(
+    expect($otherUser->fresh()->hasTeamRole(
         $user->currentTeam->fresh(), 'editor'
-    ));
+    ))->toBeTrue();
 });
 
 test('only team owner can update team member roles', function () {
@@ -36,7 +36,7 @@ test('only team owner can update team member roles', function () {
                     ->call('updateRole')
                     ->assertStatus(403);
 
-    $this->assertTrue($otherUser->fresh()->hasTeamRole(
+    expect($otherUser->fresh()->hasTeamRole(
         $user->currentTeam->fresh(), 'admin'
-    ));
+    ))->toBeTrue();
 });

--- a/stubs/pest-tests/livewire/UpdateTeamMemberRoleTest.php
+++ b/stubs/pest-tests/livewire/UpdateTeamMemberRoleTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use App\Models\User;
+use Laravel\Jetstream\Http\Livewire\TeamMemberManager;
+use Livewire\Livewire;
+
+test('team member roles can be updated', function () {
+    $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+
+    $user->currentTeam->users()->attach(
+        $otherUser = User::factory()->create(), ['role' => 'admin']
+    );
+
+    $component = Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])
+                    ->set('managingRoleFor', $otherUser)
+                    ->set('currentRole', 'editor')
+                    ->call('updateRole');
+
+    $this->assertTrue($otherUser->fresh()->hasTeamRole(
+        $user->currentTeam->fresh(), 'editor'
+    ));
+});
+
+test('only team owner can update team member roles', function () {
+    $user = User::factory()->withPersonalTeam()->create();
+
+    $user->currentTeam->users()->attach(
+        $otherUser = User::factory()->create(), ['role' => 'admin']
+    );
+
+    $this->actingAs($otherUser);
+
+    $component = Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])
+                    ->set('managingRoleFor', $otherUser)
+                    ->set('currentRole', 'editor')
+                    ->call('updateRole')
+                    ->assertStatus(403);
+
+    $this->assertTrue($otherUser->fresh()->hasTeamRole(
+        $user->currentTeam->fresh(), 'admin'
+    ));
+});

--- a/stubs/pest-tests/livewire/UpdateTeamNameTest.php
+++ b/stubs/pest-tests/livewire/UpdateTeamNameTest.php
@@ -1,0 +1,16 @@
+<?php
+
+use App\Models\User;
+use Laravel\Jetstream\Http\Livewire\UpdateTeamNameForm;
+use Livewire\Livewire;
+
+test('team names can be updated', function () {
+    $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+
+    Livewire::test(UpdateTeamNameForm::class, ['team' => $user->currentTeam])
+                ->set(['state' => ['name' => 'Test Team']])
+                ->call('updateTeamName');
+
+    $this->assertCount(1, $user->fresh()->ownedTeams);
+    $this->assertEquals('Test Team', $user->currentTeam->fresh()->name);
+});

--- a/stubs/pest-tests/livewire/UpdateTeamNameTest.php
+++ b/stubs/pest-tests/livewire/UpdateTeamNameTest.php
@@ -11,6 +11,6 @@ test('team names can be updated', function () {
                 ->set(['state' => ['name' => 'Test Team']])
                 ->call('updateTeamName');
 
-    $this->assertCount(1, $user->fresh()->ownedTeams);
-    $this->assertEquals('Test Team', $user->currentTeam->fresh()->name);
+    expect($user->fresh()->ownedTeams)->toHaveCount(1);
+    expect($user->currentTeam->fresh()->name)->toEqual('Test Team');
 });


### PR DESCRIPTION
Howdy all!

This pull request adds the `--pest` option to Jetstream

When passing the `--pest` option on the command `php artisan jetstream:install --pest`, the Pest framework will be used in favour of PHPUnit.

Kind Regards,
Luke