### PR TITLE
[2.x] Use defineComponent in vue stubs for easier typescript setup

### DIFF
--- a/stubs/inertia/resources/js/Jetstream/ActionMessage.vue
+++ b/stubs/inertia/resources/js/Jetstream/ActionMessage.vue
@@ -9,7 +9,9 @@
 </template>
 
 <script>
-    export default {
+    import { defineComponent } from 'vue'
+
+    export default defineComponent({
         props: ['on'],
-    }
+    })
 </script>

--- a/stubs/inertia/resources/js/Jetstream/ActionSection.vue
+++ b/stubs/inertia/resources/js/Jetstream/ActionSection.vue
@@ -14,11 +14,12 @@
 </template>
 
 <script>
+    import { defineComponent } from 'vue'
     import JetSectionTitle from './SectionTitle.vue'
 
-    export default {
+    export default defineComponent({
         components: {
             JetSectionTitle,
         }
-    }
+    })
 </script>

--- a/stubs/inertia/resources/js/Jetstream/AuthenticationCardLogo.vue
+++ b/stubs/inertia/resources/js/Jetstream/AuthenticationCardLogo.vue
@@ -8,11 +8,12 @@
 </template>
 
 <script>
+    import { defineComponent } from 'vue'
     import { Link } from '@inertiajs/inertia-vue3';
 
-    export default {
+    export default defineComponent({
         components: {
             Link,
         },
-    }
+    })
 </script>

--- a/stubs/inertia/resources/js/Jetstream/Banner.vue
+++ b/stubs/inertia/resources/js/Jetstream/Banner.vue
@@ -38,7 +38,9 @@
 </template>
 
 <script>
-    export default {
+    import { defineComponent } from 'vue'
+
+    export default defineComponent({
         data() {
             return {
                 show: true,
@@ -54,5 +56,5 @@
                 return this.$page.props.jetstream.flash?.banner || ''
             },
         }
-    }
+    })
 </script>

--- a/stubs/inertia/resources/js/Jetstream/Button.vue
+++ b/stubs/inertia/resources/js/Jetstream/Button.vue
@@ -5,12 +5,14 @@
 </template>
 
 <script>
-    export default {
+    import { defineComponent } from 'vue'
+
+    export default defineComponent({
         props: {
             type: {
                 type: String,
                 default: 'submit',
             },
         }
-    }
+    })
 </script>

--- a/stubs/inertia/resources/js/Jetstream/Checkbox.vue
+++ b/stubs/inertia/resources/js/Jetstream/Checkbox.vue
@@ -4,7 +4,9 @@
 </template>
 
 <script>
-export default {
+import { defineComponent } from 'vue'
+
+export default defineComponent({
     emits: ['update:checked'],
 
     props: {
@@ -28,5 +30,5 @@ export default {
             },
         },
     },
-}
+})
 </script>

--- a/stubs/inertia/resources/js/Jetstream/ConfirmationModal.vue
+++ b/stubs/inertia/resources/js/Jetstream/ConfirmationModal.vue
@@ -28,9 +28,10 @@
 </template>
 
 <script>
+    import { defineComponent } from 'vue'
     import Modal from './Modal.vue'
 
-    export default {
+    export default defineComponent({
         emits: ['close'],
 
         components: {
@@ -54,5 +55,5 @@
                 this.$emit('close')
             },
         }
-    }
+    })
 </script>

--- a/stubs/inertia/resources/js/Jetstream/ConfirmsPassword.vue
+++ b/stubs/inertia/resources/js/Jetstream/ConfirmsPassword.vue
@@ -36,13 +36,14 @@
 </template>
 
 <script>
+    import { defineComponent } from 'vue'
     import JetButton from './Button.vue'
     import JetDialogModal from './DialogModal.vue'
     import JetInput from './Input.vue'
     import JetInputError from './InputError.vue'
     import JetSecondaryButton from './SecondaryButton.vue'
 
-    export default {
+    export default defineComponent({
         emits: ['confirmed'],
 
         props: {
@@ -110,5 +111,5 @@
                 this.form.error = '';
             },
         }
-    }
+    })
 </script>

--- a/stubs/inertia/resources/js/Jetstream/DangerButton.vue
+++ b/stubs/inertia/resources/js/Jetstream/DangerButton.vue
@@ -5,12 +5,14 @@
 </template>
 
 <script>
-    export default {
+    import { defineComponent } from 'vue'
+
+    export default defineComponent({
         props: {
             type: {
                 type: String,
                 default: 'button',
             },
         }
-    }
+    })
 </script>

--- a/stubs/inertia/resources/js/Jetstream/DialogModal.vue
+++ b/stubs/inertia/resources/js/Jetstream/DialogModal.vue
@@ -20,9 +20,10 @@
 </template>
 
 <script>
+    import { defineComponent } from 'vue'
     import Modal from './Modal.vue'
 
-    export default {
+    export default defineComponent({
         emits: ['close'],
 
         components: {
@@ -46,5 +47,5 @@
                 this.$emit('close')
             },
         }
-    }
+    })
 </script>

--- a/stubs/inertia/resources/js/Jetstream/Dropdown.vue
+++ b/stubs/inertia/resources/js/Jetstream/Dropdown.vue
@@ -29,9 +29,9 @@
 </template>
 
 <script>
-import { onMounted, onUnmounted, ref } from "vue";
+import { defineComponent, onMounted, onUnmounted, ref } from "vue";
 
-export default {
+export default defineComponent({
     props: {
         align: {
             default: 'right'
@@ -78,5 +78,5 @@ export default {
             }
         },
     }
-}
+})
 </script>

--- a/stubs/inertia/resources/js/Jetstream/DropdownLink.vue
+++ b/stubs/inertia/resources/js/Jetstream/DropdownLink.vue
@@ -15,12 +15,13 @@
 </template>
 
 <script>
+    import { defineComponent } from 'vue';
     import { Link } from '@inertiajs/inertia-vue3';
 
-    export default {
+    export default defineComponent({
         components: {
             Link,
         },
         props: ['href', 'as']
-    }
+    })
 </script>

--- a/stubs/inertia/resources/js/Jetstream/FormSection.vue
+++ b/stubs/inertia/resources/js/Jetstream/FormSection.vue
@@ -23,9 +23,10 @@
 </template>
 
 <script>
+    import { defineComponent } from 'vue'
     import JetSectionTitle from './SectionTitle.vue'
 
-    export default {
+    export default defineComponent({
         emits: ['submitted'],
 
         components: {
@@ -37,5 +38,5 @@
                 return !! this.$slots.actions
             }
         }
-    }
+    })
 </script>

--- a/stubs/inertia/resources/js/Jetstream/Input.vue
+++ b/stubs/inertia/resources/js/Jetstream/Input.vue
@@ -3,7 +3,9 @@
 </template>
 
 <script>
-    export default {
+    import { defineComponent } from 'vue'
+
+    export default defineComponent({
         props: ['modelValue'],
 
         emits: ['update:modelValue'],
@@ -13,6 +15,5 @@
                 this.$refs.input.focus()
             }
         }
-    }
+    })
 </script>
-

--- a/stubs/inertia/resources/js/Jetstream/InputError.vue
+++ b/stubs/inertia/resources/js/Jetstream/InputError.vue
@@ -7,7 +7,9 @@
 </template>
 
 <script>
-    export default {
+    import { defineComponent } from 'vue'
+
+    export default defineComponent({
         props: ['message']
-    }
+    })
 </script>

--- a/stubs/inertia/resources/js/Jetstream/Label.vue
+++ b/stubs/inertia/resources/js/Jetstream/Label.vue
@@ -6,7 +6,9 @@
 </template>
 
 <script>
-    export default {
+    import { defineComponent } from 'vue'
+
+    export default defineComponent({
         props: ['value']
-    }
+    })
 </script>

--- a/stubs/inertia/resources/js/Jetstream/Modal.vue
+++ b/stubs/inertia/resources/js/Jetstream/Modal.vue
@@ -29,9 +29,9 @@
 </template>
 
 <script>
-import { onMounted, onUnmounted } from "vue";
+import { defineComponent, onMounted, onUnmounted } from "vue";
 
-export default {
+export default defineComponent({
         emits: ['close'],
 
         props: {
@@ -94,5 +94,5 @@ export default {
                 }[this.maxWidth]
             }
         }
-    }
+    })
 </script>

--- a/stubs/inertia/resources/js/Jetstream/NavLink.vue
+++ b/stubs/inertia/resources/js/Jetstream/NavLink.vue
@@ -5,9 +5,10 @@
 </template>
 
 <script>
+    import { defineComponent } from 'vue'
     import { Link } from '@inertiajs/inertia-vue3';
 
-    export default {
+    export default defineComponent({
         components: {
             Link,
         },
@@ -20,5 +21,5 @@
                     : 'inline-flex items-center px-1 pt-1 border-b-2 border-transparent text-sm font-medium leading-5 text-gray-500 hover:text-gray-700 hover:border-gray-300 focus:outline-none focus:text-gray-700 focus:border-gray-300 transition'
             }
         }
-    }
+    })
 </script>

--- a/stubs/inertia/resources/js/Jetstream/ResponsiveNavLink.vue
+++ b/stubs/inertia/resources/js/Jetstream/ResponsiveNavLink.vue
@@ -11,9 +11,10 @@
 </template>
 
 <script>
+    import { defineComponent } from 'vue';
     import { Link } from '@inertiajs/inertia-vue3';
 
-    export default {
+    export default defineComponent({
         components: {
             Link,
         },
@@ -26,5 +27,5 @@
                     : 'block pl-3 pr-4 py-2 border-l-4 border-transparent text-base font-medium text-gray-600 hover:text-gray-800 hover:bg-gray-50 hover:border-gray-300 focus:outline-none focus:text-gray-800 focus:bg-gray-50 focus:border-gray-300 transition'
             }
         }
-    }
+    })
 </script>

--- a/stubs/inertia/resources/js/Jetstream/SecondaryButton.vue
+++ b/stubs/inertia/resources/js/Jetstream/SecondaryButton.vue
@@ -5,12 +5,14 @@
 </template>
 
 <script>
-    export default {
+    import { defineComponent } from 'vue'
+
+    export default defineComponent({
         props: {
             type: {
                 type: String,
                 default: 'button',
             },
         }
-    }
+    })
 </script>

--- a/stubs/inertia/resources/js/Jetstream/ValidationErrors.vue
+++ b/stubs/inertia/resources/js/Jetstream/ValidationErrors.vue
@@ -9,7 +9,9 @@
 </template>
 
 <script>
-    export default {
+    import { defineComponent } from 'vue'
+
+    export default defineComponent({
         computed: {
             errors() {
                 return this.$page.props.errors
@@ -19,5 +21,5 @@
                 return Object.keys(this.errors).length > 0;
             },
         }
-    }
+    })
 </script>

--- a/stubs/inertia/resources/js/Jetstream/Welcome.vue
+++ b/stubs/inertia/resources/js/Jetstream/Welcome.vue
@@ -94,11 +94,12 @@
 </template>
 
 <script>
+    import { defineComponent } from 'vue'
     import JetApplicationLogo from '@/Jetstream/ApplicationLogo.vue'
 
-    export default {
+    export default defineComponent({
         components: {
             JetApplicationLogo,
         },
-    }
+    })
 </script>

--- a/stubs/inertia/resources/js/Layouts/AppLayout.vue
+++ b/stubs/inertia/resources/js/Layouts/AppLayout.vue
@@ -232,6 +232,7 @@
 </template>
 
 <script>
+    import { defineComponent } from 'vue'
     import JetApplicationMark from '@/Jetstream/ApplicationMark.vue'
     import JetBanner from '@/Jetstream/Banner.vue'
     import JetDropdown from '@/Jetstream/Dropdown.vue'
@@ -240,7 +241,7 @@
     import JetResponsiveNavLink from '@/Jetstream/ResponsiveNavLink.vue'
     import { Head, Link } from '@inertiajs/inertia-vue3';
 
-    export default {
+    export default defineComponent({
         props: {
             title: String,
         },
@@ -275,5 +276,5 @@
                 this.$inertia.post(route('logout'));
             },
         }
-    }
+    })
 </script>

--- a/stubs/inertia/resources/js/Pages/API/Index.vue
+++ b/stubs/inertia/resources/js/Pages/API/Index.vue
@@ -17,10 +17,11 @@
 </template>
 
 <script>
+    import { defineComponent } from 'vue'
     import ApiTokenManager from '@/Pages/API/Partials/ApiTokenManager.vue'
     import AppLayout from '@/Layouts/AppLayout.vue'
 
-    export default {
+    export default defineComponent({
         props: [
             'tokens',
             'availablePermissions',
@@ -31,5 +32,5 @@
             ApiTokenManager,
             AppLayout,
         },
-    }
+    })
 </script>

--- a/stubs/inertia/resources/js/Pages/API/Partials/ApiTokenManager.vue
+++ b/stubs/inertia/resources/js/Pages/API/Partials/ApiTokenManager.vue
@@ -164,6 +164,7 @@
 </template>
 
 <script>
+    import { defineComponent } from 'vue'
     import JetActionMessage from '@/Jetstream/ActionMessage.vue'
     import JetActionSection from '@/Jetstream/ActionSection.vue'
     import JetButton from '@/Jetstream/Button.vue'
@@ -178,7 +179,7 @@
     import JetSecondaryButton from '@/Jetstream/SecondaryButton.vue'
     import JetSectionBorder from '@/Jetstream/SectionBorder.vue'
 
-    export default {
+    export default defineComponent({
         components: {
             JetActionMessage,
             JetActionSection,
@@ -257,5 +258,5 @@
                 })
             },
         },
-    }
+    })
 </script>

--- a/stubs/inertia/resources/js/Pages/Auth/ConfirmPassword.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/ConfirmPassword.vue
@@ -28,6 +28,7 @@
 </template>
 
 <script>
+    import { defineComponent } from 'vue';
     import { Head } from '@inertiajs/inertia-vue3';
     import JetAuthenticationCard from '@/Jetstream/AuthenticationCard.vue'
     import JetAuthenticationCardLogo from '@/Jetstream/AuthenticationCardLogo.vue'
@@ -36,7 +37,7 @@
     import JetLabel from '@/Jetstream/Label.vue'
     import JetValidationErrors from '@/Jetstream/ValidationErrors.vue'
 
-    export default {
+    export default defineComponent({
         components: {
             Head,
             JetAuthenticationCard,
@@ -62,5 +63,5 @@
                 })
             }
         }
-    }
+    })
 </script>

--- a/stubs/inertia/resources/js/Pages/Auth/ForgotPassword.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/ForgotPassword.vue
@@ -32,6 +32,7 @@
 </template>
 
 <script>
+    import { defineComponent } from 'vue'
     import { Head } from '@inertiajs/inertia-vue3';
     import JetAuthenticationCard from '@/Jetstream/AuthenticationCard.vue'
     import JetAuthenticationCardLogo from '@/Jetstream/AuthenticationCardLogo.vue'
@@ -40,7 +41,7 @@
     import JetLabel from '@/Jetstream/Label.vue'
     import JetValidationErrors from '@/Jetstream/ValidationErrors.vue'
 
-    export default {
+    export default defineComponent({
         components: {
             Head,
             JetAuthenticationCard,
@@ -68,5 +69,5 @@
                 this.form.post(this.route('password.email'))
             }
         }
-    }
+    })
 </script>

--- a/stubs/inertia/resources/js/Pages/Auth/Login.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/Login.vue
@@ -44,6 +44,7 @@
 </template>
 
 <script>
+    import { defineComponent } from 'vue'
     import JetAuthenticationCard from '@/Jetstream/AuthenticationCard.vue'
     import JetAuthenticationCardLogo from '@/Jetstream/AuthenticationCardLogo.vue'
     import JetButton from '@/Jetstream/Button.vue'
@@ -53,7 +54,7 @@
     import JetValidationErrors from '@/Jetstream/ValidationErrors.vue'
     import { Head, Link } from '@inertiajs/inertia-vue3';
 
-    export default {
+    export default defineComponent({
         components: {
             Head,
             JetAuthenticationCard,
@@ -93,5 +94,5 @@
                     })
             }
         }
-    }
+    })
 </script>

--- a/stubs/inertia/resources/js/Pages/Auth/Register.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/Register.vue
@@ -55,6 +55,7 @@
 </template>
 
 <script>
+    import { defineComponent } from 'vue'
     import JetAuthenticationCard from '@/Jetstream/AuthenticationCard.vue'
     import JetAuthenticationCardLogo from '@/Jetstream/AuthenticationCardLogo.vue'
     import JetButton from '@/Jetstream/Button.vue'
@@ -64,7 +65,7 @@
     import JetValidationErrors from '@/Jetstream/ValidationErrors.vue'
     import { Head, Link } from '@inertiajs/inertia-vue3';
 
-    export default {
+    export default defineComponent({
         components: {
             Head,
             JetAuthenticationCard,
@@ -96,5 +97,5 @@
                 })
             }
         }
-    }
+    })
 </script>

--- a/stubs/inertia/resources/js/Pages/Auth/ResetPassword.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/ResetPassword.vue
@@ -34,6 +34,7 @@
 </template>
 
 <script>
+    import { defineComponent } from 'vue';
     import { Head } from '@inertiajs/inertia-vue3';
     import JetAuthenticationCard from '@/Jetstream/AuthenticationCard.vue'
     import JetAuthenticationCardLogo from '@/Jetstream/AuthenticationCardLogo.vue'
@@ -42,7 +43,7 @@
     import JetLabel from '@/Jetstream/Label.vue'
     import JetValidationErrors from '@/Jetstream/ValidationErrors.vue'
 
-    export default {
+    export default defineComponent({
         components: {
             Head,
             JetAuthenticationCard,
@@ -76,5 +77,5 @@
                 })
             }
         }
-    }
+    })
 </script>

--- a/stubs/inertia/resources/js/Pages/Auth/TwoFactorChallenge.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/TwoFactorChallenge.vue
@@ -49,6 +49,7 @@
 </template>
 
 <script>
+    import { defineComponent } from 'vue';
     import { Head } from '@inertiajs/inertia-vue3';
     import JetAuthenticationCard from '@/Jetstream/AuthenticationCard.vue'
     import JetAuthenticationCardLogo from '@/Jetstream/AuthenticationCardLogo.vue'
@@ -57,7 +58,7 @@
     import JetLabel from '@/Jetstream/Label.vue'
     import JetValidationErrors from '@/Jetstream/ValidationErrors.vue'
 
-    export default {
+    export default defineComponent({
         components: {
             Head,
             JetAuthenticationCard,
@@ -97,5 +98,5 @@
                 this.form.post(this.route('two-factor.login'))
             }
         }
-    }
+    })
 </script>

--- a/stubs/inertia/resources/js/Pages/Auth/VerifyEmail.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/VerifyEmail.vue
@@ -27,12 +27,13 @@
 </template>
 
 <script>
+    import { defineComponent } from 'vue'
     import JetAuthenticationCard from '@/Jetstream/AuthenticationCard.vue'
     import JetAuthenticationCardLogo from '@/Jetstream/AuthenticationCardLogo.vue'
     import JetButton from '@/Jetstream/Button.vue'
     import { Head, Link } from '@inertiajs/inertia-vue3';
 
-    export default {
+    export default defineComponent({
         components: {
             Head,
             JetAuthenticationCard,
@@ -62,5 +63,5 @@
                 return this.status === 'verification-link-sent';
             }
         }
-    }
+    })
 </script>

--- a/stubs/inertia/resources/js/Pages/Dashboard.vue
+++ b/stubs/inertia/resources/js/Pages/Dashboard.vue
@@ -17,13 +17,14 @@
 </template>
 
 <script>
+    import { defineComponent } from 'vue'
     import AppLayout from '@/Layouts/AppLayout.vue'
     import Welcome from '@/Jetstream/Welcome.vue'
 
-    export default {
+    export default defineComponent({
         components: {
             AppLayout,
             Welcome,
         },
-    }
+    })
 </script>

--- a/stubs/inertia/resources/js/Pages/PrivacyPolicy.vue
+++ b/stubs/inertia/resources/js/Pages/PrivacyPolicy.vue
@@ -16,15 +16,16 @@
 </template>
 
 <script>
+import { defineComponent } from 'vue'
 import { Head } from '@inertiajs/inertia-vue3';
 import JetAuthenticationCardLogo from '@/Jetstream/AuthenticationCardLogo.vue'
 
-export default {
+export default defineComponent({
     props: ['policy'],
 
     components: {
         Head,
         JetAuthenticationCardLogo,
     },
-}
+})
 </script>

--- a/stubs/inertia/resources/js/Pages/Profile/Partials/DeleteUserForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/Partials/DeleteUserForm.vue
@@ -53,6 +53,7 @@
 </template>
 
 <script>
+    import { defineComponent } from 'vue'
     import JetActionSection from '@/Jetstream/ActionSection.vue'
     import JetDialogModal from '@/Jetstream/DialogModal.vue'
     import JetDangerButton from '@/Jetstream/DangerButton.vue'
@@ -60,7 +61,7 @@
     import JetInputError from '@/Jetstream/InputError.vue'
     import JetSecondaryButton from '@/Jetstream/SecondaryButton.vue'
 
-    export default {
+    export default defineComponent({
         components: {
             JetActionSection,
             JetDangerButton,
@@ -102,5 +103,5 @@
                 this.form.reset()
             },
         },
-    }
+    })
 </script>

--- a/stubs/inertia/resources/js/Pages/Profile/Partials/LogoutOtherBrowserSessionsForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/Partials/LogoutOtherBrowserSessionsForm.vue
@@ -87,6 +87,7 @@
 </template>
 
 <script>
+    import { defineComponent } from 'vue'
     import JetActionMessage from '@/Jetstream/ActionMessage.vue'
     import JetActionSection from '@/Jetstream/ActionSection.vue'
     import JetButton from '@/Jetstream/Button.vue'
@@ -95,7 +96,7 @@
     import JetInputError from '@/Jetstream/InputError.vue'
     import JetSecondaryButton from '@/Jetstream/SecondaryButton.vue'
 
-    export default {
+    export default defineComponent({
         props: ['sessions'],
 
         components: {
@@ -140,5 +141,5 @@
                 this.form.reset()
             },
         },
-    }
+    })
 </script>

--- a/stubs/inertia/resources/js/Pages/Profile/Partials/TwoFactorAuthenticationForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/Partials/TwoFactorAuthenticationForm.vue
@@ -87,13 +87,14 @@
 </template>
 
 <script>
+    import { defineComponent } from 'vue'
     import JetActionSection from '@/Jetstream/ActionSection.vue'
     import JetButton from '@/Jetstream/Button.vue'
     import JetConfirmsPassword from '@/Jetstream/ConfirmsPassword.vue'
     import JetDangerButton from '@/Jetstream/DangerButton.vue'
     import JetSecondaryButton from '@/Jetstream/SecondaryButton.vue'
 
-    export default {
+    export default defineComponent({
         components: {
             JetActionSection,
             JetButton,
@@ -162,5 +163,5 @@
                 return ! this.enabling && this.$page.props.user.two_factor_enabled
             }
         }
-    }
+    })
 </script>

--- a/stubs/inertia/resources/js/Pages/Profile/Partials/UpdatePasswordForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/Partials/UpdatePasswordForm.vue
@@ -41,6 +41,7 @@
 </template>
 
 <script>
+    import { defineComponent } from 'vue'
     import JetActionMessage from '@/Jetstream/ActionMessage.vue'
     import JetButton from '@/Jetstream/Button.vue'
     import JetFormSection from '@/Jetstream/FormSection.vue'
@@ -48,7 +49,7 @@
     import JetInputError from '@/Jetstream/InputError.vue'
     import JetLabel from '@/Jetstream/Label.vue'
 
-    export default {
+    export default defineComponent({
         components: {
             JetActionMessage,
             JetButton,
@@ -88,5 +89,5 @@
                 })
             },
         },
-    }
+    })
 </script>

--- a/stubs/inertia/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
@@ -69,6 +69,7 @@
 </template>
 
 <script>
+    import { defineComponent } from 'vue'
     import JetButton from '@/Jetstream/Button.vue'
     import JetFormSection from '@/Jetstream/FormSection.vue'
     import JetInput from '@/Jetstream/Input.vue'
@@ -77,7 +78,7 @@
     import JetActionMessage from '@/Jetstream/ActionMessage.vue'
     import JetSecondaryButton from '@/Jetstream/SecondaryButton.vue'
 
-    export default {
+    export default defineComponent({
         components: {
             JetActionMessage,
             JetButton,
@@ -150,5 +151,5 @@
                 }
             },
         },
-    }
+    })
 </script>

--- a/stubs/inertia/resources/js/Pages/Profile/Show.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/Show.vue
@@ -39,6 +39,7 @@
 </template>
 
 <script>
+    import { defineComponent } from 'vue'
     import AppLayout from '@/Layouts/AppLayout.vue'
     import DeleteUserForm from '@/Pages/Profile/Partials/DeleteUserForm.vue'
     import JetSectionBorder from '@/Jetstream/SectionBorder.vue'
@@ -47,7 +48,7 @@
     import UpdatePasswordForm from '@/Pages/Profile/Partials/UpdatePasswordForm.vue'
     import UpdateProfileInformationForm from '@/Pages/Profile/Partials/UpdateProfileInformationForm.vue'
 
-    export default {
+    export default defineComponent({
         props: ['sessions'],
 
         components: {
@@ -59,5 +60,5 @@
             UpdatePasswordForm,
             UpdateProfileInformationForm,
         },
-    }
+    })
 </script>

--- a/stubs/inertia/resources/js/Pages/Teams/Create.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/Create.vue
@@ -15,13 +15,14 @@
 </template>
 
 <script>
+    import { defineComponent } from 'vue'
     import AppLayout from '@/Layouts/AppLayout.vue'
     import CreateTeamForm from '@/Pages/Teams/Partials/CreateTeamForm.vue'
 
-    export default {
+    export default defineComponent({
         components: {
             AppLayout,
             CreateTeamForm,
         },
-    }
+    })
 </script>

--- a/stubs/inertia/resources/js/Pages/Teams/Partials/CreateTeamForm.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/Partials/CreateTeamForm.vue
@@ -13,18 +13,18 @@
                 <jet-label value="Team Owner" />
 
                 <div class="flex items-center mt-2">
-                    <img class="w-12 h-12 rounded-full object-cover" :src="$page.props.user.profile_photo_url" :alt="$page.props.user.name">
+                    <img class="object-cover w-12 h-12 rounded-full" :src="$page.props.user.profile_photo_url" :alt="$page.props.user.name">
 
                     <div class="ml-4 leading-tight">
                         <div>{{ $page.props.user.name }}</div>
-                        <div class="text-gray-700 text-sm">{{ $page.props.user.email }}</div>
+                        <div class="text-sm text-gray-700">{{ $page.props.user.email }}</div>
                     </div>
                 </div>
             </div>
 
             <div class="col-span-6 sm:col-span-4">
                 <jet-label for="name" value="Team Name" />
-                <jet-input id="name" type="text" class="mt-1 block w-full" v-model="form.name" autofocus />
+                <jet-input id="name" type="text" class="block w-full mt-1" v-model="form.name" autofocus />
                 <jet-input-error :message="form.errors.name" class="mt-2" />
             </div>
         </template>
@@ -38,13 +38,14 @@
 </template>
 
 <script>
+    import { defineComponent } from 'vue'
     import JetButton from '@/Jetstream/Button.vue'
     import JetFormSection from '@/Jetstream/FormSection.vue'
     import JetInput from '@/Jetstream/Input.vue'
     import JetInputError from '@/Jetstream/InputError.vue'
     import JetLabel from '@/Jetstream/Label.vue'
 
-    export default {
+    export default defineComponent({
         components: {
             JetButton,
             JetFormSection,
@@ -69,5 +70,5 @@
                 });
             },
         },
-    }
+    })
 </script>

--- a/stubs/inertia/resources/js/Pages/Teams/Partials/DeleteTeamForm.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/Partials/DeleteTeamForm.vue
@@ -44,12 +44,13 @@
 </template>
 
 <script>
+    import { defineComponent } from 'vue'
     import JetActionSection from '@/Jetstream/ActionSection.vue'
     import JetConfirmationModal from '@/Jetstream/ConfirmationModal.vue'
     import JetDangerButton from '@/Jetstream/DangerButton.vue'
     import JetSecondaryButton from '@/Jetstream/SecondaryButton.vue'
 
-    export default {
+    export default defineComponent({
         props: ['team'],
 
         components: {
@@ -79,5 +80,5 @@
                 });
             },
         },
-    }
+    })
 </script>

--- a/stubs/inertia/resources/js/Pages/Teams/Partials/TeamMemberManager.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/Partials/TeamMemberManager.vue
@@ -247,6 +247,7 @@
 </template>
 
 <script>
+    import { defineComponent } from 'vue'
     import JetActionMessage from '@/Jetstream/ActionMessage.vue'
     import JetActionSection from '@/Jetstream/ActionSection.vue'
     import JetButton from '@/Jetstream/Button.vue'
@@ -260,7 +261,7 @@
     import JetSecondaryButton from '@/Jetstream/SecondaryButton.vue'
     import JetSectionBorder from '@/Jetstream/SectionBorder.vue'
 
-    export default {
+    export default defineComponent({
         components: {
             JetActionMessage,
             JetActionSection,
@@ -356,5 +357,5 @@
                 return this.availableRoles.find(r => r.key === role).name
             },
         },
-    }
+    })
 </script>

--- a/stubs/inertia/resources/js/Pages/Teams/Partials/UpdateTeamNameForm.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/Partials/UpdateTeamNameForm.vue
@@ -50,6 +50,7 @@
 </template>
 
 <script>
+    import { defineComponent } from 'vue'
     import JetActionMessage from '@/Jetstream/ActionMessage'
     import JetButton from '@/Jetstream/Button'
     import JetFormSection from '@/Jetstream/FormSection'
@@ -57,7 +58,7 @@
     import JetInputError from '@/Jetstream/InputError'
     import JetLabel from '@/Jetstream/Label'
 
-    export default {
+    export default defineComponent({
         components: {
             JetActionMessage,
             JetButton,
@@ -85,5 +86,5 @@
                 });
             },
         },
-    }
+    })
 </script>

--- a/stubs/inertia/resources/js/Pages/Teams/Show.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/Show.vue
@@ -26,13 +26,14 @@
 </template>
 
 <script>
+    import { defineComponent } from 'vue'
     import AppLayout from '@/Layouts/AppLayout.vue'
     import DeleteTeamForm from '@/Pages/Teams/Partials/DeleteTeamForm.vue'
     import JetSectionBorder from '@/Jetstream/SectionBorder.vue'
     import TeamMemberManager from '@/Pages/Teams/Partials/TeamMemberManager.vue'
     import UpdateTeamNameForm from '@/Pages/Teams/Partials/UpdateTeamNameForm.vue'
 
-    export default {
+    export default defineComponent({
         props: [
             'team',
             'availableRoles',
@@ -46,5 +47,5 @@
             TeamMemberManager,
             UpdateTeamNameForm,
         },
-    }
+    })
 </script>

--- a/stubs/inertia/resources/js/Pages/TermsOfService.vue
+++ b/stubs/inertia/resources/js/Pages/TermsOfService.vue
@@ -16,15 +16,16 @@
 </template>
 
 <script>
+import { defineComponent } from 'vue'
 import { Head } from '@inertiajs/inertia-vue3';
 import JetAuthenticationCardLogo from '@/Jetstream/AuthenticationCardLogo.vue'
 
-export default {
+export default defineComponent({
     props: ['terms'],
 
     components: {
         Head,
         JetAuthenticationCardLogo,
     },
-}
+})
 </script>

--- a/stubs/inertia/resources/js/Pages/Welcome.vue
+++ b/stubs/inertia/resources/js/Pages/Welcome.vue
@@ -177,9 +177,10 @@
 </style>
 
 <script>
+    import { defineComponent } from 'vue'
     import { Head, Link } from '@inertiajs/inertia-vue3';
 
-    export default {
+    export default defineComponent({
         components: {
             Head,
             Link,
@@ -191,5 +192,5 @@
             laravelVersion: String,
             phpVersion: String,
         }
-    }
+    })
 </script>


### PR DESCRIPTION
As discussed in #867, this PR adds a [`defineComponent()`](https://v3.vuejs.org/api/global-api.html#definecomponent) around the `export default { ... }` component options of all Vue components. 

`defineComponent` is just a function that returns the object passed into it. But it makes life easier for people, who want to use Typescript in their Jetstream project.