### PR TITLE
[2.x] fix: added .vue to UpdateTeamNameForm.vue imports

### DIFF
--- a/stubs/inertia/resources/js/Pages/Teams/Partials/UpdateTeamNameForm.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/Partials/UpdateTeamNameForm.vue
@@ -51,12 +51,12 @@
 
 <script>
     import { defineComponent } from 'vue'
-    import JetActionMessage from '@/Jetstream/ActionMessage'
-    import JetButton from '@/Jetstream/Button'
-    import JetFormSection from '@/Jetstream/FormSection'
-    import JetInput from '@/Jetstream/Input'
-    import JetInputError from '@/Jetstream/InputError'
-    import JetLabel from '@/Jetstream/Label'
+    import JetActionMessage from '@/Jetstream/ActionMessage.vue'
+    import JetButton from '@/Jetstream/Button.vue'
+    import JetFormSection from '@/Jetstream/FormSection.vue'
+    import JetInput from '@/Jetstream/Input.vue'
+    import JetInputError from '@/Jetstream/InputError.vue'
+    import JetLabel from '@/Jetstream/Label.vue'
 
     export default defineComponent({
         components: {


### PR DESCRIPTION
Hiya, long time user first time contributing.

This pull request adds the .vue ext to the imports on the UpdateTeamNameForm.vue 

If not mistaken not really an issue when working with webpack but with vite any vue sfc import without the .vue ext throws an error.
