### PR TITLE
Remove csrf_token from meta in Inertia app

### DIFF
--- a/stubs/inertia/resources/views/app.blade.php
+++ b/stubs/inertia/resources/views/app.blade.php
@@ -3,7 +3,6 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <meta name="csrf-token" content="{{ csrf_token() }}">
 
         <title inertia>{{ config('app.name', 'Laravel') }}</title>
 


### PR DESCRIPTION
Including the `csrf_token` as a meta element conflicts with Inertia's built-in CSRF protection: https://inertiajs.com/csrf-protection#top

![CSRF protection - Inertia js 2021-09-10 at 11 26 18 AM](https://user-images.githubusercontent.com/15267205/132824602-77e2e636-aa69-4137-97dc-21c4e332def5.jpg)

