### PR TITLE
[2.x] Use correct feature flag in password reset tests

### DIFF
--- a/stubs/pest-tests/PasswordResetTest.php
+++ b/stubs/pest-tests/PasswordResetTest.php
@@ -10,7 +10,7 @@ test('reset password link screen can be rendered', function () {
 
     $response->assertStatus(200);
 })->skip(function () {
-    return ! Features::enabled(Features::updatePasswords());
+    return ! Features::enabled(Features::resetPasswords());
 }, 'Password updates are not enabled.');
 
 test('reset password link can be requested', function () {
@@ -24,7 +24,7 @@ test('reset password link can be requested', function () {
 
     Notification::assertSentTo($user, ResetPassword::class);
 })->skip(function () {
-    return ! Features::enabled(Features::updatePasswords());
+    return ! Features::enabled(Features::resetPasswords());
 }, 'Password updates are not enabled.');
 
 test('reset password screen can be rendered', function () {
@@ -44,7 +44,7 @@ test('reset password screen can be rendered', function () {
         return true;
     });
 })->skip(function () {
-    return ! Features::enabled(Features::updatePasswords());
+    return ! Features::enabled(Features::resetPasswords());
 }, 'Password updates are not enabled.');
 
 test('password can be reset with valid token', function () {
@@ -69,5 +69,5 @@ test('password can be reset with valid token', function () {
         return true;
     });
 })->skip(function () {
-    return ! Features::enabled(Features::updatePasswords());
+    return ! Features::enabled(Features::resetPasswords());
 }, 'Password updates are not enabled.');

--- a/stubs/tests/PasswordResetTest.php
+++ b/stubs/tests/PasswordResetTest.php
@@ -15,7 +15,7 @@ class PasswordResetTest extends TestCase
 
     public function test_reset_password_link_screen_can_be_rendered()
     {
-        if (! Features::enabled(Features::updatePasswords())) {
+        if (! Features::enabled(Features::resetPasswords())) {
             return $this->markTestSkipped('Password updates are not enabled.');
         }
 
@@ -26,7 +26,7 @@ class PasswordResetTest extends TestCase
 
     public function test_reset_password_link_can_be_requested()
     {
-        if (! Features::enabled(Features::updatePasswords())) {
+        if (! Features::enabled(Features::resetPasswords())) {
             return $this->markTestSkipped('Password updates are not enabled.');
         }
 
@@ -43,7 +43,7 @@ class PasswordResetTest extends TestCase
 
     public function test_reset_password_screen_can_be_rendered()
     {
-        if (! Features::enabled(Features::updatePasswords())) {
+        if (! Features::enabled(Features::resetPasswords())) {
             return $this->markTestSkipped('Password updates are not enabled.');
         }
 
@@ -66,7 +66,7 @@ class PasswordResetTest extends TestCase
 
     public function test_password_can_be_reset_with_valid_token()
     {
-        if (! Features::enabled(Features::updatePasswords())) {
+        if (! Features::enabled(Features::resetPasswords())) {
             return $this->markTestSkipped('Password updates are not enabled.');
         }
 


### PR DESCRIPTION
## What?
In the fortify routes file, all the routes being tested in both PHPUnit and Pest variants of `PasswordResetTest` are only exposed using the following condition (see [here](https://github.com/laravel/fortify/blob/a52a980b922694fbf7298ab70cc3da7fb716cfff/routes/routes.php#L45)):

```php
// Password Reset...
if (Features::enabled(Features::resetPasswords())) {
    // ...
}
```

If the reset-passwords feature flag is disabled, this causes the published test files for `PasswordResetTest` to fail, regardless of the preferred testing framework used.

This PR updates both `PasswordResetTest` variants to use the correct feature flag, `Features::resetPasswords()` instead of `Features::updatePasswords()` which is currently being used incorrectly. 

## Why?
I installed a fresh Laravel project with Jetstream using the `2.x-dev` branch on packagist to keep one of my packages up-to-date with recent merges / changes. Upon publishing the pest tests and disabling password resets, my CI pipeline broke.

## Replicate the problem

You can replicate this on `2.x-dev` yourself locally. First, select your stack and publish all files (including tests). Then in `config/fortify.php` comment out this line: 

```php
'features' => [
    // Features::resetPasswords(),
],
```

Then run your test suite and see the `PasswordResetTest`'s fail.