### PR TITLE
Revert "fix cors policy errors with inertia stack (#797)"

### DIFF
--- a/stubs/inertia/resources/views/app.blade.php
+++ b/stubs/inertia/resources/views/app.blade.php
@@ -18,9 +18,5 @@
     </head>
     <body class="font-sans antialiased">
         @inertia
-
-        @env ('local')
-            <script src="http://localhost:3000/browser-sync/browser-sync-client.js"></script>
-        @endenv
     </body>
 </html>


### PR DESCRIPTION
Attempting to load browser-sync-client.js without it being used in
Jetstream by default results in blocked JS execution until timeout.

Fixes #850