### PR TITLE
Allow team invitation table to use connection out of the box...

### DIFF
--- a/stubs/app/Actions/Jetstream/InviteTeamMember.php
+++ b/stubs/app/Actions/Jetstream/InviteTeamMember.php
@@ -67,8 +67,11 @@ class InviteTeamMember implements InvitesTeamMembers
      */
     protected function rules($team)
     {
+        $teamInvitation = new (Jetstream::teamInvitationModel());
+        $connectionTable = $teamInvitation->getConnectionName() . '.' . $teamInvitation->getTable();
+
         return array_filter([
-            'email' => ['required', 'email', Rule::unique('team_invitations')->where(function ($query) use ($team) {
+            'email' => ['required', 'email', Rule::unique($connectionTable)->where(function ($query) use ($team) {
                 $query->where('team_id', $team->id);
             })],
             'role' => Jetstream::hasRoles()

--- a/stubs/app/Actions/Jetstream/InviteTeamMember.php
+++ b/stubs/app/Actions/Jetstream/InviteTeamMember.php
@@ -68,7 +68,7 @@ class InviteTeamMember implements InvitesTeamMembers
     protected function rules($team)
     {
         $class = Jetstream::teamInvitationModel();
-        $teamInvitation = $class::make();
+        $teamInvitation = new $class;
         $connectionTable = $teamInvitation->getConnectionName().'.'.$teamInvitation->getTable();
 
         return array_filter([

--- a/stubs/app/Actions/Jetstream/InviteTeamMember.php
+++ b/stubs/app/Actions/Jetstream/InviteTeamMember.php
@@ -68,11 +68,11 @@ class InviteTeamMember implements InvitesTeamMembers
     protected function rules($team)
     {
         $class = Jetstream::teamInvitationModel();
-        $teamInvitation = new $class;
-        $connectionTable = $teamInvitation->getConnectionName().'.'.$teamInvitation->getTable();
+
+        $table = (new $class)->getConnectionName().'.'.(new $class)->getTable();
 
         return array_filter([
-            'email' => ['required', 'email', Rule::unique($connectionTable)->where(function ($query) use ($team) {
+            'email' => ['required', 'email', Rule::unique($table)->where(function ($query) use ($team) {
                 $query->where('team_id', $team->id);
             })],
             'role' => Jetstream::hasRoles()

--- a/stubs/app/Actions/Jetstream/InviteTeamMember.php
+++ b/stubs/app/Actions/Jetstream/InviteTeamMember.php
@@ -67,7 +67,8 @@ class InviteTeamMember implements InvitesTeamMembers
      */
     protected function rules($team)
     {
-        $teamInvitation = new (Jetstream::teamInvitationModel());
+        $class = Jetstream::teamInvitationModel();
+        $teamInvitation = $class::make();
         $connectionTable = $teamInvitation->getConnectionName() . '.' . $teamInvitation->getTable();
 
         return array_filter([

--- a/stubs/app/Actions/Jetstream/InviteTeamMember.php
+++ b/stubs/app/Actions/Jetstream/InviteTeamMember.php
@@ -69,7 +69,7 @@ class InviteTeamMember implements InvitesTeamMembers
     {
         $class = Jetstream::teamInvitationModel();
         $teamInvitation = $class::make();
-        $connectionTable = $teamInvitation->getConnectionName() . '.' . $teamInvitation->getTable();
+        $connectionTable = $teamInvitation->getConnectionName().'.'.$teamInvitation->getTable();
 
         return array_filter([
             'email' => ['required', 'email', Rule::unique($connectionTable)->where(function ($query) use ($team) {


### PR DESCRIPTION
A project I work on uses Spatie's multi-tenancy package with a landlord database and multiple tenant databases. In order to guarantee that the correct connection is used, I need to change it in this file (`Rule::unique('my_connection.team_invitations')`).

This change should allow the correct connection/table in all (?) cases without having to change anything here.

I'm not convinced this is the best way to resolve the problem.  I'd love feedback or, if it's not clear, any questions about why this might be necessary.

Thanks.  🤓

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

If you change the behavior of the Inertia stack you're expected to update the Livewire stack as well and vice versa.
-->
