### PR TITLE
Add "required" attribute to terms and privacy policy checkbox

### DIFF
--- a/stubs/inertia/resources/js/Pages/Auth/Register.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/Register.vue
@@ -32,7 +32,7 @@
             <div class="mt-4" v-if="$page.props.jetstream.hasTermsAndPrivacyPolicyFeature">
                 <jet-label for="terms">
                     <div class="flex items-center">
-                        <jet-checkbox name="terms" id="terms" v-model:checked="form.terms" />
+                        <jet-checkbox name="terms" id="terms" v-model:checked="form.terms" required />
 
                         <div class="ml-2">
                             I agree to the <a target="_blank" :href="route('terms.show')" class="underline text-sm text-gray-600 hover:text-gray-900">Terms of Service</a> and <a target="_blank" :href="route('policy.show')" class="underline text-sm text-gray-600 hover:text-gray-900">Privacy Policy</a>

--- a/stubs/livewire/resources/views/auth/register.blade.php
+++ b/stubs/livewire/resources/views/auth/register.blade.php
@@ -33,7 +33,7 @@
                 <div class="mt-4">
                     <x-jet-label for="terms">
                         <div class="flex items-center">
-                            <x-jet-checkbox name="terms" id="terms"/>
+                            <x-jet-checkbox name="terms" id="terms" required />
 
                             <div class="ml-2">
                                 {!! __('I agree to the :terms_of_service and :privacy_policy', [


### PR DESCRIPTION
You must agree to the terms of service and the privacy policy during registration, if the feature is active. This is already validated, but only server-side.

This commit adds the `required` attribute to the checkbox, in order to take advantage of the native browser validation (just like with other required fields in the same form).