### PR TITLE
Skip team tests if feature is disabled

### DIFF
--- a/stubs/tests/livewire/CreateTeamTest.php
+++ b/stubs/tests/livewire/CreateTeamTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Jetstream\Http\Livewire\CreateTeamForm;
+use Laravel\Jetstream\Features;
 use Livewire\Livewire;
 use Tests\TestCase;
 
@@ -14,6 +15,10 @@ class CreateTeamTest extends TestCase
 
     public function test_teams_can_be_created()
     {
+        if (! Features::hasTeamFeatures()) {
+            return $this->markTestSkipped('Team support is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         Livewire::test(CreateTeamForm::class)

--- a/stubs/tests/livewire/CreateTeamTest.php
+++ b/stubs/tests/livewire/CreateTeamTest.php
@@ -4,8 +4,8 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Laravel\Jetstream\Http\Livewire\CreateTeamForm;
 use Laravel\Jetstream\Features;
+use Laravel\Jetstream\Http\Livewire\CreateTeamForm;
 use Livewire\Livewire;
 use Tests\TestCase;
 

--- a/stubs/tests/livewire/DeleteTeamTest.php
+++ b/stubs/tests/livewire/DeleteTeamTest.php
@@ -5,8 +5,8 @@ namespace Tests\Feature;
 use App\Models\Team;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Laravel\Jetstream\Http\Livewire\DeleteTeamForm;
 use Laravel\Jetstream\Features;
+use Laravel\Jetstream\Http\Livewire\DeleteTeamForm;
 use Livewire\Livewire;
 use Tests\TestCase;
 

--- a/stubs/tests/livewire/DeleteTeamTest.php
+++ b/stubs/tests/livewire/DeleteTeamTest.php
@@ -6,6 +6,7 @@ use App\Models\Team;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Jetstream\Http\Livewire\DeleteTeamForm;
+use Laravel\Jetstream\Features;
 use Livewire\Livewire;
 use Tests\TestCase;
 
@@ -15,6 +16,10 @@ class DeleteTeamTest extends TestCase
 
     public function test_teams_can_be_deleted()
     {
+        if (! Features::hasTeamFeatures()) {
+            return $this->markTestSkipped('Team support is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $user->ownedTeams()->save($team = Team::factory()->make([
@@ -34,6 +39,10 @@ class DeleteTeamTest extends TestCase
 
     public function test_personal_teams_cant_be_deleted()
     {
+        if (! Features::hasTeamFeatures()) {
+            return $this->markTestSkipped('Team support is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $component = Livewire::test(DeleteTeamForm::class, ['team' => $user->currentTeam])

--- a/stubs/tests/livewire/InviteTeamMemberTest.php
+++ b/stubs/tests/livewire/InviteTeamMemberTest.php
@@ -5,9 +5,9 @@ namespace Tests\Feature;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Mail;
+use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Http\Livewire\TeamMemberManager;
 use Laravel\Jetstream\Mail\TeamInvitation;
-use Laravel\Jetstream\Features;
 use Livewire\Livewire;
 use Tests\TestCase;
 

--- a/stubs/tests/livewire/InviteTeamMemberTest.php
+++ b/stubs/tests/livewire/InviteTeamMemberTest.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Mail;
 use Laravel\Jetstream\Http\Livewire\TeamMemberManager;
 use Laravel\Jetstream\Mail\TeamInvitation;
+use Laravel\Jetstream\Features;
 use Livewire\Livewire;
 use Tests\TestCase;
 
@@ -16,6 +17,10 @@ class InviteTeamMemberTest extends TestCase
 
     public function test_team_members_can_be_invited_to_team()
     {
+        if (! Features::hasTeamFeatures()) {
+            return $this->markTestSkipped('Teams support is not enabled.');
+        }
+
         Mail::fake();
 
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
@@ -33,6 +38,10 @@ class InviteTeamMemberTest extends TestCase
 
     public function test_team_member_invitations_can_be_cancelled()
     {
+        if (! Features::hasTeamFeatures()) {
+            return $this->markTestSkipped('Teams support is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         // Add the team member...

--- a/stubs/tests/livewire/LeaveTeamTest.php
+++ b/stubs/tests/livewire/LeaveTeamTest.php
@@ -4,8 +4,8 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Laravel\Jetstream\Http\Livewire\TeamMemberManager;
 use Laravel\Jetstream\Features;
+use Laravel\Jetstream\Http\Livewire\TeamMemberManager;
 use Livewire\Livewire;
 use Tests\TestCase;
 

--- a/stubs/tests/livewire/LeaveTeamTest.php
+++ b/stubs/tests/livewire/LeaveTeamTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Jetstream\Http\Livewire\TeamMemberManager;
+use Laravel\Jetstream\Features;
 use Livewire\Livewire;
 use Tests\TestCase;
 
@@ -14,6 +15,10 @@ class LeaveTeamTest extends TestCase
 
     public function test_users_can_leave_teams()
     {
+        if (! Features::hasTeamFeatures()) {
+            return $this->markTestSkipped('Team support is not enabled.');
+        }
+
         $user = User::factory()->withPersonalTeam()->create();
 
         $user->currentTeam->users()->attach(
@@ -30,6 +35,10 @@ class LeaveTeamTest extends TestCase
 
     public function test_team_owners_cant_leave_their_own_team()
     {
+        if (! Features::hasTeamFeatures()) {
+            return $this->markTestSkipped('Team support is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $component = Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])

--- a/stubs/tests/livewire/RemoveTeamMemberTest.php
+++ b/stubs/tests/livewire/RemoveTeamMemberTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Jetstream\Http\Livewire\TeamMemberManager;
+use Laravel\Jetstream\Features;
 use Livewire\Livewire;
 use Tests\TestCase;
 
@@ -14,6 +15,10 @@ class RemoveTeamMemberTest extends TestCase
 
     public function test_team_members_can_be_removed_from_teams()
     {
+        if (! Features::hasTeamFeatures()) {
+            return $this->markTestSkipped('Team support is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $user->currentTeam->users()->attach(
@@ -29,6 +34,10 @@ class RemoveTeamMemberTest extends TestCase
 
     public function test_only_team_owner_can_remove_team_members()
     {
+        if (! Features::hasTeamFeatures()) {
+            return $this->markTestSkipped('Team support is not enabled.');
+        }
+
         $user = User::factory()->withPersonalTeam()->create();
 
         $user->currentTeam->users()->attach(

--- a/stubs/tests/livewire/RemoveTeamMemberTest.php
+++ b/stubs/tests/livewire/RemoveTeamMemberTest.php
@@ -4,8 +4,8 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Laravel\Jetstream\Http\Livewire\TeamMemberManager;
 use Laravel\Jetstream\Features;
+use Laravel\Jetstream\Http\Livewire\TeamMemberManager;
 use Livewire\Livewire;
 use Tests\TestCase;
 

--- a/stubs/tests/livewire/UpdateTeamMemberRoleTest.php
+++ b/stubs/tests/livewire/UpdateTeamMemberRoleTest.php
@@ -4,8 +4,8 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Laravel\Jetstream\Http\Livewire\TeamMemberManager;
 use Laravel\Jetstream\Features;
+use Laravel\Jetstream\Http\Livewire\TeamMemberManager;
 use Livewire\Livewire;
 use Tests\TestCase;
 

--- a/stubs/tests/livewire/UpdateTeamMemberRoleTest.php
+++ b/stubs/tests/livewire/UpdateTeamMemberRoleTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Jetstream\Http\Livewire\TeamMemberManager;
+use Laravel\Jetstream\Features;
 use Livewire\Livewire;
 use Tests\TestCase;
 
@@ -14,6 +15,10 @@ class UpdateTeamMemberRoleTest extends TestCase
 
     public function test_team_member_roles_can_be_updated()
     {
+        if (! Features::hasTeamFeatures()) {
+            return $this->markTestSkipped('Team support is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $user->currentTeam->users()->attach(
@@ -32,6 +37,10 @@ class UpdateTeamMemberRoleTest extends TestCase
 
     public function test_only_team_owner_can_update_team_member_roles()
     {
+        if (! Features::hasTeamFeatures()) {
+            return $this->markTestSkipped('Team support is not enabled.');
+        }
+
         $user = User::factory()->withPersonalTeam()->create();
 
         $user->currentTeam->users()->attach(

--- a/stubs/tests/livewire/UpdateTeamNameTest.php
+++ b/stubs/tests/livewire/UpdateTeamNameTest.php
@@ -4,8 +4,8 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Laravel\Jetstream\Http\Livewire\UpdateTeamNameForm;
 use Laravel\Jetstream\Features;
+use Laravel\Jetstream\Http\Livewire\UpdateTeamNameForm;
 use Livewire\Livewire;
 use Tests\TestCase;
 

--- a/stubs/tests/livewire/UpdateTeamNameTest.php
+++ b/stubs/tests/livewire/UpdateTeamNameTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Jetstream\Http\Livewire\UpdateTeamNameForm;
+use Laravel\Jetstream\Features;
 use Livewire\Livewire;
 use Tests\TestCase;
 
@@ -14,6 +15,10 @@ class UpdateTeamNameTest extends TestCase
 
     public function test_team_names_can_be_updated()
     {
+        if (! Features::hasTeamFeatures()) {
+            return $this->markTestSkipped('Team support is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         Livewire::test(UpdateTeamNameForm::class, ['team' => $user->currentTeam])


### PR DESCRIPTION
Disabling teams feature will make test fail.

Steps to replicate:
- Fresh install a laravel application: `laravel new myproject`
- Install jetstream: `composer require laravel/jetstream`
- run: `php artisan jetstream:install livewire --teams`
- Then disable team feature.
```
// path: config/jestream.php

...

'features' => [
    ...
    // Features::teams(['invitations' => true]),
    Features::accountDeletion(),
],

...
```

- Run test: `php artisan test`

This fix will make it easier to install Jetstream with teams. Disabled it if needed, and re-enabled it when your app is ready just like API token tests.

This fix is currently for livewire only. I can do inertia if this idea is good.
