### PR TITLE
Use custom TeamInvitation model in TeamInvitationController

### DIFF
--- a/src/Http/Controllers/TeamInvitationController.php
+++ b/src/Http/Controllers/TeamInvitationController.php
@@ -7,7 +7,7 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Gate;
 use Laravel\Jetstream\Contracts\AddsTeamMembers;
-use Laravel\Jetstream\TeamInvitation;
+use Laravel\Jetstream\Jetstream;
 
 class TeamInvitationController extends Controller
 {
@@ -15,11 +15,15 @@ class TeamInvitationController extends Controller
      * Accept a team invitation.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  \Laravel\Jetstream\TeamInvitation  $invitation
+     * @param  int  $invitationId
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function accept(Request $request, TeamInvitation $invitation)
+    public function accept(Request $request, $invitationId)
     {
+        $model = Jetstream::teamInvitationModel();
+
+        $invitation = $model::whereKey($invitationId)->firstOrFail();
+
         app(AddsTeamMembers::class)->add(
             $invitation->team->owner,
             $invitation->team,
@@ -38,11 +42,15 @@ class TeamInvitationController extends Controller
      * Cancel the given team invitation.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  \Laravel\Jetstream\TeamInvitation  $invitation
+     * @param  int  $invitationId
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function destroy(Request $request, TeamInvitation $invitation)
+    public function destroy(Request $request, $invitationId)
     {
+        $model = Jetstream::teamInvitationModel();
+
+        $invitation = $model::whereKey($invitationId)->firstOrFail();
+
         if (! Gate::forUser($request->user())->check('removeTeamMember', $invitation->team)) {
             throw new AuthorizationException;
         }


### PR DESCRIPTION
### Description
Use the custom `TeamInvitation` class in the `accept` and `destroy` methods of the `TeamInvitationController` to retrieve the invitation model.

### Motivation
Fixes #890. 

### Solution
**BREAKING**: Removes the type-hint from the controller methods. Therefore the model will not be resolved by the framework and the invitation id will be passed to the controller. Uses the invitation id and the Jetstream helper to query and retrieve an instance of the custom `TeamInvitation`. Uses `firstOrFail` as the route model binding responds with a `ModelNotFoundException` as well when an invalid id is passed.