### PR TITLE
simplify updateProfilePhoto function

### DIFF
--- a/src/HasProfilePhoto.php
+++ b/src/HasProfilePhoto.php
@@ -16,17 +16,15 @@ trait HasProfilePhoto
      */
     public function updateProfilePhoto(UploadedFile $photo)
     {
-        tap($this->profile_photo_path, function ($previous) use ($photo) {
-            $this->forceFill([
-                'profile_photo_path' => $photo->storePublicly(
-                    'profile-photos', ['disk' => $this->profilePhotoDisk()]
-                ),
-            ])->save();
+        $this->forceFill([
+            'profile_photo_path' => $photo->storePublicly(
+                'profile-photos', ['disk' => $this->profilePhotoDisk()]
+            ),
+        ])->save();
 
-            if ($previous) {
-                Storage::disk($this->profilePhotoDisk())->delete($previous);
-            }
-        });
+        if ($previous) {
+            Storage::disk($this->profilePhotoDisk())->delete($previous);
+        }
     }
 
     /**


### PR DESCRIPTION
there doesn't seem to be a reason to use tap for the `updateProfilePhoto` function, is there?

`@return void` in the updateProfilePhoto function description indicates that there isn't a return value. otherwise the function description should be updated.

in the only [usage of the updateProfilePhoto function](https://github.com/laravel/jetstream/blob/9663d7eb4e58ec86f105efb07f712fb81e6c92f2/stubs/app/Actions/Fortify/UpdateUserProfileInformation.php#L28) the return value of the function isn't used.

if devs currently rely on the function to return a value despite the function description, this PR might break their code.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

If you change the behavior of the Inertia stack you're expected to update the Livewire stack as well and vice versa.
-->
