### PR TITLE
Allow personal teams to be optional

### DIFF
--- a/config/jetstream.php
+++ b/config/jetstream.php
@@ -45,7 +45,7 @@ return [
         // Features::termsAndPrivacyPolicy(),
         // Features::profilePhotos(),
         // Features::api(),
-        // Features::teams(['invitations' => true]),
+        // Features::teams(['personal' => true, 'invitations' => true]),
         Features::accountDeletion(),
     ],
 

--- a/database/factories/TeamFactory.php
+++ b/database/factories/TeamFactory.php
@@ -5,6 +5,7 @@ namespace Database\Factories;
 use App\Models\Team;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Laravel\Jetstream\Features;
 
 class TeamFactory extends Factory
 {
@@ -25,7 +26,7 @@ class TeamFactory extends Factory
         return [
             'name' => $this->faker->unique()->company(),
             'user_id' => User::factory(),
-            'personal_team' => true,
+            'personal_team' => Features::createsPersonalTeam(),
         ];
     }
 }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -61,7 +61,7 @@ class UserFactory extends Factory
         return $this->has(
             Team::factory()
                 ->state(function (array $attributes, User $user) {
-                    return ['name' => $user->name.'\'s Team', 'user_id' => $user->id, 'personal_team' => true];
+                    return ['name' => $user->name.'\'s Team', 'user_id' => $user->id, 'personal_team' => Features::createsPersonalTeam()];
                 }),
             'ownedTeams'
         );

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -447,7 +447,7 @@ EOF;
         $this->callSilent('vendor:publish', ['--tag' => 'jetstream-team-migrations', '--force' => true]);
 
         // Configuration...
-        $this->replaceInFile('// Features::teams([\'invitations\' => true])', 'Features::teams([\'invitations\' => true])', config_path('jetstream.php'));
+        $this->replaceInFile('// Features::teams([\'personal\' => true, \'invitations\' => true])', 'Features::teams([\'personal\' => true, \'invitations\' => true])', config_path('jetstream.php'));
 
         // Directories...
         (new Filesystem)->ensureDirectoryExists(app_path('Actions/Jetstream'));

--- a/src/Features.php
+++ b/src/Features.php
@@ -59,6 +59,16 @@ class Features
     }
 
     /**
+     * Determine if a personal team is created on user registration.
+     *
+     * @return bool
+     */
+    public static function createsPersonalTeam()
+    {
+        return static::optionEnabled(static::teams(), 'personal');
+    }
+
+    /**
      * Determine if invitations are sent to team members.
      *
      * @return bool

--- a/src/HasTeams.php
+++ b/src/HasTeams.php
@@ -4,6 +4,7 @@ namespace Laravel\Jetstream;
 
 use Illuminate\Support\Str;
 use Laravel\Sanctum\HasApiTokens;
+use Laravel\Jetstream\Features;
 
 trait HasTeams
 {
@@ -93,7 +94,7 @@ trait HasTeams
      */
     public function personalTeam()
     {
-        return $this->ownedTeams->where('personal_team', true)->first();
+        return $this->ownedTeams->where('personal_team', Features::createsPersonalTeam())->first();
     }
 
     /**

--- a/src/HasTeams.php
+++ b/src/HasTeams.php
@@ -3,8 +3,8 @@
 namespace Laravel\Jetstream;
 
 use Illuminate\Support\Str;
-use Laravel\Sanctum\HasApiTokens;
 use Laravel\Jetstream\Features;
+use Laravel\Sanctum\HasApiTokens;
 
 trait HasTeams
 {

--- a/stubs/app/Actions/Fortify/CreateNewUserWithTeams.php
+++ b/stubs/app/Actions/Fortify/CreateNewUserWithTeams.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 use Laravel\Fortify\Contracts\CreatesNewUsers;
+use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Jetstream;
 
 class CreateNewUser implements CreatesNewUsers
@@ -48,10 +49,12 @@ class CreateNewUser implements CreatesNewUsers
      */
     protected function createTeam(User $user)
     {
-        $user->ownedTeams()->save(Team::forceCreate([
-            'user_id' => $user->id,
-            'name' => explode(' ', $user->name, 2)[0]."'s Team",
-            'personal_team' => true,
-        ]));
+        if (Features::createsPersonalTeam()) {
+            $user->ownedTeams()->save(Team::forceCreate([
+                'user_id' => $user->id,
+                'name' => explode(' ', $user->name, 2)[0]."'s Team",
+                'personal_team' => true,
+            ]));
+        }
     }
 }

--- a/stubs/inertia/resources/js/Layouts/AppLayout.vue
+++ b/stubs/inertia/resources/js/Layouts/AppLayout.vue
@@ -26,7 +26,7 @@
                         </div>
 
                         <div class="hidden sm:flex sm:items-center sm:ml-6">
-                            <div class="ml-3 relative">
+                            <div class="ml-3 relative" v-if="$page.props.user.current_team">
                                 <!-- Teams Dropdown -->
                                 <jet-dropdown align="right" width="60" v-if="$page.props.jetstream.hasTeamFeatures">
                                     <template #trigger>
@@ -79,6 +79,12 @@
                                         </div>
                                     </template>
                                 </jet-dropdown>
+                            </div>
+
+                            <div class="ml-3 relative" v-if="!$page.props.user.current_team && $page.props.jetstream.canCreateTeams">
+                                <Link :href="route('teams.create')" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring focus:ring-gray-300 disabled:opacity-25 transition">
+                                    Create New Team
+                                </Link>
                             </div>
 
                             <!-- Settings Dropdown -->
@@ -178,37 +184,45 @@
 
                             <!-- Team Management -->
                             <template v-if="$page.props.jetstream.hasTeamFeatures">
-                                <div class="border-t border-gray-200"></div>
+                                <template v-if="$page.props.user.current_team">
+                                    <div class="border-t border-gray-200"></div>
 
-                                <div class="block px-4 py-2 text-xs text-gray-400">
-                                    Manage Team
-                                </div>
+                                    <div class="block px-4 py-2 text-xs text-gray-400">
+                                        Manage Team
+                                    </div>
 
-                                <!-- Team Settings -->
-                                <jet-responsive-nav-link :href="route('teams.show', $page.props.user.current_team)" :active="route().current('teams.show')">
-                                    Team Settings
-                                </jet-responsive-nav-link>
+                                    <!-- Team Settings -->
+                                    <jet-responsive-nav-link :href="route('teams.show', $page.props.user.current_team)" :active="route().current('teams.show')">
+                                        Team Settings
+                                    </jet-responsive-nav-link>
 
-                                <jet-responsive-nav-link :href="route('teams.create')" :active="route().current('teams.create')" v-if="$page.props.jetstream.canCreateTeams">
-                                    Create New Team
-                                </jet-responsive-nav-link>
+                                    <jet-responsive-nav-link :href="route('teams.create')" :active="route().current('teams.create')" v-if="$page.props.jetstream.canCreateTeams">
+                                        Create New Team
+                                    </jet-responsive-nav-link>
 
-                                <div class="border-t border-gray-200"></div>
+                                    <div class="border-t border-gray-200"></div>
 
-                                <!-- Team Switcher -->
-                                <div class="block px-4 py-2 text-xs text-gray-400">
-                                    Switch Teams
-                                </div>
+                                    <!-- Team Switcher -->
+                                    <div class="block px-4 py-2 text-xs text-gray-400">
+                                        Switch Teams
+                                    </div>
 
-                                <template v-for="team in $page.props.user.all_teams" :key="team.id">
-                                    <form @submit.prevent="switchToTeam(team)">
-                                        <jet-responsive-nav-link as="button">
-                                            <div class="flex items-center">
-                                                <svg v-if="team.id == $page.props.user.current_team_id" class="mr-2 h-5 w-5 text-green-400" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" stroke="currentColor" viewBox="0 0 24 24"><path d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
-                                                <div>{{ team.name }}</div>
-                                            </div>
-                                        </jet-responsive-nav-link>
-                                    </form>
+                                    <template v-for="team in $page.props.user.all_teams" :key="team.id">
+                                        <form @submit.prevent="switchToTeam(team)">
+                                            <jet-responsive-nav-link as="button">
+                                                <div class="flex items-center">
+                                                    <svg v-if="team.id == $page.props.user.current_team_id" class="mr-2 h-5 w-5 text-green-400" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" stroke="currentColor" viewBox="0 0 24 24"><path d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+                                                    <div>{{ team.name }}</div>
+                                                </div>
+                                            </jet-responsive-nav-link>
+                                        </form>
+                                    </template>
+                                </template>
+
+                                <template v-else>
+                                    <jet-responsive-nav-link :href="route('teams.create')" :active="route().current('teams.create')" v-if="$page.props.jetstream.canCreateTeams">
+                                        Create New Team
+                                    </jet-responsive-nav-link>
                                 </template>
                             </template>
                         </div>

--- a/stubs/livewire/resources/views/navigation-menu.blade.php
+++ b/stubs/livewire/resources/views/navigation-menu.blade.php
@@ -21,52 +21,62 @@
             <div class="hidden sm:flex sm:items-center sm:ml-6">
                 <!-- Teams Dropdown -->
                 @if (Laravel\Jetstream\Jetstream::hasTeamFeatures())
-                    <div class="ml-3 relative">
-                        <x-jet-dropdown align="right" width="60">
-                            <x-slot name="trigger">
-                                <span class="inline-flex rounded-md">
-                                    <button type="button" class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-gray-500 bg-white hover:bg-gray-50 hover:text-gray-700 focus:outline-none focus:bg-gray-50 active:bg-gray-50 transition">
-                                        {{ Auth::user()->currentTeam->name }}
+                    @if (Auth::user()->currentTeam)
+                        <div class="ml-3 relative">
+                            <x-jet-dropdown align="right" width="60">
+                                <x-slot name="trigger">
+                                    <span class="inline-flex rounded-md">
+                                        <button type="button" class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-gray-500 bg-white hover:bg-gray-50 hover:text-gray-700 focus:outline-none focus:bg-gray-50 active:bg-gray-50 transition">
+                                            {{ Auth::user()->currentTeam->name }}
 
-                                        <svg class="ml-2 -mr-0.5 h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-                                            <path fill-rule="evenodd" d="M10 3a1 1 0 01.707.293l3 3a1 1 0 01-1.414 1.414L10 5.414 7.707 7.707a1 1 0 01-1.414-1.414l3-3A1 1 0 0110 3zm-3.707 9.293a1 1 0 011.414 0L10 14.586l2.293-2.293a1 1 0 011.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z" clip-rule="evenodd" />
-                                        </svg>
-                                    </button>
-                                </span>
-                            </x-slot>
+                                            <svg class="ml-2 -mr-0.5 h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+                                                <path fill-rule="evenodd" d="M10 3a1 1 0 01.707.293l3 3a1 1 0 01-1.414 1.414L10 5.414 7.707 7.707a1 1 0 01-1.414-1.414l3-3A1 1 0 0110 3zm-3.707 9.293a1 1 0 011.414 0L10 14.586l2.293-2.293a1 1 0 011.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z" clip-rule="evenodd" />
+                                            </svg>
+                                        </button>
+                                    </span>
+                                </x-slot>
 
-                            <x-slot name="content">
-                                <div class="w-60">
-                                    <!-- Team Management -->
-                                    <div class="block px-4 py-2 text-xs text-gray-400">
-                                        {{ __('Manage Team') }}
-                                    </div>
+                                <x-slot name="content">
+                                    <div class="w-60">
+                                        <!-- Team Management -->
+                                        <div class="block px-4 py-2 text-xs text-gray-400">
+                                            {{ __('Manage Team') }}
+                                        </div>
 
-                                    <!-- Team Settings -->
-                                    <x-jet-dropdown-link href="{{ route('teams.show', Auth::user()->currentTeam->id) }}">
-                                        {{ __('Team Settings') }}
-                                    </x-jet-dropdown-link>
-
-                                    @can('create', Laravel\Jetstream\Jetstream::newTeamModel())
-                                        <x-jet-dropdown-link href="{{ route('teams.create') }}">
-                                            {{ __('Create New Team') }}
+                                        <!-- Team Settings -->
+                                        <x-jet-dropdown-link href="{{ route('teams.show', Auth::user()->currentTeam->id) }}">
+                                            {{ __('Team Settings') }}
                                         </x-jet-dropdown-link>
-                                    @endcan
 
-                                    <div class="border-t border-gray-100"></div>
+                                        @can('create', Laravel\Jetstream\Jetstream::newTeamModel())
+                                            <x-jet-dropdown-link href="{{ route('teams.create') }}">
+                                                {{ __('Create New Team') }}
+                                            </x-jet-dropdown-link>
+                                        @endcan
 
-                                    <!-- Team Switcher -->
-                                    <div class="block px-4 py-2 text-xs text-gray-400">
-                                        {{ __('Switch Teams') }}
+                                        <div class="border-t border-gray-100"></div>
+
+                                        <!-- Team Switcher -->
+                                        <div class="block px-4 py-2 text-xs text-gray-400">
+                                            {{ __('Switch Teams') }}
+                                        </div>
+
+                                        @foreach (Auth::user()->allTeams() as $team)
+                                            <x-jet-switchable-team :team="$team" />
+                                        @endforeach
                                     </div>
-
-                                    @foreach (Auth::user()->allTeams() as $team)
-                                        <x-jet-switchable-team :team="$team" />
-                                    @endforeach
-                                </div>
-                            </x-slot>
-                        </x-jet-dropdown>
-                    </div>
+                                </x-slot>
+                            </x-jet-dropdown>
+                        </div>
+                    @else
+                        @can('create', Laravel\Jetstream\Jetstream::newTeamModel())
+                            <div class="ml-3 relative">
+                                <a href="{{ route('teams.create') }}" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring focus:ring-gray-300 disabled:opacity-25 transition">
+                                    {{ __('Create New Team') }}
+                                </a>
+                            </div>
+                        @endcan
+                    @endif
                 @endif
 
                 <!-- Settings Dropdown -->
@@ -183,33 +193,41 @@
 
                 <!-- Team Management -->
                 @if (Laravel\Jetstream\Jetstream::hasTeamFeatures())
-                    <div class="border-t border-gray-200"></div>
+                    @if (Auth::user()->currentTeam)
+                        <div class="border-t border-gray-200"></div>
 
-                    <div class="block px-4 py-2 text-xs text-gray-400">
-                        {{ __('Manage Team') }}
-                    </div>
+                        <div class="block px-4 py-2 text-xs text-gray-400">
+                            {{ __('Manage Team') }}
+                        </div>
 
-                    <!-- Team Settings -->
-                    <x-jet-responsive-nav-link href="{{ route('teams.show', Auth::user()->currentTeam->id) }}" :active="request()->routeIs('teams.show')">
-                        {{ __('Team Settings') }}
-                    </x-jet-responsive-nav-link>
-
-                    @can('create', Laravel\Jetstream\Jetstream::newTeamModel())
-                        <x-jet-responsive-nav-link href="{{ route('teams.create') }}" :active="request()->routeIs('teams.create')">
-                            {{ __('Create New Team') }}
+                        <!-- Team Settings -->
+                        <x-jet-responsive-nav-link href="{{ route('teams.show', Auth::user()->currentTeam->id) }}" :active="request()->routeIs('teams.show')">
+                            {{ __('Team Settings') }}
                         </x-jet-responsive-nav-link>
-                    @endcan
 
-                    <div class="border-t border-gray-200"></div>
+                        @can('create', Laravel\Jetstream\Jetstream::newTeamModel())
+                            <x-jet-responsive-nav-link href="{{ route('teams.create') }}" :active="request()->routeIs('teams.create')">
+                                {{ __('Create New Team') }}
+                            </x-jet-responsive-nav-link>
+                        @endcan
 
-                    <!-- Team Switcher -->
-                    <div class="block px-4 py-2 text-xs text-gray-400">
-                        {{ __('Switch Teams') }}
-                    </div>
+                        <div class="border-t border-gray-200"></div>
 
-                    @foreach (Auth::user()->allTeams() as $team)
-                        <x-jet-switchable-team :team="$team" component="jet-responsive-nav-link" />
-                    @endforeach
+                        <!-- Team Switcher -->
+                        <div class="block px-4 py-2 text-xs text-gray-400">
+                            {{ __('Switch Teams') }}
+                        </div>
+
+                        @foreach (Auth::user()->allTeams() as $team)
+                            <x-jet-switchable-team :team="$team" component="jet-responsive-nav-link" />
+                        @endforeach
+                    @else
+                        @can('create', Laravel\Jetstream\Jetstream::newTeamModel())
+                            <x-jet-responsive-nav-link href="{{ route('teams.create') }}" :active="request()->routeIs('teams.create')">
+                                {{ __('Create New Team') }}
+                            </x-jet-responsive-nav-link>
+                        @endcan
+                    @endif
                 @endif
             </div>
         </div>

--- a/stubs/tests/inertia/DeleteTeamTest.php
+++ b/stubs/tests/inertia/DeleteTeamTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Models\Team;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Jetstream\Features;
 use Tests\TestCase;
 
 class DeleteTeamTest extends TestCase
@@ -31,6 +32,10 @@ class DeleteTeamTest extends TestCase
 
     public function test_personal_teams_cant_be_deleted()
     {
+        if (! Features::createsPersonalTeam()) {
+            return $this->markTestSkipped('Personal teams are not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $response = $this->delete('/teams/'.$user->currentTeam->id);

--- a/stubs/tests/livewire/DeleteTeamTest.php
+++ b/stubs/tests/livewire/DeleteTeamTest.php
@@ -5,8 +5,8 @@ namespace Tests\Feature;
 use App\Models\Team;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Laravel\Jetstream\Http\Livewire\DeleteTeamForm;
 use Laravel\Jetstream\Features;
+use Laravel\Jetstream\Http\Livewire\DeleteTeamForm;
 use Livewire\Livewire;
 use Tests\TestCase;
 

--- a/stubs/tests/livewire/DeleteTeamTest.php
+++ b/stubs/tests/livewire/DeleteTeamTest.php
@@ -6,6 +6,7 @@ use App\Models\Team;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Jetstream\Http\Livewire\DeleteTeamForm;
+use Laravel\Jetstream\Features;
 use Livewire\Livewire;
 use Tests\TestCase;
 
@@ -34,6 +35,10 @@ class DeleteTeamTest extends TestCase
 
     public function test_personal_teams_cant_be_deleted()
     {
+        if (! Features::createsPersonalTeam()) {
+            return $this->markTestSkipped('Personal teams are not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $component = Livewire::test(DeleteTeamForm::class, ['team' => $user->currentTeam])

--- a/tests/TeamBehaviorTest.php
+++ b/tests/TeamBehaviorTest.php
@@ -4,9 +4,9 @@ namespace Laravel\Jetstream\Tests;
 
 use App\Actions\Jetstream\CreateTeam;
 use Illuminate\Support\Facades\Gate;
+use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Jetstream;
 use Laravel\Jetstream\Team;
-use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Tests\Fixtures\TeamPolicy;
 use Laravel\Jetstream\Tests\Fixtures\User;
 use Laravel\Sanctum\Sanctum;

--- a/tests/TeamBehaviorTest.php
+++ b/tests/TeamBehaviorTest.php
@@ -42,7 +42,7 @@ class TeamBehaviorTest extends OrchestraTestCase
         $this->assertCount(1, $user->fresh()->ownedTeams);
         $this->assertCount(1, $user->fresh()->allTeams());
 
-        $team->forceFill(['personal_team' => true])->save();
+        $team->forceFill(['personal_team' => Features::createsPersonalTeam()])->save();
 
         $this->assertEquals($team->id, $user->fresh()->personalTeam()->id);
         $this->assertEquals($team->id, $user->fresh()->currentTeam->id);
@@ -143,7 +143,7 @@ class TeamBehaviorTest extends OrchestraTestCase
 
         $personalTeam = $action->create($user, ['name' => 'Personal Team']);
 
-        $personalTeam->forceFill(['personal_team' => true])->save();
+        $personalTeam->forceFill(['personal_team' => Features::createsPersonalTeam()])->save();
 
         $this->assertTrue($user->isCurrentTeam($personalTeam));
 

--- a/tests/TeamBehaviorTest.php
+++ b/tests/TeamBehaviorTest.php
@@ -6,6 +6,7 @@ use App\Actions\Jetstream\CreateTeam;
 use Illuminate\Support\Facades\Gate;
 use Laravel\Jetstream\Jetstream;
 use Laravel\Jetstream\Team;
+use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Tests\Fixtures\TeamPolicy;
 use Laravel\Jetstream\Tests\Fixtures\User;
 use Laravel\Sanctum\Sanctum;


### PR DESCRIPTION
The PR makes personal teams still default on a new install but has the option of disabling. This will allow a broader use of this package where registering a user doesn't create a personal team. This behavior is controlled by the `config/jetstream.php` file:

```PHP
Features::teams(['personal' => true, 'invitations' => true]),
```

The default behavior on a new install is unchanged. When enabled, personal teams still cannot be deleted. When disabled, no personal team is created at the time of user registration and allows the user to not be a member of any team. Team creation is still controlled by the `create` team gate in both cases. Both inertia and livewire templates have been updated and all tests pass.

The installer should decide during activation of the teams feature if this option should be enabled or disabled.
 