### PR TITLE
Use KeyboardEvent `key` attribute for Escape

### DIFF
--- a/stubs/inertia/resources/js/Jetstream/Dropdown.vue
+++ b/stubs/inertia/resources/js/Jetstream/Dropdown.vue
@@ -48,7 +48,7 @@ export default defineComponent({
         let open = ref(false)
 
         const closeOnEscape = (e) => {
-            if (open.value && e.keyCode === 27) {
+            if (open.value && e.key === 'Escape') {
                 open.value = false
             }
         }


### PR DESCRIPTION
Use KeyboardEvent `key` attribute for Escape instead of deprecated `keyCode`.

See https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

If you change the behavior of the Inertia stack you're expected to update the Livewire stack as well and vice versa.
-->
