### PR TITLE
Replaced hardcoded password validation message on LogoutOtherBrowserS…

### DIFF
--- a/src/Http/Livewire/LogoutOtherBrowserSessionsForm.php
+++ b/src/Http/Livewire/LogoutOtherBrowserSessionsForm.php
@@ -53,7 +53,7 @@ class LogoutOtherBrowserSessionsForm extends Component
 
         if (! Hash::check($this->password, Auth::user()->password)) {
             throw ValidationException::withMessages([
-                'password' => [__('This password does not match our records.')],
+                'password' => [__(trans('validation.password'))],
             ]);
         }
 


### PR DESCRIPTION
Since threre is no way to customize the LogoutOtherBrowserSessionsForm it would be great if the validations messages use the lang files of the application.