### PR TITLE
Change stub from http://localhost:3000 to the config APP_URL

### DIFF
--- a/stubs/inertia/resources/views/app.blade.php
+++ b/stubs/inertia/resources/views/app.blade.php
@@ -20,7 +20,7 @@
         @inertia
 
         @env ('local')
-            <script src="http://localhost:3000/browser-sync/browser-sync-client.js"></script>
+            <script src="{{ config('app.url', 'http://localhost') }}:3000/browser-sync/browser-sync-client.js"></script>
         @endenv
     </body>
 </html>


### PR DESCRIPTION
When working on a custom domain name like when using Valet is a better option to have only one place to change the application URL.