### PR TITLE
Correct PHP DocBlock reference

### DIFF
--- a/src/HasTeams.php
+++ b/src/HasTeams.php
@@ -53,7 +53,7 @@ trait HasTeams
     /**
      * Get all of the teams the user owns or belongs to.
      *
-     * @return \Illuminate\Collections\Collection
+     * @return \Illuminate\Support\Collection
      */
     public function allTeams()
     {


### PR DESCRIPTION
Quick fix for #924, which I appreciate was closed, but since this is fixed in 2.x, thought maybe it could sneak through. 😅 