### PR TITLE
Remove JIT mode from tailwind config

### DIFF
--- a/stubs/inertia/tailwind.config.js
+++ b/stubs/inertia/tailwind.config.js
@@ -1,7 +1,6 @@
 const defaultTheme = require('tailwindcss/defaultTheme');
 
 module.exports = {
-    mode: 'jit',
     content: [
         './vendor/laravel/framework/src/Illuminate/Pagination/resources/views/*.blade.php',
         './vendor/laravel/jetstream/**/*.blade.php',

--- a/stubs/livewire/tailwind.config.js
+++ b/stubs/livewire/tailwind.config.js
@@ -1,7 +1,6 @@
 const defaultTheme = require('tailwindcss/defaultTheme');
 
 module.exports = {
-    mode: 'jit',
     content: [
         './vendor/laravel/framework/src/Illuminate/Pagination/resources/views/*.blade.php',
         './vendor/laravel/jetstream/**/*.blade.php',


### PR DESCRIPTION
Since Jetstream is using TailwindCSS 3.x (#920) there aren't other modes than Just in Time supported anymore. 
The JIT mode is used by default.
So the mode:'jit' config entry can completely be  removed.
[Upgrade Guide for reference](https://tailwindcss.com/docs/upgrade-guide#migrating-to-the-jit-engine)

The config files should be clean and should not contain unnecessary entries.


