### PR TITLE
Typo: Pest AuthenticationTest

### DIFF
--- a/stubs/pest-tests/AuthenticationTest.php
+++ b/stubs/pest-tests/AuthenticationTest.php
@@ -21,7 +21,7 @@ test('users can authenticate using the login screen', function () {
     $response->assertRedirect(RouteServiceProvider::HOME);
 });
 
-test('users can not authenticate with invalid_password', function () {
+test('users cannot authenticate with invalid password', function () {
     $user = User::factory()->create();
 
     $this->post('/login', [


### PR DESCRIPTION
Changes:

From:
- 'users can not authenticate with invalid_password'

To:
- 'users cannot authenticate with invalid password'