### PR TITLE
Show 'Unknown' instead of 'false' if other browser session Useragent details are not matched in library

### DIFF
--- a/stubs/inertia/resources/js/Pages/Profile/Partials/LogoutOtherBrowserSessionsForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/Partials/LogoutOtherBrowserSessionsForm.vue
@@ -28,7 +28,7 @@
 
                     <div class="ml-3">
                         <div class="text-sm text-gray-600">
-                            {{ session.agent.platform }} - {{ session.agent.browser }}
+                            {{ session.agent.platform ? session.agent.platform : 'Unknown' }} - {{ session.agent.browser ? session.agent.browser : 'Unknown' }}
                         </div>
 
                         <div>

--- a/stubs/livewire/resources/views/profile/logout-other-browser-sessions-form.blade.php
+++ b/stubs/livewire/resources/views/profile/logout-other-browser-sessions-form.blade.php
@@ -31,7 +31,7 @@
 
                         <div class="ml-3">
                             <div class="text-sm text-gray-600">
-                                {{ $session->agent->platform() }} - {{ $session->agent->browser() }}
+                                {{ $session->agent->platform() ? $session->agent->platform() : 'Unknown' }} - {{ $session->agent->browser() ? $session->agent->browser() : 'Unknown' }}
                             </div>
 
                             <div>


### PR DESCRIPTION
This pull request fixes an incorrect behavior of the 'Logout Other Browser Sessions' session list. If any of the browser's details are not matched in the jenssegers/agent library, currently it is displayed as 'false,' directly showing the output of the library which intentionally returns false if there is no match.

This pull request changes this to show as 'Unknown.' This seems a suitable term, as it is searching known browsers.

As requested in the contribution guide, I made this change in both Inertia and Livewire.

[Screenshot before](https://www.jonhassall.com/assets/2021/12/FalseSS.png)
[Screenshot after](https://www.jonhassall.com/assets/2021/12/FixedSS.png)