### PR TITLE
Gravatar for default profile photo url with UI-Avatars as fallback

### DIFF
--- a/config/jetstream.php
+++ b/config/jetstream.php
@@ -55,11 +55,37 @@ return [
     |--------------------------------------------------------------------------
     |
     | This configuration value determines the default disk that will be used
-    | when storing profile photos for your application's users. Typically
-    | this will be the "public" disk but you may adjust this if needed.
+    | when storing profile photos for your application's users. Typically,
+    | this will be the "public" disk, but you may adjust this if needed.
     |
     */
 
     'profile_photo_disk' => 'public',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Profile Photo Fallback Image
+    |--------------------------------------------------------------------------
+    |
+    | This configuration value determines the default image that is used as a
+    | fallback if the user has not stored a profile photo.
+    | By default, we use Gravatar images with UI-Avatars as a fallback.
+    |
+    | Possible values for profile_photo_fallback.default_image:
+    | mp|identicon|monsterid|wavatar|retro|robohash|blank|initials
+    | (see http://gravatar.com/site/implement/images/)
+    | 'initials' (default) is a special extension where we use ui-avatars.com as
+    | a Gravatar fallback service to generate avatars with initials from names.
+    |
+    */
+
+    'profile_photo_fallback' => [
+        'default_image' => 'initials',
+        'initials' => [
+            'size'  => 64,
+            'bg'    => 'ebf4ff',
+            'color' => '7f9cf5',
+        ],
+    ],
 
 ];

--- a/src/HasProfilePhoto.php
+++ b/src/HasProfilePhoto.php
@@ -70,14 +70,14 @@ trait HasProfilePhoto
      */
     protected function defaultProfilePhotoUrl()
     {
-        $hash         = md5(strtolower(trim($this->email)));
+        $hash = md5(strtolower(trim($this->email)));
         $defaultImage = config('jetstream.profile_photo_fallback.default_image', 'initials');
 
         if ($defaultImage === 'initials') {
-            $name     = urlencode($this->name); // name needs to be double-urlencoded for Gravatar fallback URL
-            $size     = config('jetstream.profile_photo_fallback.initials.size', 64);
-            $bg       = config('jetstream.profile_photo_fallback.initials.bg', 'ebf4ff');
-            $color    = config('jetstream.profile_photo_fallback.initials.color', '7f9cf5');
+            $name = urlencode($this->name); // name needs to be double-urlencoded for Gravatar fallback URL
+            $size = config('jetstream.profile_photo_fallback.initials.size', 64);
+            $bg = config('jetstream.profile_photo_fallback.initials.bg', 'ebf4ff');
+            $color = config('jetstream.profile_photo_fallback.initials.color', '7f9cf5');
             $fallback = urlencode("https://ui-avatars.com/api/{$name}/{$size}/{$bg}/{$color}");
         } else {
             $fallback = $defaultImage;

--- a/src/HasProfilePhoto.php
+++ b/src/HasProfilePhoto.php
@@ -62,11 +62,28 @@ trait HasProfilePhoto
     /**
      * Get the default profile photo URL if no profile photo has been uploaded.
      *
+     * Using Gravatar with UI-Avatars as fallback. Like this, we get all avatars delivered by Gravatar with
+     * the following bonus: Prevent rate-limiting (ui-avatars.com uses Cloudflare that blocks fast, while Gravatar
+     * has virtually no rate-limiting), nice UI-Avatars with initials (which is currently not offered by Gravatar).
+     *
      * @return string
      */
     protected function defaultProfilePhotoUrl()
     {
-        return 'https://ui-avatars.com/api/?name='.urlencode($this->name).'&color=7F9CF5&background=EBF4FF';
+        $hash         = md5(strtolower(trim($this->email)));
+        $defaultImage = config('jetstream.profile_photo_fallback.default_image', 'initials');
+
+        if ($defaultImage === 'initials') {
+            $name     = urlencode($this->name); // name needs to be double-urlencoded for Gravatar fallback URL
+            $size     = config('jetstream.profile_photo_fallback.initials.size', 64);
+            $bg       = config('jetstream.profile_photo_fallback.initials.bg', 'ebf4ff');
+            $color    = config('jetstream.profile_photo_fallback.initials.color', '7f9cf5');
+            $fallback = urlencode("https://ui-avatars.com/api/{$name}/{$size}/{$bg}/{$color}");
+        } else {
+            $fallback = $defaultImage;
+        }
+
+        return "https://www.gravatar.com/avatar/{$hash}?d={$fallback}";
     }
 
     /**


### PR DESCRIPTION
Make the default profile photo more configurable.

By default, using Gravatar with UI-Avatars as fallback. Like this, we get all avatars delivered by Gravatar with the following bonus:

- Prevent rate-limiting (ui-avatars.com uses Cloudflare that blocks you fast, while Gravatar has virtually no rate-limiting)
- Nice UI-Avatars with initials (which is currently not offered by Gravatar) as it was before
- Let the user configure other Gravatar default images like `mp|identicon|monsterid|wavatar|retro|robohash|blank`

If you want to use this before it gets merged, simply "extend" the Jetstream trait and use your own:

```php
<?php

namespace App\Traits;

trait HasProfilePhoto
{
    use \Laravel\Jetstream\HasProfilePhoto;

    protected function defaultProfilePhotoUrl()
    {
        $hash         = md5(strtolower(trim($this->email)));
        $defaultImage = config('jetstream.profile_photo_fallback.default_image', 'initials');

        if ($defaultImage === 'initials') {
            $name     = urlencode($this->name); // name needs to be double-urlencoded for Gravatar fallback URL
            $size     = config('jetstream.profile_photo_fallback.initials.size', 64);
            $bg       = config('jetstream.profile_photo_fallback.initials.bg', 'ebf4ff');
            $color    = config('jetstream.profile_photo_fallback.initials.color', '7f9cf5');
            $fallback = urlencode("https://ui-avatars.com/api/{$name}/{$size}/{$bg}/{$color}");
        } else {
            $fallback = $defaultImage;
        }

        return "https://www.gravatar.com/avatar/{$hash}?d={$fallback}";
    }
}
```