### PR TITLE
Generate default profile avatar locally if it is supported.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "ext-json": "*",
         "illuminate/support": "^8.0",
         "jenssegers/agent": "^2.6",
-        "laravel/fortify": "^1.6.1"
+        "laravel/fortify": "^1.6.1",
+        "lasserafn/php-initial-avatar-generator": "^4.2"
     },
     "require-dev": {
         "inertiajs/inertia-laravel": "^0.3",

--- a/src/HasProfilePhoto.php
+++ b/src/HasProfilePhoto.php
@@ -73,7 +73,7 @@ trait HasProfilePhoto
         try {
             $avatar = new InitialAvatar();
 
-            return $avatar->name($this->name)->color('#7F9CF5')->background('#EBF4FF')->size(100)->generate()->encode('data-url');
+            return $avatar->name($this->name)->color('#7F9CF5')->background('#EBF4FF')->size(100)->generate()->encode('data-url')->encoded;
         } catch (NotSupportedException|MissingDependencyException $e) {
             $name = trim(collect(explode(' ', $this->name))->map(function ($segment) {
                 return $segment[0] ?? '';

--- a/src/HasProfilePhoto.php
+++ b/src/HasProfilePhoto.php
@@ -6,6 +6,8 @@ use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Laravel\Jetstream\Features;
+use LasseRafn\InitialAvatarGenerator\InitialAvatar;
+use Intervention\Image\Exception\NotSupportedException;
 
 trait HasProfilePhoto
 {
@@ -67,11 +69,17 @@ trait HasProfilePhoto
      */
     protected function defaultProfilePhotoUrl()
     {
-        $name = trim(collect(explode(' ', $this->name))->map(function ($segment) {
-            return $segment[0] ?? '';
-        })->join(' '));
-
-        return 'https://ui-avatars.com/api/?name='.urlencode($name).'&color=7F9CF5&background=EBF4FF';
+        try {
+            $avatar = new InitialAvatar();
+        
+            return $avatar->name($this->name)->color('#7F9CF5')->background('#EBF4FF')->size(100)->generate()->encode('data-url');
+        } catch (NotSupportedException $e) {
+            $name = trim(collect(explode(' ', $this->name))->map(function ($segment) {
+                return $segment[0] ?? '';
+            })->join(' '));
+    
+            return 'https://ui-avatars.com/api/?name='.urlencode($name).'&color=7F9CF5&background=EBF4FF';
+        }
     }
 
     /**

--- a/src/HasProfilePhoto.php
+++ b/src/HasProfilePhoto.php
@@ -74,7 +74,7 @@ trait HasProfilePhoto
             $avatar = new InitialAvatar();
 
             return $avatar->name($this->name)->color('#7F9CF5')->background('#EBF4FF')->size(100)->generate()->encode('data-url');
-        } catch (NotSupportedException | MissingDependencyException $e) {
+        } catch (NotSupportedException|MissingDependencyException $e) {
             $name = trim(collect(explode(' ', $this->name))->map(function ($segment) {
                 return $segment[0] ?? '';
             })->join(' '));

--- a/src/HasProfilePhoto.php
+++ b/src/HasProfilePhoto.php
@@ -4,7 +4,6 @@ namespace Laravel\Jetstream;
 
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
-use Illuminate\Support\Str;
 use Intervention\Image\Exception\MissingDependencyException;
 use Intervention\Image\Exception\NotSupportedException;
 use Laravel\Jetstream\Features;

--- a/src/HasProfilePhoto.php
+++ b/src/HasProfilePhoto.php
@@ -5,9 +5,9 @@ namespace Laravel\Jetstream;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use Intervention\Image\Exception\NotSupportedException;
 use Laravel\Jetstream\Features;
 use LasseRafn\InitialAvatarGenerator\InitialAvatar;
-use Intervention\Image\Exception\NotSupportedException;
 
 trait HasProfilePhoto
 {
@@ -71,13 +71,13 @@ trait HasProfilePhoto
     {
         try {
             $avatar = new InitialAvatar();
-        
+
             return $avatar->name($this->name)->color('#7F9CF5')->background('#EBF4FF')->size(100)->generate()->encode('data-url');
         } catch (NotSupportedException $e) {
             $name = trim(collect(explode(' ', $this->name))->map(function ($segment) {
                 return $segment[0] ?? '';
             })->join(' '));
-    
+
             return 'https://ui-avatars.com/api/?name='.urlencode($name).'&color=7F9CF5&background=EBF4FF';
         }
     }

--- a/src/HasProfilePhoto.php
+++ b/src/HasProfilePhoto.php
@@ -5,6 +5,7 @@ namespace Laravel\Jetstream;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use Intervention\Image\Exception\MissingDependencyException;
 use Intervention\Image\Exception\NotSupportedException;
 use Laravel\Jetstream\Features;
 use LasseRafn\InitialAvatarGenerator\InitialAvatar;
@@ -73,7 +74,7 @@ trait HasProfilePhoto
             $avatar = new InitialAvatar();
 
             return $avatar->name($this->name)->color('#7F9CF5')->background('#EBF4FF')->size(100)->generate()->encode('data-url');
-        } catch (NotSupportedException $e) {
+        } catch (NotSupportedException | MissingDependencyException $e) {
             $name = trim(collect(explode(' ', $this->name))->map(function ($segment) {
                 return $segment[0] ?? '';
             })->join(' '));


### PR DESCRIPTION
Rather than using a third party service to generate the avatar, it is better if we generate the avatar locally. That way it can load faster, and we can still fallback to third party service if it is not possible to generate it due to lack of gd or imagick PHP extension.
