### PR TITLE
Route group Sanctum guard

### DIFF
--- a/routes/inertia.php
+++ b/routes/inertia.php
@@ -20,7 +20,7 @@ Route::group(['middleware' => config('jetstream.middleware', ['web'])], function
         Route::get('/privacy-policy', [PrivacyPolicyController::class, 'show'])->name('policy.show');
     }
 
-    Route::group(['middleware' => ['auth', 'verified']], function () {
+    Route::group(['middleware' => ['auth:sanctum', 'verified']], function () {
         // User & Profile...
         Route::get('/user/profile', [UserProfileController::class, 'show'])
                     ->name('profile.show');

--- a/routes/livewire.php
+++ b/routes/livewire.php
@@ -16,7 +16,7 @@ Route::group(['middleware' => config('jetstream.middleware', ['web'])], function
         Route::get('/privacy-policy', [PrivacyPolicyController::class, 'show'])->name('policy.show');
     }
 
-    Route::group(['middleware' => ['auth', 'verified']], function () {
+    Route::group(['middleware' => ['auth:sanctum', 'verified']], function () {
         // User & Profile...
         Route::get('/user/profile', [UserProfileController::class, 'show'])
                     ->name('profile.show');


### PR DESCRIPTION
This addresses my issue in #956.

I believe there is a problem in the livewire and inertia route files with respect to using the default auth middleware instead of the auth:sanctum middleware which is used in the stubs for the dashboard route. This problem prevents me from using the new auth guard I've created to view the profile route because it does not respect the sanctum guard and there is no other way I see to change what guard this route group uses. I've tested this change and when implemented it allows me to correctly access the profile route as expected with my new auth guard.

I believe this could also be solved in a similar way to Fortify:

`
config('fortify.auth_middleware', 'auth').':'.config('fortify.guard')
`

but Jetstream doesn't seem to use the more complicated system so I believe defaulting to using auth:sanctum is appropriate if the intention is to encourage people to use sanctum as per the built in dashboard route. 