### PR TITLE
Add Check before deleting a profile photo

### DIFF
--- a/src/HasProfilePhoto.php
+++ b/src/HasProfilePhoto.php
@@ -41,7 +41,7 @@ trait HasProfilePhoto
             return;
         }
 
-        if($this->profile_photo_path === null) {
+        if ($this->profile_photo_path === null) {
             return;
         }
 

--- a/src/HasProfilePhoto.php
+++ b/src/HasProfilePhoto.php
@@ -41,7 +41,7 @@ trait HasProfilePhoto
             return;
         }
 
-        if ($this->profile_photo_path === null) {
+        if (is_null($this->profile_photo_path)) {
             return;
         }
 

--- a/src/HasProfilePhoto.php
+++ b/src/HasProfilePhoto.php
@@ -41,6 +41,10 @@ trait HasProfilePhoto
             return;
         }
 
+        if($this->profile_photo_path === null) {
+            return;
+        }
+
         Storage::disk($this->profilePhotoDisk())->delete($this->profile_photo_path);
 
         $this->forceFill([


### PR DESCRIPTION
Laravel 9 uses Filesystem 3.
For deleting a file you must provide a string. But if no profile photo is set the profile_photo_path can be null.

This PR adds a Check before deleting the profile photo.

FilesystemAdapter Interface which requires the usage of a string:
https://github.com/thephpleague/flysystem/blob/912ba3e5595280999b9fa99a3c20c5ecb7de6870/src/FilesystemAdapter.php#L53