### PR TITLE
Switch to Laravel 8.37 >= anonymous migrations

### DIFF
--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateUsersTable extends Migration
+return new class extends Migration
 {
     /**
      * Run the migrations.
@@ -35,4 +35,4 @@ class CreateUsersTable extends Migration
     {
         Schema::dropIfExists('users');
     }
-}
+};

--- a/database/migrations/2020_05_21_100000_create_teams_table.php
+++ b/database/migrations/2020_05_21_100000_create_teams_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateTeamsTable extends Migration
+return new class extends Migration
 {
     /**
      * Run the migrations.
@@ -31,4 +31,4 @@ class CreateTeamsTable extends Migration
     {
         Schema::dropIfExists('teams');
     }
-}
+};

--- a/database/migrations/2020_05_21_200000_create_team_user_table.php
+++ b/database/migrations/2020_05_21_200000_create_team_user_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateTeamUserTable extends Migration
+return new class extends Migration
 {
     /**
      * Run the migrations.
@@ -33,4 +33,4 @@ class CreateTeamUserTable extends Migration
     {
         Schema::dropIfExists('team_user');
     }
-}
+};

--- a/database/migrations/2020_05_21_300000_create_team_invitations_table.php
+++ b/database/migrations/2020_05_21_300000_create_team_invitations_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateTeamInvitationsTable extends Migration
+return new class extends Migration
 {
     /**
      * Run the migrations.
@@ -33,4 +33,4 @@ class CreateTeamInvitationsTable extends Migration
     {
         Schema::dropIfExists('team_invitations');
     }
-}
+};


### PR DESCRIPTION
Hello,

this PR refactors all of the migrations to anonymous migrations.

Since the upcoming Laravel 9 release is pretty close maybe it is time to drop some old dependencies (Laravel 8 & PHP 7.x) in the Jetstream package and start doing changes for a next major Jetstream (3.x) version?

So this is a kind of a tryout pr. I just want to checkout how the future of Jetstream Open Source development will look like. And how these kind of PRs are received by the maintainers.

I'm not sure how the Jetstream Package Major Versions release cycle is going to look like in the future since this is the first Major Laravel Release after Jetstream was born  ( it really feels like a long time ago). 

I hope I'm not annoying anyone with this PR. Feel free to close this pr and thank you for your feedback!

Have a nice weekend!

