### PR TITLE
[2.x] switch to Laravel 8.80 >= route group controllers

### DIFF
--- a/routes/inertia.php
+++ b/routes/inertia.php
@@ -42,23 +42,31 @@ Route::group(['middleware' => config('jetstream.middleware', ['web'])], function
 
         // API...
         if (Jetstream::hasApiFeatures()) {
-            Route::get('/user/api-tokens', [ApiTokenController::class, 'index'])->name('api-tokens.index');
-            Route::post('/user/api-tokens', [ApiTokenController::class, 'store'])->name('api-tokens.store');
-            Route::put('/user/api-tokens/{token}', [ApiTokenController::class, 'update'])->name('api-tokens.update');
-            Route::delete('/user/api-tokens/{token}', [ApiTokenController::class, 'destroy'])->name('api-tokens.destroy');
+            Route::controller(ApiTokenController::class)->prefix('api-tokens.')->group(function (){
+                Route::get('/user/api-tokens', 'index')->name('index');
+                Route::post('/user/api-tokens', 'store')->name('store');
+                Route::put('/user/api-tokens/{token}', 'update')->name('update');
+                Route::delete('/user/api-tokens/{token}','destroy')->name('destroy');
+            });
         }
 
         // Teams...
         if (Jetstream::hasTeamFeatures()) {
-            Route::get('/teams/create', [TeamController::class, 'create'])->name('teams.create');
-            Route::post('/teams', [TeamController::class, 'store'])->name('teams.store');
-            Route::get('/teams/{team}', [TeamController::class, 'show'])->name('teams.show');
-            Route::put('/teams/{team}', [TeamController::class, 'update'])->name('teams.update');
-            Route::delete('/teams/{team}', [TeamController::class, 'destroy'])->name('teams.destroy');
+            Route::controller(TeamController::class)->prefix('teams.')->group(function () {
+                Route::get('/teams/create', 'create')->name('create');
+                Route::post('/teams', 'store')->name('store');
+                Route::get('/teams/{team}', 'show')->name('show');
+                Route::put('/teams/{team}', 'update')->name('update');
+                Route::delete('/teams/{team}', 'destroy')->name('destroy');
+            });
+
             Route::put('/current-team', [CurrentTeamController::class, 'update'])->name('current-team.update');
-            Route::post('/teams/{team}/members', [TeamMemberController::class, 'store'])->name('team-members.store');
-            Route::put('/teams/{team}/members/{user}', [TeamMemberController::class, 'update'])->name('team-members.update');
-            Route::delete('/teams/{team}/members/{user}', [TeamMemberController::class, 'destroy'])->name('team-members.destroy');
+
+            Route::controller(TeamController::class)->prefix('team-members.')->group(function () {
+                Route::post('/teams/{team}/members', 'store')->name('store');
+                Route::put('/teams/{team}/members/{user}', 'update')->name('update');
+                Route::delete('/teams/{team}/members/{user}', 'destroy')->name('destroy');
+            });
 
             Route::get('/team-invitations/{invitation}', [TeamInvitationController::class, 'accept'])
                         ->middleware(['signed'])

--- a/routes/inertia.php
+++ b/routes/inertia.php
@@ -42,7 +42,7 @@ Route::group(['middleware' => config('jetstream.middleware', ['web'])], function
 
         // API...
         if (Jetstream::hasApiFeatures()) {
-            Route::controller(ApiTokenController::class)->prefix('api-tokens.')->group(function (){
+            Route::controller(ApiTokenController::class)->name('api-tokens.')->group(function (){
                 Route::get('/user/api-tokens', 'index')->name('index');
                 Route::post('/user/api-tokens', 'store')->name('store');
                 Route::put('/user/api-tokens/{token}', 'update')->name('update');
@@ -52,7 +52,7 @@ Route::group(['middleware' => config('jetstream.middleware', ['web'])], function
 
         // Teams...
         if (Jetstream::hasTeamFeatures()) {
-            Route::controller(TeamController::class)->prefix('teams.')->group(function () {
+            Route::controller(TeamController::class)->name('teams.')->group(function () {
                 Route::get('/teams/create', 'create')->name('create');
                 Route::post('/teams', 'store')->name('store');
                 Route::get('/teams/{team}', 'show')->name('show');
@@ -62,7 +62,7 @@ Route::group(['middleware' => config('jetstream.middleware', ['web'])], function
 
             Route::put('/current-team', [CurrentTeamController::class, 'update'])->name('current-team.update');
 
-            Route::controller(TeamController::class)->prefix('team-members.')->group(function () {
+            Route::controller(TeamMemberController::class)->name('team-members.')->group(function () {
                 Route::post('/teams/{team}/members', 'store')->name('store');
                 Route::put('/teams/{team}/members/{user}', 'update')->name('update');
                 Route::delete('/teams/{team}/members/{user}', 'destroy')->name('destroy');

--- a/routes/inertia.php
+++ b/routes/inertia.php
@@ -42,11 +42,11 @@ Route::group(['middleware' => config('jetstream.middleware', ['web'])], function
 
         // API...
         if (Jetstream::hasApiFeatures()) {
-            Route::controller(ApiTokenController::class)->name('api-tokens.')->group(function (){
+            Route::controller(ApiTokenController::class)->name('api-tokens.')->group(function () {
                 Route::get('/user/api-tokens', 'index')->name('index');
                 Route::post('/user/api-tokens', 'store')->name('store');
                 Route::put('/user/api-tokens/{token}', 'update')->name('update');
-                Route::delete('/user/api-tokens/{token}','destroy')->name('destroy');
+                Route::delete('/user/api-tokens/{token}', 'destroy')->name('destroy');
             });
         }
 

--- a/routes/livewire.php
+++ b/routes/livewire.php
@@ -33,8 +33,8 @@ Route::group(['middleware' => config('jetstream.middleware', ['web'])], function
         // Teams...
         if (Jetstream::hasTeamFeatures()) {
             Route::controller(TeamController::class)->name('teams.')->group(function () {
-                Route::get('/teams/create','create')->name('create');
-                Route::get('/teams/{team}','show')->name('show');
+                Route::get('/teams/create', 'create')->name('create');
+                Route::get('/teams/{team}', 'show')->name('show');
             });
 
             Route::put('/current-team', [CurrentTeamController::class, 'update'])->name('current-team.update');

--- a/routes/livewire.php
+++ b/routes/livewire.php
@@ -32,7 +32,7 @@ Route::group(['middleware' => config('jetstream.middleware', ['web'])], function
 
         // Teams...
         if (Jetstream::hasTeamFeatures()) {
-            Route::controller(TeamController::class)->prefix('teams.')->group(function(){
+            Route::controller(TeamController::class)->name('teams.')->group(function(){
                 Route::get('/teams/create','create')->name('create');
                 Route::get('/teams/{team}','show')->name('show');
             });

--- a/routes/livewire.php
+++ b/routes/livewire.php
@@ -32,7 +32,7 @@ Route::group(['middleware' => config('jetstream.middleware', ['web'])], function
 
         // Teams...
         if (Jetstream::hasTeamFeatures()) {
-            Route::controller(TeamController::class)->name('teams.')->group(function (){
+            Route::controller(TeamController::class)->name('teams.')->group(function () {
                 Route::get('/teams/create','create')->name('create');
                 Route::get('/teams/{team}','show')->name('show');
             });

--- a/routes/livewire.php
+++ b/routes/livewire.php
@@ -32,8 +32,11 @@ Route::group(['middleware' => config('jetstream.middleware', ['web'])], function
 
         // Teams...
         if (Jetstream::hasTeamFeatures()) {
-            Route::get('/teams/create', [TeamController::class, 'create'])->name('teams.create');
-            Route::get('/teams/{team}', [TeamController::class, 'show'])->name('teams.show');
+            Route::controller(TeamController::class)->prefix('teams.')->group(function(){
+                Route::get('/teams/create','create')->name('create');
+                Route::get('/teams/{team}','show')->name('show');
+            });
+
             Route::put('/current-team', [CurrentTeamController::class, 'update'])->name('current-team.update');
 
             Route::get('/team-invitations/{invitation}', [TeamInvitationController::class, 'accept'])

--- a/routes/livewire.php
+++ b/routes/livewire.php
@@ -32,7 +32,7 @@ Route::group(['middleware' => config('jetstream.middleware', ['web'])], function
 
         // Teams...
         if (Jetstream::hasTeamFeatures()) {
-            Route::controller(TeamController::class)->name('teams.')->group(function(){
+            Route::controller(TeamController::class)->name('teams.')->group(function (){
                 Route::get('/teams/create','create')->name('create');
                 Route::get('/teams/{team}','show')->name('show');
             });

--- a/src/JetstreamServiceProvider.php
+++ b/src/JetstreamServiceProvider.php
@@ -197,7 +197,6 @@ class JetstreamServiceProvider extends ServiceProvider
     {
         if (Jetstream::$registersRoutes) {
             Route::group([
-                'namespace' => 'Laravel\Jetstream\Http\Controllers',
                 'domain' => config('jetstream.domain', null),
                 'prefix' => config('jetstream.prefix', config('jetstream.path')),
             ], function () {


### PR DESCRIPTION
This PR refactors the route files to the new route group controller syntax by @lukeraymonddowning added in this [pr](https://github.com/laravel/framework/pull/40276).

Thank you for your time and have a nice weekend!