### PR TITLE
Always return array to ui from allTeams()

### DIFF
--- a/src/Http/Middleware/ShareInertiaData.php
+++ b/src/Http/Middleware/ShareInertiaData.php
@@ -46,7 +46,7 @@ class ShareInertiaData
                 }
 
                 return array_merge($request->user()->toArray(), array_filter([
-                    'all_teams' => Jetstream::hasTeamFeatures() ? $request->user()->allTeams() : null,
+                    'all_teams' => Jetstream::hasTeamFeatures() ? $request->user()->allTeams()->values() : null,
                 ]), [
                     'two_factor_enabled' => ! is_null($request->user()->two_factor_secret),
                 ]);


### PR DESCRIPTION
Hi there, this is my first laravel PR

The `$user->allTeams()` method returns a merged collection in the HasTeams trait with `$this->ownedTeams` and `$this->teams`.

Unfortunately eloquent `sortBy` method will re-index the keys out of order, so json encoding the output value of this method will convert it to a map in javascript rather than an array.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

If you change the behavior of the Inertia stack you're expected to update the Livewire stack as well and vice versa.
-->
