### PR TITLE
[2.x] Jetstream shared data moved to a public method

### DIFF
--- a/src/Http/Middleware/ShareInertiaData.php
+++ b/src/Http/Middleware/ShareInertiaData.php
@@ -25,9 +25,9 @@ class ShareInertiaData
     }
 
     /**
-     * Jetstream related data to be shared with Inertia
+     * Jetstream related data to be shared with Inertia.
      *
-     * @param \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Http\Request  $request
      * @return array
      */
     public function shareJetstreamData($request)

--- a/src/Http/Middleware/ShareInertiaData.php
+++ b/src/Http/Middleware/ShareInertiaData.php
@@ -19,12 +19,25 @@ class ShareInertiaData
      */
     public function handle($request, $next)
     {
-        Inertia::share(array_filter([
+        Inertia::share($this->shareJetstreamData($request));
+
+        return $next($request);
+    }
+
+    /**
+     * Jetstream related data to be shared with Inertia
+     *
+     * @param \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function shareJetstreamData($request)
+    {
+        return array_filter([
             'jetstream' => function () use ($request) {
                 return [
                     'canCreateTeams' => $request->user() &&
-                                        Jetstream::hasTeamFeatures() &&
-                                        Gate::forUser($request->user())->check('create', Jetstream::newTeamModel()),
+                        Jetstream::hasTeamFeatures() &&
+                        Gate::forUser($request->user())->check('create', Jetstream::newTeamModel()),
                     'canManageTwoFactorAuthentication' => Features::canManageTwoFactorAuthentication(),
                     'canUpdatePassword' => Features::enabled(Features::updatePasswords()),
                     'canUpdateProfileInformation' => Features::canUpdateProfileInformation(),
@@ -56,8 +69,6 @@ class ShareInertiaData
                     return [$key => $bag->messages()];
                 })->all();
             },
-        ]));
-
-        return $next($request);
+        ]);
     }
 }


### PR DESCRIPTION
Preface: **Hoping for feedback**, as this is probably not the best way, but so far it seems to work for my use-case.

We ran into an issue today, attempting to render errors with Inertia (https://inertiajs.com/error-handling).

We use pretty much the exact same error handler Jonathan recommends, but with a small difference in how we select a layout.

We want both unauthenticated and authenticated users to be able to navigate the site, so I thought maybe using the Inertia layout-option was a good way to do this.

Example - `resources/js/Pages/Error.vue`:

```javascript
export default {
    props: {
         status: Number,
    },

    layout: (h, page) => {
        return page.props.user ?
            h(AppLayout, {title: page.props.title}, {
                default: page,
                header: 'Error',
            }) :
            h(GuestLayout, {title: page.props.title}, {
                default: page,
                header: 'Error',
            })
    },
}
```

Turns out it didn't work right out of the box. Both layouts are default Jetstream layouts, which means they require various Jetstream data to function correctly.

My quick'n'dirty solution was to, in Laravel's `App\Exceptions\Handler`, modify the existing Inertia boilerplate to include all the necessary props required for the layouts to function.

Example - `app/Exceptions/Handler.php`

```php
// various imports

class Handler extends ExceptionHandler
{
    public function render($request, Throwable $e)
    {
        $response = parent::render($request, $e);

        $titles = []; // just keyed by status code, with various titles

        $descriptions = []; // just keyed by status code, with various descriptions

        if (! app()->environment(['local', 'testing']) && in_array($response->status(), [500, 503, 404, 403])) {
            return Inertia::render(
                'Error',
                $this->inertiaErrorData($request, $response, $titles, $descriptions)
            )
                ->toResponse($request)
                ->setStatusCode($response->status());
        } else if ($response->status() === 419) {
            return back()->with([
                'message' => 'The page expired, please try again.',
            ]);
        }

        return $response;
    }

    protected function inertiaErrorData($request, $response, $titles, $descriptions)
    {
        $handleInertiaRequest = new HandleInertiaRequests; // reference our local HandleInertiaRequest middleware

        $jetstreamShareInertiaData = new ShareInertiaData; // reference Jetstreams ShareInertiaData middleware

        return array_merge(
            $jetstreamShareInertiaData->jetstreamData($request),
            $handleInertiaRequest->share($request), [
                'status' => $response->status(),
                'title' => $titles[$response->status()],
                'description' => $descriptions[$response->status()],
            ]
        );
    }
}
```