### PR TITLE
[8.x] Fix PHP 8.1 return type

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip
+          ini-values: error_reporting=E_ALL
           tools: composer:v2
           coverage: none
 

--- a/src/Role.php
+++ b/src/Role.php
@@ -67,6 +67,7 @@ class Role implements JsonSerializable
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/tests/JetstreamTest.php
+++ b/tests/JetstreamTest.php
@@ -31,4 +31,22 @@ class JetstreamTest extends OrchestraTestCase
             'update',
         ], Jetstream::$permissions);
     }
+
+    public function test_roles_can_be_json_serialized()
+    {
+        Jetstream::$permissions = [];
+        Jetstream::$roles = [];
+
+        $role = Jetstream::role('admin', 'Admin', [
+            'read',
+            'create',
+        ])->description('Admin Description');
+
+        $serialized = $role->jsonSerialize();
+
+        $this->assertArrayHasKey('key', $serialized);
+        $this->assertArrayHasKey('name', $serialized);
+        $this->assertArrayHasKey('description', $serialized);
+        $this->assertArrayHasKey('permissions', $serialized);
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/laravel/jetstream/issues/968

I'm a bit baffled that I couldn't reproduce this. No matter what I tried I couldn't trigger the error they experiencing while clearly this indeed is an issue. There's something that's hard-suppressing deprecation notices but I don't know what...