### PR TITLE
Add multiple roles usage

### DIFF
--- a/src/Actions/UpdateTeamMemberRole.php
+++ b/src/Actions/UpdateTeamMemberRole.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Jetstream\Actions;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Validator;
 use Laravel\Jetstream\Events\TeamMemberUpdated;
@@ -16,17 +17,17 @@ class UpdateTeamMemberRole
      * @param  mixed  $user
      * @param  mixed  $team
      * @param  int  $teamMemberId
-     * @param  string  $role
+     * @param  array<string>|string|null  $role
      * @return void
      */
-    public function update($user, $team, $teamMemberId, string $role)
+    public function update($user, $team, $teamMemberId, $role)
     {
         Gate::forUser($user)->authorize('updateTeamMember', $team);
-
+        $role = Arr::wrap($role);
         Validator::make([
-            'role' => $role,
+            'role.*' => $role,
         ], [
-            'role' => ['required', 'string', new Role],
+            'role.*' => ['required', 'string', new Role],
         ])->validate();
 
         $team->users()->updateExistingPivot($teamMemberId, [

--- a/src/Contracts/AddsTeamMembers.php
+++ b/src/Contracts/AddsTeamMembers.php
@@ -10,7 +10,8 @@ interface AddsTeamMembers
      * @param  mixed  $user
      * @param  mixed  $team
      * @param  string  $email
+     * @param  array<string>|string|null  $role
      * @return void
      */
-    public function add($user, $team, string $email, string $role = null);
+    public function add($user, $team, string $email, $role = []);
 }

--- a/src/Contracts/InvitesTeamMembers.php
+++ b/src/Contracts/InvitesTeamMembers.php
@@ -10,7 +10,8 @@ interface InvitesTeamMembers
      * @param  mixed  $user
      * @param  mixed  $team
      * @param  string  $email
+     * @param  array<string>|string|null  $role
      * @return void
      */
-    public function invite($user, $team, string $email, string $role = null);
+    public function invite($user, $team, string $email, $role = []);
 }

--- a/src/HasTeams.php
+++ b/src/HasTeams.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Jetstream;
 
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Laravel\Sanctum\HasApiTokens;
 
@@ -128,25 +129,29 @@ trait HasTeams
      * Get the role that the user has on the team.
      *
      * @param  mixed  $team
-     * @return \Laravel\Jetstream\Role|null
+     * @return Collection<int,\Laravel\Jetstream\Role>
      */
-    public function teamRole($team)
+    public function teamRoles($team): Collection
     {
-        if ($this->ownsTeam($team)) {
-            return new OwnerRole;
-        }
+        $roles = Collection::make();
 
         if (! $this->belongsToTeam($team)) {
-            return;
+            return $roles;
         }
 
-        $role = $team->users
-            ->where('id', $this->id)
-            ->first()
-            ->membership
-            ->role;
+        if ($this->ownsTeam($team)) {
+            $roles->push(new OwnerRole);
+        }
 
-        return $role ? Jetstream::findRole($role) : null;
+        $memberShip = $team->users()
+            ->where('users.id', $this->id)
+            ->limit(1)
+            ->first();
+        $otherRoles = $memberShip ? optional($memberShip)->membership->role : [];
+
+        return $roles->merge($otherRoles)->filter()->map(function ($role) {
+            return $role instanceof Role ? $role : Jetstream::findRole($role);
+        });
     }
 
     /**
@@ -158,13 +163,9 @@ trait HasTeams
      */
     public function hasTeamRole($team, string $role)
     {
-        if ($this->ownsTeam($team)) {
-            return true;
-        }
-
-        return $this->belongsToTeam($team) && optional(Jetstream::findRole($team->users->where(
-            'id', $this->id
-        )->first()->membership->role))->key === $role;
+        return (bool) $this->teamRoles($team)->first(function (Role $userRole) use ($role) {
+            return $userRole->key=== $role;
+        });
     }
 
     /**
@@ -179,11 +180,11 @@ trait HasTeams
             return ['*'];
         }
 
-        if (! $this->belongsToTeam($team)) {
+        if (! $this->belongsToTeam($team)){
             return [];
         }
 
-        return (array) optional($this->teamRole($team))->permissions;
+        return $this->teamRoles($team)->pluck('permissions')->flatten()->toArray();
     }
 
     /**

--- a/src/Membership.php
+++ b/src/Membership.php
@@ -12,4 +12,6 @@ abstract class Membership extends Pivot
      * @var string
      */
     protected $table = 'team_user';
+
+    protected $casts = ['role' => 'array'];
 }

--- a/stubs/app/Actions/Jetstream/AddTeamMember.php
+++ b/stubs/app/Actions/Jetstream/AddTeamMember.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions\Jetstream;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Validator;
 use Laravel\Jetstream\Contracts\AddsTeamMembers;
@@ -18,13 +19,13 @@ class AddTeamMember implements AddsTeamMembers
      * @param  mixed  $user
      * @param  mixed  $team
      * @param  string  $email
-     * @param  string|null  $role
+     * @param  array<string>|string|null  $role
      * @return void
      */
-    public function add($user, $team, string $email, string $role = null)
+    public function add($user, $team, string $email, $role = [])
     {
         Gate::forUser($user)->authorize('addTeamMember', $team);
-
+        $role = Arr::wrap($role);
         $this->validate($team, $email, $role);
 
         $newTeamMember = Jetstream::findUserByEmailOrFail($email);
@@ -43,14 +44,14 @@ class AddTeamMember implements AddsTeamMembers
      *
      * @param  mixed  $team
      * @param  string  $email
-     * @param  string|null  $role
+     * @param  array  $role
      * @return void
      */
-    protected function validate($team, string $email, ?string $role)
+    protected function validate($team, string $email,array $role)
     {
         Validator::make([
             'email' => $email,
-            'role' => $role,
+            'role.*' => $role,
         ], $this->rules(), [
             'email.exists' => __('We were unable to find a registered user with this email address.'),
         ])->after(
@@ -67,7 +68,7 @@ class AddTeamMember implements AddsTeamMembers
     {
         return array_filter([
             'email' => ['required', 'email', 'exists:users'],
-            'role' => Jetstream::hasRoles()
+            'role.*' => Jetstream::hasRoles()
                             ? ['required', 'string', new Role]
                             : null,
         ]);

--- a/tests/AddTeamMemberTest.php
+++ b/tests/AddTeamMemberTest.php
@@ -58,6 +58,43 @@ class AddTeamMemberTest extends OrchestraTestCase
         $this->assertFalse($team->users->first()->hasTeamPermission($team, 'bar'));
     }
 
+    public function test_team_members_can_be_added_with_multiple_roles()
+    {
+        Jetstream::role('admin', 'Admin', ['foo']);
+        Jetstream::role('admin2', 'Admin2', ['foo2']);
+
+        $this->migrate();
+
+        $team = $this->createTeam();
+
+        $otherUser = User::forceCreate([
+            'name' => 'Adam Wathan',
+            'email' => 'adam@laravel.com',
+            'password' => 'secret',
+        ]);
+
+        $action = new AddTeamMember;
+
+        $action->add($team->owner, $team, 'adam@laravel.com', ['admin','admin2',]);
+
+        $team = $team->fresh();
+
+        $this->assertCount(1, $team->users);
+
+        $this->assertInstanceOf(Membership::class, $team->users[0]->membership);
+
+        $this->assertTrue($otherUser->hasTeamRole($team, 'admin'));
+        $this->assertTrue($otherUser->hasTeamRole($team, 'admin2'));
+        $this->assertFalse($otherUser->hasTeamRole($team, 'editor'));
+        $this->assertFalse($otherUser->hasTeamRole($team, 'foobar'));
+
+        $team->users->first()->withAccessToken(new TransientToken);
+
+        $this->assertTrue($team->users->first()->hasTeamPermission($team, 'foo'));
+        $this->assertTrue($team->users->first()->hasTeamPermission($team, 'foo2'));
+        $this->assertFalse($team->users->first()->hasTeamPermission($team, 'bar'));
+    }
+
     public function test_user_email_address_must_exist()
     {
         $this->expectException(ValidationException::class);

--- a/tests/HasTeamsTest.php
+++ b/tests/HasTeamsTest.php
@@ -29,7 +29,7 @@ class HasTeamsTest extends OrchestraTestCase
     {
         $team = Team::factory()->create();
 
-        $this->assertInstanceOf(OwnerRole::class, $team->owner->teamRole($team));
+        $this->assertInstanceOf(OwnerRole::class, $team->owner->teamRoles($team)->first());
     }
 
     public function test_teamRole_returns_the_matching_role(): void
@@ -44,7 +44,7 @@ class HasTeamsTest extends OrchestraTestCase
                 'role' => 'admin',
             ])
             ->create();
-        $role = $team->users->first()->teamRole($team);
+        $role = $team->users->first()->teamRoles($team)->first();
 
         $this->assertInstanceOf(Role::class, $role);
         $this->assertSame('admin', $role->key);
@@ -54,7 +54,7 @@ class HasTeamsTest extends OrchestraTestCase
     {
         $team = Team::factory()->create();
 
-        $this->assertNull((new UserFixture())->teamRole($team));
+        $this->assertEmpty((new UserFixture())->teamRoles($team));
     }
 
     public function test_teamRole_returns_null_if_the_user_does_not_have_a_role_on_the_site(): void
@@ -63,7 +63,7 @@ class HasTeamsTest extends OrchestraTestCase
             ->has(User::factory())
             ->create();
 
-        $this->assertNull($team->users->first()->teamRole($team));
+        $this->assertEmpty($team->users->first()->teamRoles($team));
     }
 
     public function test_teamPermissions_returns_all_for_team_owners(): void

--- a/tests/UpdateTeamMemberRoleTest.php
+++ b/tests/UpdateTeamMemberRoleTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Laravel\Jetstream\Tests;
+
+use App\Actions\Jetstream\AddTeamMember;
+use App\Actions\Jetstream\CreateTeam;
+use App\Models\Team;
+use Illuminate\Support\Facades\Gate;
+use Laravel\Jetstream\Actions\UpdateTeamMemberRole;
+use Laravel\Jetstream\Jetstream;
+use Laravel\Jetstream\Membership;
+use Laravel\Jetstream\Tests\Fixtures\TeamPolicy;
+use Laravel\Jetstream\Tests\Fixtures\User;
+use Laravel\Sanctum\TransientToken;
+
+class UpdateTeamMemberRoleTest extends OrchestraTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Gate::policy(Team::class, TeamPolicy::class);
+        Jetstream::useUserModel(User::class);
+    }
+
+    public function test_team_members_can_be_updated()
+    {
+        Jetstream::role('admin', 'Admin', ['foo']);
+        Jetstream::role('admin2', 'Admin2', ['foo2']);
+        Jetstream::role('admin3', 'Admin3', ['foo3']);
+
+        $this->migrate();
+
+        $team = $this->createTeam();
+
+        $otherUser = User::forceCreate([
+            'name' => 'Adam Wathan',
+            'email' => 'adam@laravel.com',
+            'password' => 'secret',
+        ]);
+
+        $action = new AddTeamMember;
+        $action->add($team->owner, $team, 'adam@laravel.com', 'admin');
+
+        $team = $team->fresh();
+
+        $this->assertCount(1, $team->users);
+
+        $this->assertInstanceOf(Membership::class, $team->users[0]->membership);
+
+        $this->assertTrue($otherUser->hasTeamRole($team, 'admin'));
+        $this->assertFalse($otherUser->hasTeamRole($team, 'admin2'));
+        $this->assertFalse($otherUser->hasTeamRole($team, 'admin3'));
+
+        $team->users->first()->withAccessToken(new TransientToken);
+
+        $this->assertTrue($team->users->first()->hasTeamPermission($team, 'foo'));
+        $this->assertFalse($team->users->first()->hasTeamPermission($team, 'foo2'));
+        $this->assertFalse($team->users->first()->hasTeamPermission($team, 'foo3'));
+
+        $action = new UpdateTeamMemberRole();
+        $action->update($team->owner, $team, $otherUser->id, ['admin2', 'admin3']);
+
+        $team = $team->fresh();
+
+        $this->assertFalse($otherUser->hasTeamRole($team, 'admin'));
+        $this->assertTrue($otherUser->hasTeamRole($team, 'admin2'));
+        $this->assertTrue($otherUser->hasTeamRole($team, 'admin3'));
+
+        $this->assertFalse($team->users->first()->hasTeamPermission($team, 'foo'));
+        $this->assertTrue($team->users->first()->hasTeamPermission($team, 'foo2'));
+        $this->assertTrue($team->users->first()->hasTeamPermission($team, 'foo3'));
+    }
+
+    protected function createTeam()
+    {
+        $action = new CreateTeam;
+
+        $user = User::forceCreate([
+            'name' => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
+            'password' => 'secret',
+        ]);
+
+        return $action->create($user, ['name' => 'Test Team']);
+    }
+
+    protected function migrate()
+    {
+        // $this->loadLaravelMigrations(['--database' => 'testbench']);
+
+        $this->artisan('migrate', ['--database' => 'testbench'])->run();
+    }
+}


### PR DESCRIPTION
Given that jetstream is a popular official laravel package that gives a head start to many projects, and provides basic acl functionality, I would like to help on this, providing a way to support **multiple** user roles per Team. 

During research & planning for different projects, I have been in the need of an acl package to cover business needs. 
The only thing that filters out this package from the eligible choices is the lack of multiple roles support.

So taking advantage of #944, I opened this PR as a proof of concept.

It **includes** the proper **PHP scoped changes** & **testing,** & **needs** tweaks on the **front templates**

This Pr introduces a breaking change:

```php
function teamRole($team): \Laravel\Jetstream\Role|null
```
is changed to:

```php
function teamRoles($team): Collection<int,\Laravel\Jetstream\Role>
```
making it better candidate for next package major version 

<br><br>
_PS: Probably I will be suggested to begin my personal fork and continue on it, but it would be better for most devs, to support & trust one package, instead of random subversions around github._