### PR TITLE
[3.x] Support multiple Roles per Team

### DIFF
--- a/src/Actions/UpdateTeamMemberRole.php
+++ b/src/Actions/UpdateTeamMemberRole.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Jetstream\Actions;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Validator;
 use Laravel\Jetstream\Events\TeamMemberUpdated;
@@ -16,17 +17,17 @@ class UpdateTeamMemberRole
      * @param  mixed  $user
      * @param  mixed  $team
      * @param  int  $teamMemberId
-     * @param  string  $role
+     * @param  array<string>|string|null  $role
      * @return void
      */
-    public function update($user, $team, $teamMemberId, string $role)
+    public function update($user, $team, $teamMemberId, $role)
     {
         Gate::forUser($user)->authorize('updateTeamMember', $team);
-
+        $role = Arr::wrap($role);
         Validator::make([
-            'role' => $role,
+            'role.*' => $role,
         ], [
-            'role' => ['required', 'string', new Role],
+            'role.*' => ['required', 'string', new Role],
         ])->validate();
 
         $team->users()->updateExistingPivot($teamMemberId, [

--- a/src/Actions/UpdateTeamMemberRole.php
+++ b/src/Actions/UpdateTeamMemberRole.php
@@ -17,21 +17,21 @@ class UpdateTeamMemberRole
      * @param  mixed  $user
      * @param  mixed  $team
      * @param  int  $teamMemberId
-     * @param  array<string>|string|null  $role
+     * @param  array<string>|string|null  $roles
      * @return void
      */
-    public function update($user, $team, $teamMemberId, $role)
+    public function update($user, $team, $teamMemberId, $roles)
     {
         Gate::forUser($user)->authorize('updateTeamMember', $team);
-        $role = Arr::wrap($role);
+        $roles = Arr::wrap($roles);
         Validator::make([
-            'role.*' => $role,
+            'role.*' => $roles,
         ], [
             'role.*' => ['required', 'string', new Role],
         ])->validate();
 
         $team->users()->updateExistingPivot($teamMemberId, [
-            'role' => $role,
+            'role' => $roles,
         ]);
 
         TeamMemberUpdated::dispatch($team->fresh(), Jetstream::findUserByIdOrFail($teamMemberId));

--- a/src/Contracts/AddsTeamMembers.php
+++ b/src/Contracts/AddsTeamMembers.php
@@ -10,7 +10,8 @@ interface AddsTeamMembers
      * @param  mixed  $user
      * @param  mixed  $team
      * @param  string  $email
+     * @param  array<string>|string|null  $role
      * @return void
      */
-    public function add($user, $team, string $email, string $role = null);
+    public function add($user, $team, string $email, $role = []);
 }

--- a/src/Contracts/AddsTeamMembers.php
+++ b/src/Contracts/AddsTeamMembers.php
@@ -10,8 +10,8 @@ interface AddsTeamMembers
      * @param  mixed  $user
      * @param  mixed  $team
      * @param  string  $email
-     * @param  array<string>|string|null  $role
+     * @param  array<string>|string|null  $roles
      * @return void
      */
-    public function add($user, $team, string $email, $role = []);
+    public function add($user, $team, string $email, $roles = []);
 }

--- a/src/Contracts/InvitesTeamMembers.php
+++ b/src/Contracts/InvitesTeamMembers.php
@@ -10,7 +10,8 @@ interface InvitesTeamMembers
      * @param  mixed  $user
      * @param  mixed  $team
      * @param  string  $email
+     * @param  array<string>|string|null  $role
      * @return void
      */
-    public function invite($user, $team, string $email, string $role = null);
+    public function invite($user, $team, string $email, $role = []);
 }

--- a/src/Contracts/InvitesTeamMembers.php
+++ b/src/Contracts/InvitesTeamMembers.php
@@ -10,8 +10,8 @@ interface InvitesTeamMembers
      * @param  mixed  $user
      * @param  mixed  $team
      * @param  string  $email
-     * @param  array<string>|string|null  $role
+     * @param  array<string>|string|null  $roles
      * @return void
      */
-    public function invite($user, $team, string $email, $role = []);
+    public function invite($user, $team, string $email, $roles = []);
 }

--- a/src/Membership.php
+++ b/src/Membership.php
@@ -12,4 +12,6 @@ abstract class Membership extends Pivot
      * @var string
      */
     protected $table = 'team_user';
+
+    protected $casts = ['role' => 'array'];
 }

--- a/stubs/app/Actions/Jetstream/AddTeamMember.php
+++ b/stubs/app/Actions/Jetstream/AddTeamMember.php
@@ -19,21 +19,21 @@ class AddTeamMember implements AddsTeamMembers
      * @param  mixed  $user
      * @param  mixed  $team
      * @param  string  $email
-     * @param  array<string>|string|null  $role
+     * @param  array<string>|string|null  $roles
      * @return void
      */
-    public function add($user, $team, string $email, $role = [])
+    public function add($user, $team, string $email, $roles = [])
     {
         Gate::forUser($user)->authorize('addTeamMember', $team);
-        $role = Arr::wrap($role);
-        $this->validate($team, $email, $role);
+        $roles = Arr::wrap($roles);
+        $this->validate($team, $email, $roles);
 
         $newTeamMember = Jetstream::findUserByEmailOrFail($email);
 
         AddingTeamMember::dispatch($team, $newTeamMember);
 
         $team->users()->attach(
-            $newTeamMember, ['role' => $role]
+            $newTeamMember, ['role' => $roles]
         );
 
         TeamMemberAdded::dispatch($team, $newTeamMember);
@@ -44,14 +44,14 @@ class AddTeamMember implements AddsTeamMembers
      *
      * @param  mixed  $team
      * @param  string  $email
-     * @param  array  $role
+     * @param  array  $roles
      * @return void
      */
-    protected function validate($team, string $email, array $role)
+    protected function validate($team, string $email, array $roles)
     {
         Validator::make([
             'email' => $email,
-            'role.*' => $role,
+            'role.*' => $roles,
         ], $this->rules(), [
             'email.exists' => __('We were unable to find a registered user with this email address.'),
         ])->after(

--- a/stubs/app/Actions/Jetstream/InviteTeamMember.php
+++ b/stubs/app/Actions/Jetstream/InviteTeamMember.php
@@ -21,20 +21,20 @@ class InviteTeamMember implements InvitesTeamMembers
      * @param  mixed  $user
      * @param  mixed  $team
      * @param  string  $email
-     * @param  array<string>|string|null  $role
+     * @param  array<string>|string|null  $roles
      * @return void
      */
-    public function invite($user, $team, string $email, $role = [])
+    public function invite($user, $team, string $email, $roles = [])
     {
         Gate::forUser($user)->authorize('addTeamMember', $team);
-        $role = Arr::wrap($role);
-        $this->validate($team, $email, $role);
+        $roles = Arr::wrap($roles);
+        $this->validate($team, $email, $roles);
 
-        InvitingTeamMember::dispatch($team, $email, $role);
+        InvitingTeamMember::dispatch($team, $email, $roles);
 
         $invitation = $team->teamInvitations()->create([
             'email' => $email,
-            'role.*' => $role,
+            'role.*' => $roles,
         ]);
 
         Mail::to($email)->send(new TeamInvitation($invitation));
@@ -45,14 +45,14 @@ class InviteTeamMember implements InvitesTeamMembers
      *
      * @param  mixed  $team
      * @param  string  $email
-     * @param  array  $role
+     * @param  array  $roles
      * @return void
      */
-    protected function validate($team, string $email, array $role)
+    protected function validate($team, string $email, array $roles)
     {
         Validator::make([
             'email' => $email,
-            'role.*' => $role,
+            'role.*' => $roles,
         ], $this->rules($team), [
             'email.unique' => __('This user has already been invited to the team.'),
         ])->after(

--- a/tests/HasTeamsTest.php
+++ b/tests/HasTeamsTest.php
@@ -29,7 +29,7 @@ class HasTeamsTest extends OrchestraTestCase
     {
         $team = Team::factory()->create();
 
-        $this->assertInstanceOf(OwnerRole::class, $team->owner->teamRole($team));
+        $this->assertInstanceOf(OwnerRole::class, $team->owner->teamRoles($team)->first());
     }
 
     public function test_teamRole_returns_the_matching_role(): void
@@ -44,7 +44,7 @@ class HasTeamsTest extends OrchestraTestCase
                 'role' => 'admin',
             ])
             ->create();
-        $role = $team->users->first()->teamRole($team);
+        $role = $team->users->first()->teamRoles($team)->first();
 
         $this->assertInstanceOf(Role::class, $role);
         $this->assertSame('admin', $role->key);
@@ -54,7 +54,7 @@ class HasTeamsTest extends OrchestraTestCase
     {
         $team = Team::factory()->create();
 
-        $this->assertNull((new UserFixture())->teamRole($team));
+        $this->assertEmpty((new UserFixture())->teamRoles($team));
     }
 
     public function test_teamRole_returns_null_if_the_user_does_not_have_a_role_on_the_site(): void
@@ -63,7 +63,7 @@ class HasTeamsTest extends OrchestraTestCase
             ->has(User::factory())
             ->create();
 
-        $this->assertNull($team->users->first()->teamRole($team));
+        $this->assertEmpty($team->users->first()->teamRoles($team));
     }
 
     public function test_teamPermissions_returns_all_for_team_owners(): void

--- a/tests/UpdateTeamMemberRoleTest.php
+++ b/tests/UpdateTeamMemberRoleTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Laravel\Jetstream\Tests;
+
+use App\Actions\Jetstream\AddTeamMember;
+use App\Actions\Jetstream\CreateTeam;
+use App\Models\Team;
+use Illuminate\Support\Facades\Gate;
+use Laravel\Jetstream\Actions\UpdateTeamMemberRole;
+use Laravel\Jetstream\Jetstream;
+use Laravel\Jetstream\Membership;
+use Laravel\Jetstream\Tests\Fixtures\TeamPolicy;
+use Laravel\Jetstream\Tests\Fixtures\User;
+use Laravel\Sanctum\TransientToken;
+
+class UpdateTeamMemberRoleTest extends OrchestraTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Gate::policy(Team::class, TeamPolicy::class);
+        Jetstream::useUserModel(User::class);
+    }
+
+    public function test_team_members_can_be_updated()
+    {
+        Jetstream::role('admin', 'Admin', ['foo']);
+        Jetstream::role('admin2', 'Admin2', ['foo2']);
+        Jetstream::role('admin3', 'Admin3', ['foo3']);
+
+        $this->migrate();
+
+        $team = $this->createTeam();
+
+        $otherUser = User::forceCreate([
+            'name' => 'Adam Wathan',
+            'email' => 'adam@laravel.com',
+            'password' => 'secret',
+        ]);
+
+        $action = new AddTeamMember;
+        $action->add($team->owner, $team, 'adam@laravel.com', 'admin');
+
+        $team = $team->fresh();
+
+        $this->assertCount(1, $team->users);
+
+        $this->assertInstanceOf(Membership::class, $team->users[0]->membership);
+
+        $this->assertTrue($otherUser->hasTeamRole($team, 'admin'));
+        $this->assertFalse($otherUser->hasTeamRole($team, 'admin2'));
+        $this->assertFalse($otherUser->hasTeamRole($team, 'admin3'));
+
+        $team->users->first()->withAccessToken(new TransientToken);
+
+        $this->assertTrue($team->users->first()->hasTeamPermission($team, 'foo'));
+        $this->assertFalse($team->users->first()->hasTeamPermission($team, 'foo2'));
+        $this->assertFalse($team->users->first()->hasTeamPermission($team, 'foo3'));
+
+        $action = new UpdateTeamMemberRole();
+        $action->update($team->owner, $team, $otherUser->id, ['admin2', 'admin3']);
+
+        $team = $team->fresh();
+
+        $this->assertFalse($otherUser->hasTeamRole($team, 'admin'));
+        $this->assertTrue($otherUser->hasTeamRole($team, 'admin2'));
+        $this->assertTrue($otherUser->hasTeamRole($team, 'admin3'));
+
+        $this->assertFalse($team->users->first()->hasTeamPermission($team, 'foo'));
+        $this->assertTrue($team->users->first()->hasTeamPermission($team, 'foo2'));
+        $this->assertTrue($team->users->first()->hasTeamPermission($team, 'foo3'));
+    }
+
+    protected function createTeam()
+    {
+        $action = new CreateTeam;
+
+        $user = User::forceCreate([
+            'name' => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
+            'password' => 'secret',
+        ]);
+
+        return $action->create($user, ['name' => 'Test Team']);
+    }
+
+    protected function migrate()
+    {
+        // $this->loadLaravelMigrations(['--database' => 'testbench']);
+
+        $this->artisan('migrate', ['--database' => 'testbench'])->run();
+    }
+}


### PR DESCRIPTION
Given that jetstream is a popular official laravel package that gives a head start to many projects, and provides basic acl functionality, I would like to help on this, providing a way to support **multiple** user roles per Team. 

During research & planning for different projects, I have been in the need of an acl package to cover business needs. 
The only thing that filters out this package from the eligible choices is the lack of multiple roles support.

So taking advantage of #944, I opened this PR as a proof of concept.

It **includes** the proper **PHP scoped changes** & **testing,** & **needs** tweaks on the **front templates**

This Pr introduces a breaking change:

```php
function teamRole($team): \Laravel\Jetstream\Role|null
```
is changed to:

```php
function teamRoles($team): Collection<int,\Laravel\Jetstream\Role>
```
making it better candidate for next package major version 

<br><br>
_PS: Probably I will be suggested to begin my personal fork and continue on it, but it would be better for most devs, to support & trust one package, instead of random subversions around github._