### PR TITLE
Fixed avatar multibyte character issue

### DIFF
--- a/src/HasProfilePhoto.php
+++ b/src/HasProfilePhoto.php
@@ -72,7 +72,7 @@ trait HasProfilePhoto
     protected function defaultProfilePhotoUrl()
     {
         $name = trim(collect(explode(' ', $this->name))->map(function ($segment) {
-            return $segment[0] ?? '';
+            return mb_substr($segment, 0, 1);
         })->join(' '));
 
         return 'https://ui-avatars.com/api/?name='.urlencode($name).'&color=7F9CF5&background=EBF4FF';


### PR DESCRIPTION
Getting the first letter of a string by treating the string as an array corrupts multibyte characters; "İsmail"[0] returns � instead of İ, this causes question marks in the avatar. Changed it to mb_substr.
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

If you change the behavior of the Inertia stack you're expected to update the Livewire stack as well and vice versa.
-->
