### PR TITLE
Install command find the path to the php binary used

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -6,6 +6,7 @@ use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
+use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
 
 class InstallCommand extends Command
@@ -119,7 +120,7 @@ class InstallCommand extends Command
         $this->requireComposerPackages('livewire/livewire:^2.5');
 
         // Sanctum...
-        (new Process(['php', 'artisan', 'vendor:publish', '--provider=Laravel\Sanctum\SanctumServiceProvider', '--force'], base_path()))
+        (new Process([$this->getPhpBinary(), 'artisan', 'vendor:publish', '--provider=Laravel\Sanctum\SanctumServiceProvider', '--force'], base_path()))
                 ->setTimeout(null)
                 ->run(function ($type, $output) {
                     $this->output->write($output);
@@ -299,7 +300,7 @@ EOF;
         });
 
         // Sanctum...
-        (new Process(['php', 'artisan', 'vendor:publish', '--provider=Laravel\Sanctum\SanctumServiceProvider', '--force'], base_path()))
+        (new Process([$this->getPhpBinary(), 'artisan', 'vendor:publish', '--provider=Laravel\Sanctum\SanctumServiceProvider', '--force'], base_path()))
                 ->setTimeout(null)
                 ->run(function ($type, $output) {
                     $this->output->write($output);
@@ -336,7 +337,7 @@ EOF;
         $this->installServiceProviderAfter('FortifyServiceProvider', 'JetstreamServiceProvider');
 
         // Middleware...
-        (new Process(['php', 'artisan', 'inertia:middleware', 'HandleInertiaRequests', '--force'], base_path()))
+        (new Process([$this->getPhpBinary(), 'artisan', 'inertia:middleware', 'HandleInertiaRequests', '--force'], base_path()))
             ->setTimeout(null)
             ->run(function ($type, $output) {
                 $this->output->write($output);
@@ -554,7 +555,7 @@ EOF;
         $composer = $this->option('composer');
 
         if ($composer !== 'global') {
-            $command = ['php', $composer, 'require'];
+            $command = [$this->getPhpBinary(), $composer, 'require'];
         }
 
         $command = array_merge(
@@ -625,5 +626,15 @@ EOF;
     protected function replaceInFile($search, $replace, $path)
     {
         file_put_contents($path, str_replace($search, $replace, file_get_contents($path)));
+    }
+
+    /**
+     * Find the path to the php binary used
+     *
+     * @return string
+     */
+    protected function getPhpBinary(): string
+    {
+        return (new PhpExecutableFinder())->find(false) ?: 'php';
     }
 }

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -120,7 +120,7 @@ class InstallCommand extends Command
         $this->requireComposerPackages('livewire/livewire:^2.5');
 
         // Sanctum...
-        (new Process([$this->getPhpBinary(), 'artisan', 'vendor:publish', '--provider=Laravel\Sanctum\SanctumServiceProvider', '--force'], base_path()))
+        (new Process([$this->phpBinary(), 'artisan', 'vendor:publish', '--provider=Laravel\Sanctum\SanctumServiceProvider', '--force'], base_path()))
                 ->setTimeout(null)
                 ->run(function ($type, $output) {
                     $this->output->write($output);
@@ -300,7 +300,7 @@ EOF;
         });
 
         // Sanctum...
-        (new Process([$this->getPhpBinary(), 'artisan', 'vendor:publish', '--provider=Laravel\Sanctum\SanctumServiceProvider', '--force'], base_path()))
+        (new Process([$this->phpBinary(), 'artisan', 'vendor:publish', '--provider=Laravel\Sanctum\SanctumServiceProvider', '--force'], base_path()))
                 ->setTimeout(null)
                 ->run(function ($type, $output) {
                     $this->output->write($output);
@@ -337,7 +337,7 @@ EOF;
         $this->installServiceProviderAfter('FortifyServiceProvider', 'JetstreamServiceProvider');
 
         // Middleware...
-        (new Process([$this->getPhpBinary(), 'artisan', 'inertia:middleware', 'HandleInertiaRequests', '--force'], base_path()))
+        (new Process([$this->phpBinary(), 'artisan', 'inertia:middleware', 'HandleInertiaRequests', '--force'], base_path()))
             ->setTimeout(null)
             ->run(function ($type, $output) {
                 $this->output->write($output);
@@ -555,7 +555,7 @@ EOF;
         $composer = $this->option('composer');
 
         if ($composer !== 'global') {
-            $command = [$this->getPhpBinary(), $composer, 'require'];
+            $command = [$this->phpBinary(), $composer, 'require'];
         }
 
         $command = array_merge(

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -629,11 +629,11 @@ EOF;
     }
 
     /**
-     * Find the path to the php binary used
+     * Get the path to the appropriate PHP binary.
      *
      * @return string
      */
-    protected function getPhpBinary(): string
+    protected function phpBinary()
     {
         return (new PhpExecutableFinder())->find(false) ?: 'php';
     }


### PR DESCRIPTION
When I have multiple php versions, when trying to differentiate them using different aliases like `php`(7.1), `php74`, `php81`, now when I execute `php81 artisan jetstream:install livewire` in CLI , here will be unexpectedly fallback to `php`(7.1) execution, which will fail.

Now he will correctly get the `php81` I am using

I'm not sure how to write a test case for this modification, but it works for me, and I installed it by modifying the project's composer.json.

```json
    "repositories": [
        {
            "type": "path",
            "url": "C:\\web\\server\\laravel\\jetstream"
        }
    ],
```