### PR TITLE
[2.x] Mail Faker need on test cancelled invitations

### DIFF
--- a/stubs/tests/livewire/InviteTeamMemberTest.php
+++ b/stubs/tests/livewire/InviteTeamMemberTest.php
@@ -33,6 +33,8 @@ class InviteTeamMemberTest extends TestCase
 
     public function test_team_member_invitations_can_be_cancelled()
     {
+        Mail::fake();
+        
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         // Add the team member...


### PR DESCRIPTION
 • Tests\Feature\InviteTeamMemberTest > team member invitations can be cancelled
   Symfony\Component\Mime\Exception\LogicException 

  An email must have a "From" or a "Sender" header.

  at vendor/symfony/mime/Message.php:132
    128▕             throw new LogicException('An email must have a "To", "Cc", or "Bcc" header.');
    129▕         }
    130▕ 
    131▕         if (!$this->headers->has('From') && !$this->headers->has('Sender')) {
  ➜ 132▕             throw new LogicException('An email must have a "From" or a "Sender" header.');
    133▕         }
    134▕ 
    135▕         parent::ensureValidity();
    136▕     }

      +11 vendor frames 
  12  app/Actions/Jetstream/InviteTeamMember.php:39
      Illuminate\Mail\PendingMail::send(Object(Laravel\Jetstream\Mail\TeamInvitation))

      +32 vendor frames 
  45  tests/Feature/InviteTeamMemberTest.php:43
      Livewire\Testing\TestableLivewire::call("addTeamMember")

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

If you change the behavior of the Inertia stack you're expected to update the Livewire stack as well and vice versa.
-->
