### PR TITLE
Use typesetter’s apostrophe instead of typewriter’s one when creating user’s own team

### DIFF
--- a/stubs/app/Actions/Fortify/CreateNewUserWithTeams.php
+++ b/stubs/app/Actions/Fortify/CreateNewUserWithTeams.php
@@ -50,7 +50,7 @@ class CreateNewUser implements CreatesNewUsers
     {
         $user->ownedTeams()->save(Team::forceCreate([
             'user_id' => $user->id,
-            'name' => explode(' ', $user->name, 2)[0]."'s Team",
+            'name' => explode(' ', $user->name, 2)[0] . '’s Team',
             'personal_team' => true,
         ]));
     }


### PR DESCRIPTION
It looks better and more semantically correct in UIs.

https://en.wikipedia.org/wiki/Apostrophe