### PR TITLE
[2.x] Changed all request and Auth user calls to use the correct config('jetstream.guard') value.

### DIFF
--- a/resources/views/components/switchable-team.blade.php
+++ b/resources/views/components/switchable-team.blade.php
@@ -9,7 +9,7 @@
 
     <x-dynamic-component :component="$component" href="#" onclick="event.preventDefault(); this.closest('form').submit();">
         <div class="flex items-center">
-            @if (Auth::user()->isCurrentTeam($team))
+            @if (Auth::guard(config('jetstream.guard'))->user()->isCurrentTeam($team))
                 <svg class="mr-2 h-5 w-5 text-green-400" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" stroke="currentColor" viewBox="0 0 24 24"><path d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
             @endif
 

--- a/src/ConfirmsPasswords.php
+++ b/src/ConfirmsPasswords.php
@@ -72,7 +72,7 @@ trait ConfirmsPasswords
      */
     public function confirmPassword()
     {
-        if (! app(ConfirmPassword::class)(app(StatefulGuard::class), Auth::user(), $this->confirmablePassword)) {
+        if (! app(ConfirmPassword::class)(app(StatefulGuard::class), Auth::guard(config('jetstream.guard'))->user(), $this->confirmablePassword)) {
             throw ValidationException::withMessages([
                 'confirmable_password' => [__('This password does not match our records.')],
             ]);

--- a/src/Http/Controllers/CurrentTeamController.php
+++ b/src/Http/Controllers/CurrentTeamController.php
@@ -18,7 +18,7 @@ class CurrentTeamController extends Controller
     {
         $team = Jetstream::newTeamModel()->findOrFail($request->team_id);
 
-        if (! $request->user()->switchTeam($team)) {
+        if (! $request->user(config('jetstream.guard'))->switchTeam($team)) {
             abort(403);
         }
 

--- a/src/Http/Controllers/Inertia/ApiTokenController.php
+++ b/src/Http/Controllers/Inertia/ApiTokenController.php
@@ -17,7 +17,7 @@ class ApiTokenController extends Controller
     public function index(Request $request)
     {
         return Jetstream::inertia()->render($request, 'API/Index', [
-            'tokens' => $request->user()->tokens->map(function ($token) {
+            'tokens' => $request->user(config('jetstream.guard'))->tokens->map(function ($token) {
                 return $token->toArray() + [
                     'last_used_ago' => optional($token->last_used_at)->diffForHumans(),
                 ];
@@ -39,7 +39,7 @@ class ApiTokenController extends Controller
             'name' => ['required', 'string', 'max:255'],
         ]);
 
-        $token = $request->user()->createToken(
+        $token = $request->user(config('jetstream.guard'))->createToken(
             $request->name,
             Jetstream::validPermissions($request->input('permissions', []))
         );
@@ -63,7 +63,7 @@ class ApiTokenController extends Controller
             'permissions.*' => 'string',
         ]);
 
-        $token = $request->user()->tokens()->where('id', $tokenId)->firstOrFail();
+        $token = $request->user(config('jetstream.guard'))->tokens()->where('id', $tokenId)->firstOrFail();
 
         $token->forceFill([
             'abilities' => Jetstream::validPermissions($request->input('permissions', [])),
@@ -81,7 +81,7 @@ class ApiTokenController extends Controller
      */
     public function destroy(Request $request, $tokenId)
     {
-        $request->user()->tokens()->where('id', $tokenId)->first()->delete();
+        $request->user(config('jetstream.guard'))->tokens()->where('id', $tokenId)->first()->delete();
 
         return back(303);
     }

--- a/src/Http/Controllers/Inertia/CurrentUserController.php
+++ b/src/Http/Controllers/Inertia/CurrentUserController.php
@@ -22,7 +22,7 @@ class CurrentUserController extends Controller
     public function destroy(Request $request, StatefulGuard $guard)
     {
         $confirmed = app(ConfirmPassword::class)(
-            $guard, $request->user(), $request->password
+            $guard, $request->user(config('jetstream.guard')), $request->password
         );
 
         if (! $confirmed) {
@@ -31,7 +31,7 @@ class CurrentUserController extends Controller
             ]);
         }
 
-        app(DeletesUsers::class)->delete($request->user()->fresh());
+        app(DeletesUsers::class)->delete($request->user(config('jetstream.guard'))->fresh());
 
         $guard->logout();
 

--- a/src/Http/Controllers/Inertia/OtherBrowserSessionsController.php
+++ b/src/Http/Controllers/Inertia/OtherBrowserSessionsController.php
@@ -21,7 +21,7 @@ class OtherBrowserSessionsController extends Controller
     public function destroy(Request $request, StatefulGuard $guard)
     {
         $confirmed = app(ConfirmPassword::class)(
-            $guard, $request->user(), $request->password
+            $guard, $request->user(config('jetstream.guard')), $request->password
         );
 
         if (! $confirmed) {
@@ -50,7 +50,7 @@ class OtherBrowserSessionsController extends Controller
         }
 
         DB::connection(config('session.connection'))->table(config('session.table', 'sessions'))
-            ->where('user_id', $request->user()->getAuthIdentifier())
+            ->where('user_id', $request->user(config('jetstream.guard'))->getAuthIdentifier())
             ->where('id', '!=', $request->session()->getId())
             ->delete();
     }

--- a/src/Http/Controllers/Inertia/ProfilePhotoController.php
+++ b/src/Http/Controllers/Inertia/ProfilePhotoController.php
@@ -15,7 +15,7 @@ class ProfilePhotoController extends Controller
      */
     public function destroy(Request $request)
     {
-        $request->user()->deleteProfilePhoto();
+        $request->user(config('jetstream.guard'))->deleteProfilePhoto();
 
         return back(303)->with('status', 'profile-photo-deleted');
     }

--- a/src/Http/Controllers/Inertia/TeamController.php
+++ b/src/Http/Controllers/Inertia/TeamController.php
@@ -67,7 +67,7 @@ class TeamController extends Controller
     {
         $creator = app(CreatesTeams::class);
 
-        $creator->create($request->user(), $request->all());
+        $creator->create($request->user(config('jetstream.guard')), $request->all());
 
         return $this->redirectPath($creator);
     }
@@ -83,7 +83,7 @@ class TeamController extends Controller
     {
         $team = Jetstream::newTeamModel()->findOrFail($teamId);
 
-        app(UpdatesTeamNames::class)->update($request->user(), $team, $request->all());
+        app(UpdatesTeamNames::class)->update($request->user(config('jetstream.guard')), $team, $request->all());
 
         return back(303);
     }
@@ -99,7 +99,7 @@ class TeamController extends Controller
     {
         $team = Jetstream::newTeamModel()->findOrFail($teamId);
 
-        app(ValidateTeamDeletion::class)->validate($request->user(), $team);
+        app(ValidateTeamDeletion::class)->validate($request->user(config('jetstream.guard')), $team);
 
         $deleter = app(DeletesTeams::class);
 

--- a/src/Http/Controllers/Inertia/TeamMemberController.php
+++ b/src/Http/Controllers/Inertia/TeamMemberController.php
@@ -26,14 +26,14 @@ class TeamMemberController extends Controller
 
         if (Features::sendsTeamInvitations()) {
             app(InvitesTeamMembers::class)->invite(
-                $request->user(),
+                $request->user(config('jetstream.guard')),
                 $team,
                 $request->email ?: '',
                 $request->role
             );
         } else {
             app(AddsTeamMembers::class)->add(
-                $request->user(),
+                $request->user(config('jetstream.guard')),
                 $team,
                 $request->email ?: '',
                 $request->role
@@ -54,7 +54,7 @@ class TeamMemberController extends Controller
     public function update(Request $request, $teamId, $userId)
     {
         app(UpdateTeamMemberRole::class)->update(
-            $request->user(),
+            $request->user(config('jetstream.guard')),
             Jetstream::newTeamModel()->findOrFail($teamId),
             $userId,
             $request->role
@@ -76,12 +76,12 @@ class TeamMemberController extends Controller
         $team = Jetstream::newTeamModel()->findOrFail($teamId);
 
         app(RemovesTeamMembers::class)->remove(
-            $request->user(),
+            $request->user(config('jetstream.guard')),
             $team,
             $user = Jetstream::findUserByIdOrFail($userId)
         );
 
-        if ($request->user()->id === $user->id) {
+        if ($request->user(config('jetstream.guard'))->id === $user->id) {
             return redirect(config('fortify.home'));
         }
 

--- a/src/Http/Controllers/Inertia/UserProfileController.php
+++ b/src/Http/Controllers/Inertia/UserProfileController.php
@@ -38,7 +38,7 @@ class UserProfileController extends Controller
 
         return collect(
             DB::connection(config('session.connection'))->table(config('session.table', 'sessions'))
-                    ->where('user_id', $request->user()->getAuthIdentifier())
+                    ->where('user_id', $request->user(config('jetstream.guard'))->getAuthIdentifier())
                     ->orderBy('last_activity', 'desc')
                     ->get()
         )->map(function ($session) use ($request) {

--- a/src/Http/Controllers/Livewire/ApiTokenController.php
+++ b/src/Http/Controllers/Livewire/ApiTokenController.php
@@ -17,7 +17,7 @@ class ApiTokenController extends Controller
     {
         return view('api.index', [
             'request' => $request,
-            'user' => $request->user(),
+            'user' => $request->user(config('jetstream.guard')),
         ]);
     }
 }

--- a/src/Http/Controllers/Livewire/TeamController.php
+++ b/src/Http/Controllers/Livewire/TeamController.php
@@ -25,7 +25,7 @@ class TeamController extends Controller
         }
 
         return view('teams.show', [
-            'user' => $request->user(),
+            'user' => $request->user(config('jetstream.guard')),
             'team' => $team,
         ]);
     }
@@ -41,7 +41,7 @@ class TeamController extends Controller
         Gate::authorize('create', Jetstream::newTeamModel());
 
         return view('teams.create', [
-            'user' => $request->user(),
+            'user' => $request->user(config('jetstream.guard')),
         ]);
     }
 }

--- a/src/Http/Controllers/Livewire/UserProfileController.php
+++ b/src/Http/Controllers/Livewire/UserProfileController.php
@@ -17,7 +17,7 @@ class UserProfileController extends Controller
     {
         return view('profile.show', [
             'request' => $request,
-            'user' => $request->user(),
+            'user' => $request->user(config('jetstream.guard')),
         ]);
     }
 }

--- a/src/Http/Controllers/TeamInvitationController.php
+++ b/src/Http/Controllers/TeamInvitationController.php
@@ -43,7 +43,7 @@ class TeamInvitationController extends Controller
      */
     public function destroy(Request $request, TeamInvitation $invitation)
     {
-        if (! Gate::forUser($request->user())->check('removeTeamMember', $invitation->team)) {
+        if (! Gate::forUser($request->user(config('jetstream.guard')))->check('removeTeamMember', $invitation->team)) {
             throw new AuthorizationException;
         }
 

--- a/src/Http/Livewire/ApiTokenManager.php
+++ b/src/Http/Livewire/ApiTokenManager.php
@@ -188,7 +188,7 @@ class ApiTokenManager extends Component
      */
     public function getUserProperty()
     {
-        return Auth::user();
+        return Auth::guard(config('jetstream.guard'))->user();
     }
 
     /**

--- a/src/Http/Livewire/CreateTeamForm.php
+++ b/src/Http/Livewire/CreateTeamForm.php
@@ -28,7 +28,7 @@ class CreateTeamForm extends Component
     {
         $this->resetErrorBag();
 
-        $creator->create(Auth::user(), $this->state);
+        $creator->create(Auth::guard(config('jetstream.guard'))->user(), $this->state);
 
         return $this->redirectPath($creator);
     }
@@ -40,7 +40,7 @@ class CreateTeamForm extends Component
      */
     public function getUserProperty()
     {
-        return Auth::user();
+        return Auth::guard(config('jetstream.guard'))->user();
     }
 
     /**

--- a/src/Http/Livewire/DeleteTeamForm.php
+++ b/src/Http/Livewire/DeleteTeamForm.php
@@ -46,7 +46,7 @@ class DeleteTeamForm extends Component
      */
     public function deleteTeam(ValidateTeamDeletion $validator, DeletesTeams $deleter)
     {
-        $validator->validate(Auth::user(), $this->team);
+        $validator->validate(Auth::guard(config('jetstream.guard'))->user(), $this->team);
 
         $deleter->delete($this->team);
 

--- a/src/Http/Livewire/DeleteUserForm.php
+++ b/src/Http/Livewire/DeleteUserForm.php
@@ -54,13 +54,13 @@ class DeleteUserForm extends Component
     {
         $this->resetErrorBag();
 
-        if (! Hash::check($this->password, Auth::user()->password)) {
+        if (! Hash::check($this->password, Auth::guard(config('jetstream.guard'))->user()->password)) {
             throw ValidationException::withMessages([
                 'password' => [__('This password does not match our records.')],
             ]);
         }
 
-        $deleter->delete(Auth::user()->fresh());
+        $deleter->delete(Auth::guard(config('jetstream.guard'))->user()->fresh());
 
         $auth->logout();
 

--- a/src/Http/Livewire/LogoutOtherBrowserSessionsForm.php
+++ b/src/Http/Livewire/LogoutOtherBrowserSessionsForm.php
@@ -51,7 +51,7 @@ class LogoutOtherBrowserSessionsForm extends Component
     {
         $this->resetErrorBag();
 
-        if (! Hash::check($this->password, Auth::user()->password)) {
+        if (! Hash::check($this->password, Auth::guard(config('jetstream.guard'))->user()->password)) {
             throw ValidationException::withMessages([
                 'password' => [__('This password does not match our records.')],
             ]);
@@ -78,7 +78,7 @@ class LogoutOtherBrowserSessionsForm extends Component
         }
 
         DB::connection(config('session.connection'))->table(config('session.table', 'sessions'))
-            ->where('user_id', Auth::user()->getAuthIdentifier())
+            ->where('user_id', Auth::guard(config('jetstream.guard'))->user()->getAuthIdentifier())
             ->where('id', '!=', request()->session()->getId())
             ->delete();
     }
@@ -96,7 +96,7 @@ class LogoutOtherBrowserSessionsForm extends Component
 
         return collect(
             DB::connection(config('session.connection'))->table(config('session.table', 'sessions'))
-                    ->where('user_id', Auth::user()->getAuthIdentifier())
+                    ->where('user_id', Auth::guard(config('jetstream.guard'))->user()->getAuthIdentifier())
                     ->orderBy('last_activity', 'desc')
                     ->get()
         )->map(function ($session) {

--- a/src/Http/Livewire/TeamMemberManager.php
+++ b/src/Http/Livewire/TeamMemberManager.php
@@ -241,7 +241,7 @@ class TeamMemberManager extends Component
      */
     public function getUserProperty()
     {
-        return Auth::user();
+        return Auth::guard(config('jetstream.guard'))->user();
     }
 
     /**

--- a/src/Http/Livewire/TwoFactorAuthenticationForm.php
+++ b/src/Http/Livewire/TwoFactorAuthenticationForm.php
@@ -40,7 +40,7 @@ class TwoFactorAuthenticationForm extends Component
             $this->ensurePasswordIsConfirmed();
         }
 
-        $enable(Auth::user());
+        $enable(Auth::guard(config('jetstream.guard'))->user());
 
         $this->showingQrCode = true;
         $this->showingRecoveryCodes = true;
@@ -72,7 +72,7 @@ class TwoFactorAuthenticationForm extends Component
             $this->ensurePasswordIsConfirmed();
         }
 
-        $generate(Auth::user());
+        $generate(Auth::guard(config('jetstream.guard'))->user());
 
         $this->showingRecoveryCodes = true;
     }
@@ -89,7 +89,7 @@ class TwoFactorAuthenticationForm extends Component
             $this->ensurePasswordIsConfirmed();
         }
 
-        $disable(Auth::user());
+        $disable(Auth::guard(config('jetstream.guard'))->user());
     }
 
     /**
@@ -99,7 +99,7 @@ class TwoFactorAuthenticationForm extends Component
      */
     public function getUserProperty()
     {
-        return Auth::user();
+        return Auth::guard(config('jetstream.guard'))->user();
     }
 
     /**

--- a/src/Http/Livewire/UpdatePasswordForm.php
+++ b/src/Http/Livewire/UpdatePasswordForm.php
@@ -29,7 +29,7 @@ class UpdatePasswordForm extends Component
     {
         $this->resetErrorBag();
 
-        $updater->update(Auth::user(), $this->state);
+        $updater->update(Auth::guard(config('jetstream.guard'))->user(), $this->state);
 
         $this->state = [
             'current_password' => '',
@@ -47,7 +47,7 @@ class UpdatePasswordForm extends Component
      */
     public function getUserProperty()
     {
-        return Auth::user();
+        return Auth::guard(config('jetstream.guard'))->user();
     }
 
     /**

--- a/src/Http/Livewire/UpdateProfileInformationForm.php
+++ b/src/Http/Livewire/UpdateProfileInformationForm.php
@@ -32,7 +32,7 @@ class UpdateProfileInformationForm extends Component
      */
     public function mount()
     {
-        $this->state = Auth::user()->withoutRelations()->toArray();
+        $this->state = Auth::guard(config('jetstream.guard'))->user()->withoutRelations()->toArray();
     }
 
     /**
@@ -46,7 +46,7 @@ class UpdateProfileInformationForm extends Component
         $this->resetErrorBag();
 
         $updater->update(
-            Auth::user(),
+            Auth::guard(config('jetstream.guard'))->user(),
             $this->photo
                 ? array_merge($this->state, ['photo' => $this->photo])
                 : $this->state
@@ -68,7 +68,7 @@ class UpdateProfileInformationForm extends Component
      */
     public function deleteProfilePhoto()
     {
-        Auth::user()->deleteProfilePhoto();
+        Auth::guard(config('jetstream.guard'))->user()->deleteProfilePhoto();
 
         $this->emit('refresh-navigation-menu');
     }
@@ -80,7 +80,7 @@ class UpdateProfileInformationForm extends Component
      */
     public function getUserProperty()
     {
-        return Auth::user();
+        return Auth::guard(config('jetstream.guard'))->user();
     }
 
     /**

--- a/src/Http/Livewire/UpdateTeamNameForm.php
+++ b/src/Http/Livewire/UpdateTeamNameForm.php
@@ -59,7 +59,7 @@ class UpdateTeamNameForm extends Component
      */
     public function getUserProperty()
     {
-        return Auth::user();
+        return Auth::guard(config('jetstream.guard'))->user();
     }
 
     /**

--- a/src/Http/Middleware/ShareInertiaData.php
+++ b/src/Http/Middleware/ShareInertiaData.php
@@ -22,9 +22,9 @@ class ShareInertiaData
         Inertia::share(array_filter([
             'jetstream' => function () use ($request) {
                 return [
-                    'canCreateTeams' => $request->user() &&
+                    'canCreateTeams' => $request->user(config('jetstream.guard')) &&
                                         Jetstream::hasTeamFeatures() &&
-                                        Gate::forUser($request->user())->check('create', Jetstream::newTeamModel()),
+                                        Gate::forUser($request->user(config('jetstream.guard')))->check('create', Jetstream::newTeamModel()),
                     'canManageTwoFactorAuthentication' => Features::canManageTwoFactorAuthentication(),
                     'canUpdatePassword' => Features::enabled(Features::updatePasswords()),
                     'canUpdateProfileInformation' => Features::canUpdateProfileInformation(),
@@ -37,18 +37,18 @@ class ShareInertiaData
                 ];
             },
             'user' => function () use ($request) {
-                if (! $request->user()) {
+                if (! $request->user(config('jetstream.guard'))) {
                     return;
                 }
 
-                if (Jetstream::hasTeamFeatures() && $request->user()) {
-                    $request->user()->currentTeam;
+                if (Jetstream::hasTeamFeatures() && $request->user(config('jetstream.guard'))) {
+                    $request->user(config('jetstream.guard'))->currentTeam;
                 }
 
-                return array_merge($request->user()->toArray(), array_filter([
-                    'all_teams' => Jetstream::hasTeamFeatures() ? $request->user()->allTeams()->values() : null,
+                return array_merge($request->user(config('jetstream.guard'))->toArray(), array_filter([
+                    'all_teams' => Jetstream::hasTeamFeatures() ? $request->user(config('jetstream.guard'))->allTeams()->values() : null,
                 ]), [
-                    'two_factor_enabled' => ! is_null($request->user()->two_factor_secret),
+                    'two_factor_enabled' => ! is_null($request->user(config('jetstream.guard'))->two_factor_secret),
                 ]);
             },
             'errorBags' => function () {

--- a/stubs/livewire/resources/views/navigation-menu.blade.php
+++ b/stubs/livewire/resources/views/navigation-menu.blade.php
@@ -26,7 +26,7 @@
                             <x-slot name="trigger">
                                 <span class="inline-flex rounded-md">
                                     <button type="button" class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-gray-500 bg-white hover:bg-gray-50 hover:text-gray-700 focus:outline-none focus:bg-gray-50 active:bg-gray-50 transition">
-                                        {{ Auth::user()->currentTeam->name }}
+                                        {{ Auth::guard(config('jetstream.guard'))->user()->currentTeam->name }}
 
                                         <svg class="ml-2 -mr-0.5 h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
                                             <path fill-rule="evenodd" d="M10 3a1 1 0 01.707.293l3 3a1 1 0 01-1.414 1.414L10 5.414 7.707 7.707a1 1 0 01-1.414-1.414l3-3A1 1 0 0110 3zm-3.707 9.293a1 1 0 011.414 0L10 14.586l2.293-2.293a1 1 0 011.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z" clip-rule="evenodd" />
@@ -43,7 +43,7 @@
                                     </div>
 
                                     <!-- Team Settings -->
-                                    <x-jet-dropdown-link href="{{ route('teams.show', Auth::user()->currentTeam->id) }}">
+                                    <x-jet-dropdown-link href="{{ route('teams.show', Auth::guard(config('jetstream.guard'))->user()->currentTeam->id) }}">
                                         {{ __('Team Settings') }}
                                     </x-jet-dropdown-link>
 
@@ -60,7 +60,7 @@
                                         {{ __('Switch Teams') }}
                                     </div>
 
-                                    @foreach (Auth::user()->allTeams() as $team)
+                                    @foreach (Auth::guard(config('jetstream.guard'))->user()->allTeams() as $team)
                                         <x-jet-switchable-team :team="$team" />
                                     @endforeach
                                 </div>
@@ -75,12 +75,12 @@
                         <x-slot name="trigger">
                             @if (Laravel\Jetstream\Jetstream::managesProfilePhotos())
                                 <button class="flex text-sm border-2 border-transparent rounded-full focus:outline-none focus:border-gray-300 transition">
-                                    <img class="h-8 w-8 rounded-full object-cover" src="{{ Auth::user()->profile_photo_url }}" alt="{{ Auth::user()->name }}" />
+                                    <img class="h-8 w-8 rounded-full object-cover" src="{{ Auth::guard(config('jetstream.guard'))->user()->profile_photo_url }}" alt="{{ Auth::guard(config('jetstream.guard'))->user()->name }}" />
                                 </button>
                             @else
                                 <span class="inline-flex rounded-md">
                                     <button type="button" class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-gray-500 bg-white hover:text-gray-700 focus:outline-none transition">
-                                        {{ Auth::user()->name }}
+                                        {{ Auth::guard(config('jetstream.guard'))->user()->name }}
 
                                         <svg class="ml-2 -mr-0.5 h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
                                             <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
@@ -148,13 +148,13 @@
             <div class="flex items-center px-4">
                 @if (Laravel\Jetstream\Jetstream::managesProfilePhotos())
                     <div class="shrink-0 mr-3">
-                        <img class="h-10 w-10 rounded-full object-cover" src="{{ Auth::user()->profile_photo_url }}" alt="{{ Auth::user()->name }}" />
+                        <img class="h-10 w-10 rounded-full object-cover" src="{{ Auth::guard(config('jetstream.guard'))->user()->profile_photo_url }}" alt="{{ Auth::guard(config('jetstream.guard'))->user()->name }}" />
                     </div>
                 @endif
 
                 <div>
-                    <div class="font-medium text-base text-gray-800">{{ Auth::user()->name }}</div>
-                    <div class="font-medium text-sm text-gray-500">{{ Auth::user()->email }}</div>
+                    <div class="font-medium text-base text-gray-800">{{ Auth::guard(config('jetstream.guard'))->user()->name }}</div>
+                    <div class="font-medium text-sm text-gray-500">{{ Auth::guard(config('jetstream.guard'))->user()->email }}</div>
                 </div>
             </div>
 
@@ -190,7 +190,7 @@
                     </div>
 
                     <!-- Team Settings -->
-                    <x-jet-responsive-nav-link href="{{ route('teams.show', Auth::user()->currentTeam->id) }}" :active="request()->routeIs('teams.show')">
+                    <x-jet-responsive-nav-link href="{{ route('teams.show', Auth::guard(config('jetstream.guard'))->user()->currentTeam->id) }}" :active="request()->routeIs('teams.show')">
                         {{ __('Team Settings') }}
                     </x-jet-responsive-nav-link>
 
@@ -207,7 +207,7 @@
                         {{ __('Switch Teams') }}
                     </div>
 
-                    @foreach (Auth::user()->allTeams() as $team)
+                    @foreach (Auth::guard(config('jetstream.guard'))->user()->allTeams() as $team)
                         <x-jet-switchable-team :team="$team" component="jet-responsive-nav-link" />
                     @endforeach
                 @endif


### PR DESCRIPTION
I'm working on a multitenant application with a separate frontend and backend auth. The frontend uses a customer auth guard and the backend uses the default web auth guard. Everything is configured correctly and works fine as long as I sign into the frontend first and then the backend. If I sign into the backend and then try to load the frontend I get errors with Inertia in the ShareInertiaData middleware, specifically this section:

```php
'user' => function () use ($request) {
    if (! $request->user()) {
        return;
    }

    if (Jetstream::hasTeamFeatures() && $request->user()) {
        $request->user()->currentTeam;
    }

    return array_merge($request->user()->toArray(), array_filter([
        'all_teams' => Jetstream::hasTeamFeatures() ? $request->user()->allTeams()->values() : null,
    ]), [
        'two_factor_enabled' => ! is_null($request->user()->two_factor_secret),
    ]);
},
```

I realized that Inertia is resolving the wrong user if I'm not signed into the frontend first because the $request->user() calls do not respect the config('jetstream.guard'), and I'm using teams on the frontend, but not the backend so ! $request->user() doesn't catch it. 

I fixed this file to respect the config guard and it has fixed my problems. 

```php
<?php

namespace Laravel\Jetstream\Http\Middleware;

use Illuminate\Support\Facades\Gate;
use Illuminate\Support\Facades\Session;
use Inertia\Inertia;
use Laravel\Fortify\Features;
use Laravel\Jetstream\Jetstream;

class ShareInertiaData
{
    /**
     * Handle the incoming request.
     *
     * @param  \Illuminate\Http\Request  $request
     * @param  callable  $next
     * @return \Illuminate\Http\Response
     */
    public function handle($request, $next)
    {
        Inertia::share(array_filter([
            'jetstream' => function () use ($request) {
                return [
                    'canCreateTeams' => $request->user(config('jetstream.guard')) &&
                                        Jetstream::hasTeamFeatures() &&
                                        Gate::forUser($request->user(config('jetstream.guard')))->check('create', Jetstream::newTeamModel()),
                    'canManageTwoFactorAuthentication' => Features::canManageTwoFactorAuthentication(),
                    'canUpdatePassword' => Features::enabled(Features::updatePasswords()),
                    'canUpdateProfileInformation' => Features::canUpdateProfileInformation(),
                    'flash' => $request->session()->get('flash', []),
                    'hasAccountDeletionFeatures' => Jetstream::hasAccountDeletionFeatures(),
                    'hasApiFeatures' => Jetstream::hasApiFeatures(),
                    'hasTeamFeatures' => Jetstream::hasTeamFeatures(),
                    'hasTermsAndPrivacyPolicyFeature' => Jetstream::hasTermsAndPrivacyPolicyFeature(),
                    'managesProfilePhotos' => Jetstream::managesProfilePhotos(),
                ];
            },
            'user' => function () use ($request) {
                if (! $request->user(config('jetstream.guard'))) {
                    return;
                }

                if (Jetstream::hasTeamFeatures() && $request->user(config('jetstream.guard'))) {
                    $request->user(config('jetstream.guard'))->currentTeam;
                }

                return array_merge($request->user(config('jetstream.guard'))->toArray(), array_filter([
                    'all_teams' => Jetstream::hasTeamFeatures() ? $request->user(config('jetstream.guard'))->allTeams()->values() : null,
                ]), [
                    'two_factor_enabled' => ! is_null($request->user(config('jetstream.guard'))->two_factor_secret),
                ]);
            },
            'errorBags' => function () {
                return collect(optional(Session::get('errors'))->getBags() ?: [])->mapWithKeys(function ($bag, $key) {
                    return [$key => $bag->messages()];
                })->all();
            },
        ]));

        return $next($request);
    }
}

```

But I started looking around and noticed that most, if not all, of the calls to either $request->user() and Auth::user() do not respect the config guard. So it went through and replaced those as well.

In summary:
```php
$request()->user() => $request->user(config('jetstream.guard'))
Auth::user() => Auth::guard(config('jetstream.guard'))->user()
```
