### PR TITLE
Fix: don't show error when user has no teams

### DIFF
--- a/stubs/livewire/resources/views/navigation-menu.blade.php
+++ b/stubs/livewire/resources/views/navigation-menu.blade.php
@@ -57,7 +57,7 @@
 
                                     <div class="border-t border-gray-100"></div>
 
-                                    @if(Auth::user()->allTeams())
+                                    @if(Auth::user()->allTeams()->count())
                                     <!-- Team Switcher -->
                                     <div class="block px-4 py-2 text-xs text-gray-400">
                                         {{ __('Switch Teams') }}

--- a/stubs/livewire/resources/views/navigation-menu.blade.php
+++ b/stubs/livewire/resources/views/navigation-menu.blade.php
@@ -26,7 +26,7 @@
                             <x-slot name="trigger">
                                 <span class="inline-flex rounded-md">
                                     <button type="button" class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-gray-500 bg-white hover:bg-gray-50 hover:text-gray-700 focus:outline-none focus:bg-gray-50 active:bg-gray-50 transition">
-                                        {{ Auth::user()->currentTeam->name }}
+                                        {{ Auth::user()->currentTeam ? Auth::user()->currentTeam->name : __('My Teams') }}
 
                                         <svg class="ml-2 -mr-0.5 h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
                                             <path fill-rule="evenodd" d="M10 3a1 1 0 01.707.293l3 3a1 1 0 01-1.414 1.414L10 5.414 7.707 7.707a1 1 0 01-1.414-1.414l3-3A1 1 0 0110 3zm-3.707 9.293a1 1 0 011.414 0L10 14.586l2.293-2.293a1 1 0 011.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z" clip-rule="evenodd" />
@@ -43,9 +43,11 @@
                                     </div>
 
                                     <!-- Team Settings -->
+                                    @if(Auth::user()->currentTeam)
                                     <x-jet-dropdown-link href="{{ route('teams.show', Auth::user()->currentTeam->id) }}">
                                         {{ __('Team Settings') }}
                                     </x-jet-dropdown-link>
+                                    @endif
 
                                     @can('create', Laravel\Jetstream\Jetstream::newTeamModel())
                                         <x-jet-dropdown-link href="{{ route('teams.create') }}">
@@ -55,6 +57,7 @@
 
                                     <div class="border-t border-gray-100"></div>
 
+                                    @if(Auth::user()->allTeams())
                                     <!-- Team Switcher -->
                                     <div class="block px-4 py-2 text-xs text-gray-400">
                                         {{ __('Switch Teams') }}
@@ -63,6 +66,7 @@
                                     @foreach (Auth::user()->allTeams() as $team)
                                         <x-jet-switchable-team :team="$team" />
                                     @endforeach
+                                    @endif
                                 </div>
                             </x-slot>
                         </x-jet-dropdown>
@@ -190,7 +194,7 @@
                     </div>
 
                     <!-- Team Settings -->
-                    <x-jet-responsive-nav-link href="{{ route('teams.show', Auth::user()->currentTeam->id) }}" :active="request()->routeIs('teams.show')">
+                    <x-jet-responsive-nav-link href="{{ Auth::user()->currentTeam && route('teams.show', Auth::user()->currentTeam->id) }}" :active="request()->routeIs('teams.show')">
                         {{ __('Team Settings') }}
                     </x-jet-responsive-nav-link>
 


### PR DESCRIPTION
This is a quick fix to avoid throwing `ErrorException` when Jetstream is installed but the user has no teams yet.

Description: when Jetstream is installed and the teams feature is enabled but the user doesn't have any teams, it throws an `ErrorException` with the message `Attempt to read property "name" on null`.

Error screenshot attached.
<img width="1790" alt="Screenshot 2022-02-20 at 11 23 46 PM" src="https://user-images.githubusercontent.com/8243067/154864861-0d78bdb2-f023-415e-8879-f00b89300b7f.png">

