### PR TITLE
[2.x] Fix missing laravel version upgrade for anonymous migrations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^7.3|^8.0",
         "ext-json": "*",
-        "illuminate/support": "^8.0|^9.0",
+        "illuminate/support": "^8.37|^9.0",
         "jenssegers/agent": "^2.6",
         "laravel/fortify": "^1.9"
     },


### PR DESCRIPTION
PR #961 updated the migrations files to use the new anonymous class style. This is only supported with laravel >= 8.37