### PR TITLE
HasTeams.php: make belongsToTeam accept null team

### DIFF
--- a/src/HasTeams.php
+++ b/src/HasTeams.php
@@ -119,6 +119,10 @@ trait HasTeams
      */
     public function belongsToTeam($team)
     {
+        if (is_null($team)) {
+            return false;
+        }
+        
         return $this->teams->contains(function ($t) use ($team) {
             return $t->id === $team->id;
         }) || $this->ownsTeam($team);


### PR DESCRIPTION
This will allow users to pass a null value into belongsToTeam and have it return false instead of blowing up, similarly to ownsTeam.

It makes intuitive sense that if you were to Find() a team, for example, and it came back null, you could pass that in and simply get the response back that you do not belong to the team since it does not exist.

In my case, teams are able to have nullable parentTeam's, so for my policy I would like to be able to simply pass:
`can view: $user->belongsToTeam($user->currentTeam->parentTeam)`

It would allow me to write more elegant code than wrapping all of these in a check for if they're null or not.