### PR TITLE
Solving profile photo issue when using Socialite

### DIFF
--- a/src/HasProfilePhoto.php
+++ b/src/HasProfilePhoto.php
@@ -59,9 +59,15 @@ trait HasProfilePhoto
      */
     public function getProfilePhotoUrlAttribute()
     {
-        return $this->profile_photo_path
-                    ? Storage::disk($this->profilePhotoDisk())->url($this->profile_photo_path)
-                    : $this->defaultProfilePhotoUrl();
+         $photo = $this->profile_photo_path;
+
+        if (str_starts_with($this->profile_photo_path, 'profile-photos'))
+            return Storage::disk($this->profilePhotoDisk())->url($this->profile_photo_path);
+
+        if (str_starts_with($this->profile_photo_path, 'https://'))
+            return $this->profile_photo_path;
+
+        return $this->defaultProfilePhotoUrl();
     }
 
     /**


### PR DESCRIPTION
When using Laravel Jetstream along with Socialite, the avatar URL which is retrieved from the provider gets broken!  

For example if the URL is like this:  
``
https://avatars.githubusercontent.com/u/30769988
``

Jetstream turns it to something like this:
``
/storage/profile-photos/https://avatars.githubusercontent.com/u/30769988
``

This PR solves that problem.
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

If you change the behavior of the Inertia stack you're expected to update the Livewire stack as well and vice versa.
-->
