### PR TITLE
[2.x] Confirm 2FA when enabling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "ext-json": "*",
         "illuminate/support": "^8.37|^9.0",
         "jenssegers/agent": "^2.6",
-        "laravel/fortify": "^1.9"
+        "laravel/fortify": "^1.11.1"
     },
     "require-dev": {
         "inertiajs/inertia-laravel": "^0.5.2",

--- a/src/Http/Controllers/Inertia/Concerns/ConfirmsTwoFactorAuthentication.php
+++ b/src/Http/Controllers/Inertia/Concerns/ConfirmsTwoFactorAuthentication.php
@@ -51,7 +51,7 @@ trait ConfirmsTwoFactorAuthentication
     protected function twoFactorAuthenticationDisabled(Request $request)
     {
         return is_null($request->user()->two_factor_secret) &&
-               is_null($request->user()->two_factor_confirmed_at);
+            is_null($request->user()->two_factor_confirmed_at);
     }
 
     /**
@@ -63,9 +63,9 @@ trait ConfirmsTwoFactorAuthentication
     protected function hasJustBegunConfirmingTwoFactorAuthentication(Request $request)
     {
         return ! is_null($request->user()->two_factor_secret) &&
-               is_null($request->user()->two_factor_confirmed_at) &&
-               $request->session()->has('two_factor_empty_at') &&
-               is_null($request->session()->get('two_factor_confirming_at'));
+            is_null($request->user()->two_factor_confirmed_at) &&
+            $request->session()->has('two_factor_empty_at') &&
+            is_null($request->session()->get('two_factor_confirming_at'));
     }
 
     /**
@@ -78,6 +78,6 @@ trait ConfirmsTwoFactorAuthentication
     protected function neverFinishedConfirmingTwoFactorAuthentication(Request $request, $currentTime)
     {
         return is_null($request->user()->two_factor_confirmed_at) &&
-               $request->session()->get('two_factor_confirming_at', 0) != $currentTime;
+            $request->session()->get('two_factor_confirming_at', 0) != $currentTime;
     }
 }

--- a/src/Http/Controllers/Inertia/Concerns/ConfirmsTwoFactorAuthentication.php
+++ b/src/Http/Controllers/Inertia/Concerns/ConfirmsTwoFactorAuthentication.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Laravel\Jetstream\Http\Controllers\Inertia\Concerns;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Laravel\Fortify\Actions\DisableTwoFactorAuthentication;
+use Laravel\Fortify\Features;
+
+trait ConfirmsTwoFactorAuthentication
+{
+    /**
+     * Validate the two factor authentication state for the request.
+     *
+     * @param  \Illuminate\Http\Request
+     * @return void
+     */
+    protected function validateTwoFactorAuthenticationState(Request $request)
+    {
+        if (! Features::optionEnabled(Features::twoFactorAuthentication(), 'confirm')) {
+            return;
+        }
+
+        $currentTime = time();
+
+        // Notate totally disabled state in session...
+        if ($this->twoFactorAuthenticationDisabled($request)) {
+            $request->session()->put('two_factor_empty_at', $currentTime);
+        }
+
+        // If was previously totally disabled this session but is now confirming, notate time...
+        if ($this->hasJustBegunConfirmingTwoFactorAuthentication($request)) {
+            $request->session()->put('two_factor_confirming_at', $currentTime);
+        }
+
+        // If the profile is reloaded and is not confirmed but was previously in confirming state, disable...
+        if ($this->neverFinishedConfirmingTwoFactorAuthentication($request, $currentTime)) {
+            app(DisableTwoFactorAuthentication::class)(Auth::user());
+
+            $request->session()->put('two_factor_empty_at', $currentTime);
+            $request->session()->remove('two_factor_confirming_at');
+        }
+    }
+
+    /**
+     * Determine if two factor authenticatoin is totally disabled.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return bool
+     */
+    protected function twoFactorAuthenticationDisabled(Request $request)
+    {
+        return is_null($request->user()->two_factor_secret) &&
+               is_null($request->user()->two_factor_confirmed_at);
+    }
+
+    /**
+     * Determine if two factor authentication is just now being confirmed within the last request cycle.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return bool
+     */
+    protected function hasJustBegunConfirmingTwoFactorAuthentication(Request $request)
+    {
+        return ! is_null($request->user()->two_factor_secret) &&
+               is_null($request->user()->two_factor_confirmed_at) &&
+               $request->session()->has('two_factor_empty_at') &&
+               is_null($request->session()->get('two_factor_confirming_at'));
+    }
+
+    /**
+     * Determine if two factor authentication was never totally confirmed once confirmation started.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $currentTime
+     * @return bool
+     */
+    protected function neverFinishedConfirmingTwoFactorAuthentication(Request $request, $currentTime)
+    {
+        return is_null($request->user()->two_factor_confirmed_at) &&
+               $request->session()->get('two_factor_confirming_at', 0) != $currentTime;
+    }
+}

--- a/src/Http/Controllers/Inertia/UserProfileController.php
+++ b/src/Http/Controllers/Inertia/UserProfileController.php
@@ -14,6 +14,8 @@ use Laravel\Jetstream\Jetstream;
 
 class UserProfileController extends Controller
 {
+    use Concerns\ConfirmsTwoFactorAuthentication;
+
     /**
      * Show the general profile settings screen.
      *
@@ -22,34 +24,7 @@ class UserProfileController extends Controller
      */
     public function show(Request $request)
     {
-        $currentTime = time();
-
-        // Notate totally disabled state in session...
-        if (Features::optionEnabled(Features::twoFactorAuthentication(), 'confirm') &&
-            is_null(Auth::user()->two_factor_secret) &&
-            is_null(Auth::user()->two_factor_confirmed_at)) {
-            $request->session()->put('two_factor_empty_at', $currentTime);
-        }
-
-        // If was previously totally disabled this session but is now confirming, notate time...
-        if (Features::optionEnabled(Features::twoFactorAuthentication(), 'confirm') &&
-            ! is_null(Auth::user()->two_factor_secret) &&
-            is_null(Auth::user()->two_factor_confirmed_at) &&
-            $request->session()->has('two_factor_empty_at') &&
-            is_null($request->session()->get('two_factor_confirming_at'))) {
-            $request->session()->put('two_factor_confirming_at', $currentTime);
-        }
-
-        // If the profile is reloaded and is not confirmed but was previously in confirming state, disable...
-        if (Features::optionEnabled(Features::twoFactorAuthentication(), 'confirm') &&
-            is_null(Auth::user()->two_factor_confirmed_at) &&
-            // Don't disable if confirmation was first noted during this same request...
-            $request->session()->get('two_factor_confirming_at', 0) != $currentTime) {
-            app(DisableTwoFactorAuthentication::class)(Auth::user());
-
-            $request->session()->put('two_factor_empty_at', $currentTime);
-            $request->session()->remove('two_factor_confirming_at');
-        }
+        $this->validateTwoFactorAuthenticationState($request);
 
         return Jetstream::inertia()->render($request, 'Profile/Show', [
             'confirmsTwoFactorAuthentication' => Features::optionEnabled(Features::twoFactorAuthentication(), 'confirm'),

--- a/src/Http/Livewire/TwoFactorAuthenticationForm.php
+++ b/src/Http/Livewire/TwoFactorAuthenticationForm.php
@@ -23,7 +23,7 @@ class TwoFactorAuthenticationForm extends Component
     public $showingQrCode = false;
 
     /**
-     * Indicates if two factor authentication confirmation input and button are being displayed.
+     * Indicates if the two factor authentication confirmation input and button are being displayed.
      *
      * @var bool
      */
@@ -37,7 +37,7 @@ class TwoFactorAuthenticationForm extends Component
     public $showingRecoveryCodes = false;
 
     /**
-     * The OTP code for confirming 2FA.
+     * The OTP code for confirming two factor authentication.
      *
      * @var string|null
      */

--- a/src/Http/Livewire/TwoFactorAuthenticationForm.php
+++ b/src/Http/Livewire/TwoFactorAuthenticationForm.php
@@ -3,6 +3,7 @@
 namespace Laravel\Jetstream\Http\Livewire;
 
 use Illuminate\Support\Facades\Auth;
+use Laravel\Fortify\Actions\ConfirmTwoFactorAuthentication;
 use Laravel\Fortify\Actions\DisableTwoFactorAuthentication;
 use Laravel\Fortify\Actions\EnableTwoFactorAuthentication;
 use Laravel\Fortify\Actions\GenerateNewRecoveryCodes;
@@ -22,11 +23,38 @@ class TwoFactorAuthenticationForm extends Component
     public $showingQrCode = false;
 
     /**
+     * Indicates if two factor authentication confirmation input and button are being displayed.
+     *
+     * @var bool
+     */
+    public $showingConfirmation = false;
+
+    /**
      * Indicates if two factor authentication recovery codes are being displayed.
      *
      * @var bool
      */
     public $showingRecoveryCodes = false;
+
+    /**
+     * The OTP code for confirming 2FA.
+     *
+     * @var string|null
+     */
+    public $code;
+
+    /**
+     * Mount the component.
+     *
+     * @return void
+     */
+    public function mount()
+    {
+        if (Features::optionEnabled(Features::twoFactorAuthentication(), 'confirm') &&
+            is_null(Auth::user()->two_factor_confirmed_at)) {
+            app(DisableTwoFactorAuthentication::class)(Auth::user());
+        }
+    }
 
     /**
      * Enable two factor authentication for the user.
@@ -43,6 +71,30 @@ class TwoFactorAuthenticationForm extends Component
         $enable(Auth::user());
 
         $this->showingQrCode = true;
+
+        if (Features::optionEnabled(Features::twoFactorAuthentication(), 'confirm')) {
+            $this->showingConfirmation = true;
+        } else {
+            $this->showingRecoveryCodes = true;
+        }
+    }
+
+    /**
+     * Confirm two factor authentication for the user.
+     *
+     * @param  \Laravel\Fortify\Actions\ConfirmTwoFactorAuthentication  $confirm
+     * @return void
+     */
+    public function confirmTwoFactorAuthentication(ConfirmTwoFactorAuthentication $confirm)
+    {
+        if (Features::optionEnabled(Features::twoFactorAuthentication(), 'confirmPassword')) {
+            $this->ensurePasswordIsConfirmed();
+        }
+
+        $confirm(Auth::user(), $this->code);
+
+        $this->showingQrCode = false;
+        $this->showingConfirmation = false;
         $this->showingRecoveryCodes = true;
     }
 
@@ -90,6 +142,10 @@ class TwoFactorAuthenticationForm extends Component
         }
 
         $disable(Auth::user());
+
+        $this->showingQrCode = false;
+        $this->showingConfirmation = false;
+        $this->showingRecoveryCodes = false;
     }
 
     /**

--- a/stubs/inertia/resources/js/Pages/Profile/Show.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/Show.vue
@@ -21,7 +21,9 @@
                 </div>
 
                 <div v-if="$page.props.jetstream.canManageTwoFactorAuthentication">
-                    <two-factor-authentication-form class="mt-10 sm:mt-0" />
+                    <two-factor-authentication-form
+                                class="mt-10 sm:mt-0"
+                                :requires-confirmation="confirmsTwoFactorAuthentication" />
 
                     <jet-section-border />
                 </div>
@@ -49,7 +51,10 @@
     import UpdateProfileInformationForm from '@/Pages/Profile/Partials/UpdateProfileInformationForm.vue'
 
     export default defineComponent({
-        props: ['sessions'],
+        props: [
+            'confirmsTwoFactorAuthentication',
+            'sessions'
+        ],
 
         components: {
             AppLayout,

--- a/stubs/livewire/resources/views/profile/two-factor-authentication-form.blade.php
+++ b/stubs/livewire/resources/views/profile/two-factor-authentication-form.blade.php
@@ -46,7 +46,7 @@
                     <div class="mt-4">
                         <x-jet-label for="code" value="{{ __('Code') }}" />
 
-                        <x-jet-input id="code" class="block mt-1 w-1/2" type="text" inputmode="numeric" name="code" autofocus autocomplete="one-time-code"
+                        <x-jet-input id="code" type="text" name="code" class="block mt-1 w-1/2" inputmode="numeric" autofocus autocomplete="one-time-code"
                             wire:model.defer="code"
                             wire:keydown.enter="confirmTwoFactorAuthentication" />
 

--- a/stubs/livewire/resources/views/profile/two-factor-authentication-form.blade.php
+++ b/stubs/livewire/resources/views/profile/two-factor-authentication-form.blade.php
@@ -11,7 +11,7 @@
         <h3 class="text-lg font-medium text-gray-900">
             @if ($this->enabled)
                 @if ($showingConfirmation)
-                    {{ __('You are enabling two factor authentication.') }}
+                    {{ __('Finish enabling two factor authentication.') }}
                 @else
                     {{ __('You have enabled two factor authentication.') }}
                 @endif
@@ -31,7 +31,7 @@
                 <div class="mt-4 max-w-xl text-sm text-gray-600">
                     <p class="font-semibold">
                         @if ($showingConfirmation)
-                            {{ __('Scan the following QR code using your phone\'s authenticator application and confirm it with the generated OTP code.') }}
+                            {{ __('To finish enabling two factor authentication, scan the following QR code using your phone\'s authenticator application and provide the generated OTP code.') }}
                         @else
                             {{ __('Two factor authentication is now enabled. Scan the following QR code using your phone\'s authenticator application.') }}
                         @endif
@@ -45,9 +45,11 @@
                 @if ($showingConfirmation)
                     <div class="mt-4">
                         <x-jet-label for="code" value="{{ __('Code') }}" />
-                        <x-jet-input id="code" class="block mt-1 w-full" type="text" inputmode="numeric" name="code" autofocus autocomplete="one-time-code"
+
+                        <x-jet-input id="code" class="block mt-1 w-1/2" type="text" inputmode="numeric" name="code" autofocus autocomplete="one-time-code"
                             wire:model.defer="code"
                             wire:keydown.enter="confirmTwoFactorAuthentication" />
+
                         <x-jet-input-error for="code" class="mt-2" />
                     </div>
                 @endif
@@ -84,7 +86,7 @@
                     </x-jet-confirms-password>
                 @elseif ($showingConfirmation)
                     <x-jet-confirms-password wire:then="confirmTwoFactorAuthentication">
-                        <x-jet-button type="button" wire:loading.attr="disabled">
+                        <x-jet-button type="button" class="mr-3" wire:loading.attr="disabled">
                             {{ __('Confirm') }}
                         </x-jet-button>
                     </x-jet-confirms-password>
@@ -96,11 +98,20 @@
                     </x-jet-confirms-password>
                 @endif
 
-                <x-jet-confirms-password wire:then="disableTwoFactorAuthentication">
-                    <x-jet-danger-button wire:loading.attr="disabled">
-                        {{ __('Disable') }}
-                    </x-jet-danger-button>
-                </x-jet-confirms-password>
+                @if ($showingConfirmation)
+                    <x-jet-confirms-password wire:then="disableTwoFactorAuthentication">
+                        <x-jet-secondary-button wire:loading.attr="disabled">
+                            {{ __('Cancel') }}
+                        </x-jet-secondary-button>
+                    </x-jet-confirms-password>
+                @else
+                    <x-jet-confirms-password wire:then="disableTwoFactorAuthentication">
+                        <x-jet-danger-button wire:loading.attr="disabled">
+                            {{ __('Disable') }}
+                        </x-jet-danger-button>
+                    </x-jet-confirms-password>
+                @endif
+
             @endif
         </div>
     </x-slot>

--- a/stubs/livewire/resources/views/profile/two-factor-authentication-form.blade.php
+++ b/stubs/livewire/resources/views/profile/two-factor-authentication-form.blade.php
@@ -10,7 +10,11 @@
     <x-slot name="content">
         <h3 class="text-lg font-medium text-gray-900">
             @if ($this->enabled)
-                {{ __('You have enabled two factor authentication.') }}
+                @if ($showingConfirmation)
+                    {{ __('You are enabling two factor authentication.') }}
+                @else
+                    {{ __('You have enabled two factor authentication.') }}
+                @endif
             @else
                 {{ __('You have not enabled two factor authentication.') }}
             @endif
@@ -26,13 +30,27 @@
             @if ($showingQrCode)
                 <div class="mt-4 max-w-xl text-sm text-gray-600">
                     <p class="font-semibold">
-                        {{ __('Two factor authentication is now enabled. Scan the following QR code using your phone\'s authenticator application.') }}
+                        @if ($showingConfirmation)
+                            {{ __('Scan the following QR code using your phone\'s authenticator application and confirm it with the generated OTP code.') }}
+                        @else
+                            {{ __('Two factor authentication is now enabled. Scan the following QR code using your phone\'s authenticator application.') }}
+                        @endif
                     </p>
                 </div>
 
                 <div class="mt-4">
                     {!! $this->user->twoFactorQrCodeSvg() !!}
                 </div>
+
+                @if ($showingConfirmation)
+                    <div class="mt-4">
+                        <x-jet-label for="code" value="{{ __('Code') }}" />
+                        <x-jet-input id="code" class="block mt-1 w-full" type="text" inputmode="numeric" name="code" autofocus autocomplete="one-time-code"
+                            wire:model.defer="code"
+                            wire:keydown.enter="confirmTwoFactorAuthentication" />
+                        <x-jet-input-error for="code" class="mt-2" />
+                    </div>
+                @endif
             @endif
 
             @if ($showingRecoveryCodes)
@@ -63,6 +81,12 @@
                         <x-jet-secondary-button class="mr-3">
                             {{ __('Regenerate Recovery Codes') }}
                         </x-jet-secondary-button>
+                    </x-jet-confirms-password>
+                @elseif ($showingConfirmation)
+                    <x-jet-confirms-password wire:then="confirmTwoFactorAuthentication">
+                        <x-jet-button type="button" wire:loading.attr="disabled">
+                            {{ __('Confirm') }}
+                        </x-jet-button>
                     </x-jet-confirms-password>
                 @else
                     <x-jet-confirms-password wire:then="showRecoveryCodes">

--- a/tests/UserProfileControllerTest.php
+++ b/tests/UserProfileControllerTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Laravel\Jetstream\Tests;
+
+use Illuminate\Support\Facades\Schema;
+use Laravel\Fortify\Actions\DisableTwoFactorAuthentication;
+use Laravel\Fortify\Features;
+use Laravel\Jetstream\Jetstream;
+use Laravel\Jetstream\Tests\Fixtures\User;
+use Mockery as m;
+
+class UserProfileControllerTest extends OrchestraTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Jetstream::useUserModel(User::class);
+    }
+
+    public function test_empty_two_factor_state_is_noted()
+    {
+        $this->migrate();
+
+        $disable = $this->mock(DisableTwoFactorAuthentication::class);
+        $disable->shouldReceive('__invoke')->once();
+
+        Jetstream::$inertiaManager = $inertia = m::mock();
+        $inertia->shouldReceive('render')->once();
+
+        $user = User::forceCreate([
+            'name' => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
+            'password' => 'secret',
+        ]);
+
+        $response = $this->actingAs($user)->get('/user/profile');
+
+        $response->assertSessionHas('two_factor_empty_at');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_two_factor_is_not_disabled_if_was_previously_empty_and_currently_confirming()
+    {
+        $this->migrate();
+
+        $disable = $this->mock(DisableTwoFactorAuthentication::class);
+        $disable->shouldReceive('__invoke')->never();
+
+        Jetstream::$inertiaManager = $inertia = m::mock();
+        $inertia->shouldReceive('render')->once();
+
+        $user = User::forceCreate([
+            'name' => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
+            'password' => 'secret',
+            'two_factor_secret' => 'test-secret',
+        ]);
+
+        $response = $this->actingAs($user)
+                        ->withSession(['two_factor_empty_at' => time()])
+                        ->get('/user/profile');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_two_factor_is_disabled_if_was_previously_confirming_and_page_is_reloaded()
+    {
+        $this->migrate();
+
+        $disable = $this->mock(DisableTwoFactorAuthentication::class);
+        $disable->shouldReceive('__invoke')->once();
+
+        Jetstream::$inertiaManager = $inertia = m::mock();
+        $inertia->shouldReceive('render')->once();
+
+        $user = User::forceCreate([
+            'name' => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
+            'password' => 'secret',
+            'two_factor_secret' => 'test-secret',
+        ]);
+
+        $response = $this->actingAs($user)
+                        ->withSession([
+                            'two_factor_empty_at' => time(),
+                            'two_factor_confirming_at' => time() - 10,
+                        ])
+                        ->get('/user/profile');
+
+        $response->assertStatus(200);
+    }
+
+    protected function migrate()
+    {
+        $this->artisan('migrate', ['--database' => 'testbench'])->run();
+
+        Schema::table('users', function ($table) {
+            $table->string('two_factor_secret')->nullable();
+            $table->timestamp('two_factor_confirmed_at')->nullable();
+        });
+    }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('jetstream.stack', 'inertia');
+        $app['config']->set('fortify.features', [
+            Features::registration(),
+            Features::resetPasswords(),
+            // Features::emailVerification(),
+            Features::updateProfileInformation(),
+            Features::updatePasswords(),
+            Features::twoFactorAuthentication([
+                'confirm' => true,
+                'confirmPassword' => true,
+            ]),
+        ]);
+    }
+}


### PR DESCRIPTION
This PR implements the Jetstream side of things to confirm 2FA when enabling it. This prevents the user from accidentally enabling 2FA and locking themselves out of their account.

Related Fortify PR: https://github.com/laravel/fortify/pull/358

Todo:
- [x] Livewire
- [x] Inertia
- [x] Tests

Closes https://github.com/laravel/jetstream/issues/74