### PR TITLE
[2.x] First check for ownership

### DIFF
--- a/src/HasTeams.php
+++ b/src/HasTeams.php
@@ -123,9 +123,9 @@ trait HasTeams
             return false;
         }
 
-        return $this->teams->contains(function ($t) use ($team) {
+        return $this->ownsTeam($team) || $this->teams->contains(function ($t) use ($team) {
             return $t->id === $team->id;
-        }) || $this->ownsTeam($team);
+        });
     }
 
     /**


### PR DESCRIPTION
Just a small tweak, not a functional one. Would call for `teams` after checks for ownership.

This should not break anything.