### PR TITLE
Adding Storage Path support to the HasProfilePhoto Trait

### DIFF
--- a/src/HasProfilePhoto.php
+++ b/src/HasProfilePhoto.php
@@ -15,12 +15,12 @@ trait HasProfilePhoto
      * @param  \Illuminate\Http\UploadedFile  $photo
      * @return void
      */
-    public function updateProfilePhoto(UploadedFile $photo)
+    public function updateProfilePhoto(UploadedFile $photo, $storagePath = 'profile-photos')
     {
-        tap($this->profile_photo_path, function ($previous) use ($photo) {
+        tap($this->profile_photo_path, function ($previous) use ($photo, $storagePath) {
             $this->forceFill([
                 'profile_photo_path' => $photo->storePublicly(
-                    'profile-photos', ['disk' => $this->profilePhotoDisk()]
+                    $storagePath, ['disk' => $this->profilePhotoDisk()]
                 ),
             ])->save();
 

--- a/src/HasProfilePhoto.php
+++ b/src/HasProfilePhoto.php
@@ -13,6 +13,7 @@ trait HasProfilePhoto
      * Update the user's profile photo.
      *
      * @param  \Illuminate\Http\UploadedFile  $photo
+     * @param  string  $storagePath
      * @return void
      */
     public function updateProfilePhoto(UploadedFile $photo, $storagePath = 'profile-photos')


### PR DESCRIPTION
In order to use the hasProfilePhoto Trait on other Models i added a second parameter to set the storage path for the model. With this you can store profile photos for teams in a different folder as user profile photos. 

This time in the correct branch. 