### PR TITLE
Add `lang` support to Inertia stubs

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -290,6 +290,7 @@ EOF;
                 '@inertiajs/progress' => '^0.2.7',
                 '@tailwindcss/forms' => '^0.5.0',
                 '@tailwindcss/typography' => '^0.5.2',
+                'laravel-vue-i18n' => '^1.3.1',
                 'postcss-import' => '^14.0.2',
                 'tailwindcss' => '^3.0.0',
                 'vue' => '^3.2.31',

--- a/stubs/inertia/resources/js/Pages/Dashboard.vue
+++ b/stubs/inertia/resources/js/Pages/Dashboard.vue
@@ -1,13 +1,14 @@
 <script setup>
 import AppLayout from '@/Layouts/AppLayout.vue';
 import Welcome from '@/Jetstream/Welcome.vue';
+
 </script>
 
 <template>
-    <AppLayout title="Dashboard">
+    <AppLayout :title="$t('Dashboard')">
         <template #header>
             <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-                Dashboard
+                {{ $t('Dashboard') }}
             </h2>
         </template>
 

--- a/stubs/inertia/resources/js/app.js
+++ b/stubs/inertia/resources/js/app.js
@@ -3,6 +3,7 @@ require('./bootstrap');
 import { createApp, h } from 'vue';
 import { createInertiaApp } from '@inertiajs/inertia-vue3';
 import { InertiaProgress } from '@inertiajs/progress';
+import { i18nVue } from 'laravel-vue-i18n';
 
 const appName = window.document.getElementsByTagName('title')[0]?.innerText || 'Laravel';
 
@@ -12,6 +13,9 @@ createInertiaApp({
     setup({ el, app, props, plugin }) {
         return createApp({ render: () => h(app, props) })
             .use(plugin)
+            .use(i18nVue, {
+                resolve: lang => require(`../../lang/${lang}.json`),
+            })
             .mixin({ methods: { route } })
             .mount(el);
     },


### PR DESCRIPTION
This PR is a possible addition to add to the Inertia stubs, looking on the blade views, it looks like it's using the translation helper.

My proposal is to do the same for Inertia, but since there is no built in way to do it, I built a package called [`laravel-vue-i18n`](https://github.com/xiCO2k/laravel-vue-i18n) couple of months ago for that exact purpose, it even supports the same syntax for replacements.

If you guys think this is a good addition to have, I can finish the implementation.

Let me know if there is any questions.
