### PR TITLE
Use `.alias` method from `Mix`

### DIFF
--- a/stubs/inertia/webpack.config.js
+++ b/stubs/inertia/webpack.config.js
@@ -1,9 +1,0 @@
-const path = require('path');
-
-module.exports = {
-    resolve: {
-        alias: {
-            '@': path.resolve('resources/js'),
-        },
-    },
-};

--- a/stubs/inertia/webpack.mix.js
+++ b/stubs/inertia/webpack.mix.js
@@ -16,7 +16,9 @@ mix.js('resources/js/app.js', 'public/js').vue()
         require('postcss-import'),
         require('tailwindcss'),
     ])
-    .webpackConfig(require('./webpack.config'));
+    .alias({
+        '@': 'resources/js',
+    });
 
 if (mix.inProduction()) {
     mix.version();


### PR DESCRIPTION
This PR removes the `webpack.config.js` file in order to use the `alias` method from `Mix`.