### PR TITLE
[2.x] Add Inertia SSR Support

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -289,16 +289,13 @@ EOF;
                 '@inertiajs/inertia' => '^0.11.0',
                 '@inertiajs/inertia-vue3' => '^0.6.0',
                 '@inertiajs/progress' => '^0.2.7',
-                '@inertiajs/server' => '^0.1.0',
                 '@tailwindcss/forms' => '^0.5.0',
                 '@tailwindcss/typography' => '^0.5.2',
                 'postcss-import' => '^14.0.2',
                 'tailwindcss' => '^3.0.0',
                 'vue' => '^3.2.31',
                 '@vue/compiler-sfc' => '^3.2.31',
-                '@vue/server-renderer' => '^3.2.31',
                 'vue-loader' => '^17.0.0',
-                'webpack-node-externals' => '^3.0.0'
             ] + $packages;
         });
 
@@ -502,7 +499,7 @@ EOF;
             return [
                 '@inertiajs/server' => '^0.1.0',
                 '@vue/server-renderer' => '^3.2.31',
-                'webpack-node-externals' => '^3.0.0'
+                'webpack-node-externals' => '^3.0.0',
             ] + $packages;
         });
 

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -513,7 +513,7 @@ EOF;
             });
 
         $this->replaceInFile("'enabled' => false", "'enabled' => true", config_path('inertia.php'));
-        $this->replaceInFile("mix --production", "mix --production --mix-config=webpack.ssr.mix.js && mix --production", base_path('package.json'));
+        $this->replaceInFile('mix --production', 'mix --production --mix-config=webpack.ssr.mix.js && mix --production', base_path('package.json'));
     }
 
     /**

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -19,6 +19,7 @@ class InstallCommand extends Command
     protected $signature = 'jetstream:install {stack : The development stack that should be installed}
                                               {--teams : Indicates if team support should be installed}
                                               {--pest : Indicates if Pest should be installed}
+                                              {--ssr : Indicates if Inertia SSR support should be installed}
                                               {--composer=global : Absolute path to the Composer binary which should be used to install packages}';
 
     /**
@@ -345,16 +346,6 @@ EOF;
                 $this->output->write($output);
             });
 
-        // SSR...
-        (new Process([$this->phpBinary(), 'artisan', 'vendor:publish', '--provider=Inertia\ServiceProvider', '--force'], base_path()))
-            ->setTimeout(null)
-            ->run(function ($type, $output) {
-                $this->output->write($output);
-            });
-
-        $this->replaceInFile("'enabled' => false", "'enabled' => true", config_path('inertia.php'));
-        $this->replaceInFile("mix --production", "mix --production --mix-config=webpack.ssr.mix.js && mix --production", base_path('package.json'));
-
         $this->installMiddlewareAfter('SubstituteBindings::class', '\App\Http\Middleware\HandleInertiaRequests::class');
 
         // Models...
@@ -396,7 +387,6 @@ EOF;
         copy(__DIR__.'/../../stubs/public/css/app.css', public_path('css/app.css'));
         copy(__DIR__.'/../../stubs/resources/css/app.css', resource_path('css/app.css'));
         copy(__DIR__.'/../../stubs/inertia/resources/js/app.js', resource_path('js/app.js'));
-        copy(__DIR__.'/../../stubs/inertia/resources/js/ssr.js', resource_path('js/ssr.js'));
 
         // Flush node_modules...
         // static::flushNodeModules();
@@ -416,6 +406,10 @@ EOF;
         // Teams...
         if ($this->option('teams')) {
             $this->installInertiaTeamStack();
+        }
+
+        if ($this->option('ssr')) {
+            $this->installInertiaSsrStack();
         }
 
         $this->line('');
@@ -495,6 +489,34 @@ EOF;
         // Factories...
         copy(__DIR__.'/../../database/factories/UserFactory.php', base_path('database/factories/UserFactory.php'));
         copy(__DIR__.'/../../database/factories/TeamFactory.php', base_path('database/factories/TeamFactory.php'));
+    }
+
+    /**
+     * Install the Inertia SSR stack into the application.
+     *
+     * @return void
+     */
+    protected function installInertiaSsrStack()
+    {
+        $this->updateNodePackages(function ($packages) {
+            return [
+                '@inertiajs/server' => '^0.1.0',
+                '@vue/server-renderer' => '^3.2.31',
+                'webpack-node-externals' => '^3.0.0'
+            ] + $packages;
+        });
+
+        copy(__DIR__.'/../../stubs/inertia/webpack.ssr.mix.js', base_path('webpack.ssr.mix.js'));
+        copy(__DIR__.'/../../stubs/inertia/resources/js/ssr.js', resource_path('js/ssr.js'));
+
+        (new Process([$this->phpBinary(), 'artisan', 'vendor:publish', '--provider=Inertia\ServiceProvider', '--force'], base_path()))
+            ->setTimeout(null)
+            ->run(function ($type, $output) {
+                $this->output->write($output);
+            });
+
+        $this->replaceInFile("'enabled' => false", "'enabled' => true", config_path('inertia.php'));
+        $this->replaceInFile("mix --production", "mix --production --mix-config=webpack.ssr.mix.js && mix --production", base_path('package.json'));
     }
 
     /**

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -309,7 +309,6 @@ EOF;
         // Tailwind Configuration...
         copy(__DIR__.'/../../stubs/inertia/tailwind.config.js', base_path('tailwind.config.js'));
         copy(__DIR__.'/../../stubs/inertia/webpack.mix.js', base_path('webpack.mix.js'));
-        copy(__DIR__.'/../../stubs/inertia/webpack.ssr.mix.js', base_path('webpack.ssr.mix.js'));
 
         // Directories...
         (new Filesystem)->ensureDirectoryExists(app_path('Actions/Fortify'));

--- a/src/Http/Middleware/ShareInertiaData.php
+++ b/src/Http/Middleware/ShareInertiaData.php
@@ -59,7 +59,7 @@ class ShareInertiaData
             },
             'ziggy' => function () {
                 return (new Ziggy)->toArray();
-            }
+            },
         ]));
 
         return $next($request);

--- a/src/Http/Middleware/ShareInertiaData.php
+++ b/src/Http/Middleware/ShareInertiaData.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Session;
 use Inertia\Inertia;
 use Laravel\Fortify\Features;
 use Laravel\Jetstream\Jetstream;
+use Tightenco\Ziggy\Ziggy;
 
 class ShareInertiaData
 {
@@ -56,6 +57,9 @@ class ShareInertiaData
                     return [$key => $bag->messages()];
                 })->all();
             },
+            'ziggy' => function () {
+                return (new Ziggy)->toArray();
+            }
         ]));
 
         return $next($request);

--- a/stubs/inertia/resources/js/ssr.js
+++ b/stubs/inertia/resources/js/ssr.js
@@ -1,7 +1,7 @@
 import { createSSRApp, h } from 'vue';
 import { renderToString } from '@vue/server-renderer';
 import { createInertiaApp } from '@inertiajs/inertia-vue3';
-import createServer from '@inertiajs/server'
+import createServer from '@inertiajs/server';
 import route from 'ziggy';
 
 const appName = 'Laravel';

--- a/stubs/inertia/resources/js/ssr.js
+++ b/stubs/inertia/resources/js/ssr.js
@@ -1,28 +1,30 @@
-import { createSSRApp, h } from 'vue'
-import { renderToString } from '@vue/server-renderer'
+import { createSSRApp, h } from 'vue';
+import { renderToString } from '@vue/server-renderer';
 import { createInertiaApp } from '@inertiajs/inertia-vue3';
 import createServer from '@inertiajs/server'
 import route from 'ziggy';
 
 const appName = 'Laravel';
 
-createServer((page) => createInertiaApp({
-    page,
-    render: renderToString,
-    title: (title) => `${title} - ${appName}`,
-    resolve: (name) => require(`./Pages/${name}.vue`),
-    setup({ app, props, plugin }) {
-        return createSSRApp({ render: () => h(app, props) })
-            .use(plugin)
-            .mixin({
-                methods: {
-                    route: (name, params, absolute) => {
-                        return route(name, params, absolute, {
-                            ...page.props.ziggy,
-                            location: new URL(page.props.ziggy.url),
-                        })
-                    },
-                }
-            });
-    },
-}));
+createServer((page) =>
+    createInertiaApp({
+        page,
+        render: renderToString,
+        title: (title) => `${title} - ${appName}`,
+        resolve: (name) => require(`./Pages/${name}.vue`),
+        setup({ app, props, plugin }) {
+            return createSSRApp({ render: () => h(app, props) })
+                .use(plugin)
+                .mixin({
+                    methods: {
+                        route: (name, params, absolute) => {
+                            return route(name, params, absolute, {
+                                ...page.props.ziggy,
+                                location: new URL(page.props.ziggy.url),
+                            })
+                        },
+                    }
+                });
+        },
+    })
+);

--- a/stubs/inertia/resources/js/ssr.js
+++ b/stubs/inertia/resources/js/ssr.js
@@ -1,0 +1,28 @@
+import { createSSRApp, h } from 'vue'
+import { renderToString } from '@vue/server-renderer'
+import { createInertiaApp } from '@inertiajs/inertia-vue3';
+import createServer from '@inertiajs/server'
+import route from 'ziggy';
+
+const appName = 'Laravel';
+
+createServer((page) => createInertiaApp({
+    page,
+    render: renderToString,
+    title: (title) => `${title} - ${appName}`,
+    resolve: (name) => require(`./Pages/${name}.vue`),
+    setup({ app, props, plugin }) {
+        return createSSRApp({ render: () => h(app, props) })
+            .use(plugin)
+            .mixin({
+                methods: {
+                    route: (name, params, absolute) => {
+                        return route(name, params, absolute, {
+                            ...page.props.ziggy,
+                            location: new URL(page.props.ziggy.url),
+                        })
+                    },
+                }
+            });
+    },
+}));

--- a/stubs/inertia/resources/js/ssr.js
+++ b/stubs/inertia/resources/js/ssr.js
@@ -21,9 +21,9 @@ createServer((page) =>
                             return route(name, params, absolute, {
                                 ...page.props.ziggy,
                                 location: new URL(page.props.ziggy.url),
-                            })
+                            });
                         },
-                    }
+                    },
                 });
         },
     })

--- a/stubs/inertia/resources/views/app.blade.php
+++ b/stubs/inertia/resources/views/app.blade.php
@@ -15,6 +15,7 @@
         <!-- Scripts -->
         @routes
         <script src="{{ mix('js/app.js') }}" defer></script>
+        @inertiaHead
     </head>
     <body class="font-sans antialiased">
         @inertia

--- a/stubs/inertia/webpack.ssr.mix.js
+++ b/stubs/inertia/webpack.ssr.mix.js
@@ -1,0 +1,18 @@
+const mix = require('laravel-mix');
+const webpackNodeExternals = require('webpack-node-externals')
+
+mix
+    .js('resources/js/ssr.js', 'public/js')
+    .vue({
+        version: 3,
+        useVueStyleLoader: true,
+        options: { optimizeSSR: true }
+    })
+    .alias({
+        '@': 'resources/js',
+        'ziggy': 'vendor/tightenco/ziggy/dist/index',
+    })
+    .webpackConfig({
+        target: 'node',
+        externals: [webpackNodeExternals()],
+    })

--- a/stubs/inertia/webpack.ssr.mix.js
+++ b/stubs/inertia/webpack.ssr.mix.js
@@ -1,18 +1,17 @@
 const mix = require('laravel-mix');
-const webpackNodeExternals = require('webpack-node-externals')
+const webpackNodeExternals = require('webpack-node-externals');
 
-mix
-    .js('resources/js/ssr.js', 'public/js')
+mix.js('resources/js/ssr.js', 'public/js')
     .vue({
         version: 3,
         useVueStyleLoader: true,
-        options: { optimizeSSR: true }
+        options: { optimizeSSR: true },
     })
     .alias({
         '@': 'resources/js',
-        'ziggy': 'vendor/tightenco/ziggy/dist/index',
+        ziggy: 'vendor/tightenco/ziggy/dist/index',
     })
     .webpackConfig({
         target: 'node',
         externals: [webpackNodeExternals()],
-    })
+    });


### PR DESCRIPTION
This PR adds the SSR support for the Inertia stack.

To not be a default option, I added a `--ssr` option, this way we will only include the SSR part if the user wants.

to have the SSR running make sure to run:

```sh
npm run prod
```

then to start the ssr server run:

```sh
node public/js/ssr.js
```

More information on the Inertia website: https://inertiajs.com/server-side-rendering

The directive `@inertiaHead` added to the `app.blade.php` will not do anything if the SSR is not enabled.