### PR TITLE
prop to prevent closing dropdown on item click

### DIFF
--- a/resources/views/components/dropdown.blade.php
+++ b/resources/views/components/dropdown.blade.php
@@ -1,4 +1,4 @@
-@props(['align' => 'right', 'width' => '48', 'contentClasses' => 'py-1 bg-white', 'dropdownClasses' => ''])
+@props(['align' => 'right', 'width' => '48', 'contentClasses' => 'py-1 bg-white', 'dropdownClasses' => '', 'skipClickToClose' => false])
 
 @php
 switch ($align) {
@@ -39,7 +39,7 @@ switch ($width) {
             x-transition:leave-end="transform opacity-0 scale-95"
             class="absolute z-50 mt-2 {{ $width }} rounded-md shadow-lg {{ $alignmentClasses }} {{ $dropdownClasses }}"
             style="display: none;"
-            @click="open = false">
+            {!! $skipClickToClose ? '' : 'x-on:click="open = false"' !!}>
         <div class="rounded-md ring-1 ring-black ring-opacity-5 {{ $contentClasses }}">
             {{ $content }}
         </div>


### PR DESCRIPTION
`skipClickToClose` prop to skip the closing of dropdown when any item is clicked.

useful when the dropdown items are non link item and require the dropdown to stay opened even after click, for example a delete action button that shows a pair of confirm / cancel buttons.

Usage:
```html
<x-jet-dropdown :skipClickToClose="true" ...>
      ...
</x-jet-dropdown>
```

Exaple:-
![ezgif com-gif-maker](https://user-images.githubusercontent.com/26733312/160275635-66e8d8bf-f992-469e-a60e-21c74e9e47d4.gif)

