### PR TITLE
prop to prevent closing dropdown on item click

### DIFF
--- a/resources/views/components/dropdown.blade.php
+++ b/resources/views/components/dropdown.blade.php
@@ -1,4 +1,4 @@
-@props(['align' => 'right', 'width' => '48', 'contentClasses' => 'py-1 bg-white', 'dropdownClasses' => ''])
+@props(['align' => 'right', 'width' => '48', 'contentClasses' => 'py-1 bg-white', 'dropdownClasses' => '', 'closeOnClick' => true])
 
 @php
 switch ($align) {
@@ -38,8 +38,8 @@ switch ($width) {
             x-transition:leave-start="transform opacity-100 scale-100"
             x-transition:leave-end="transform opacity-0 scale-95"
             class="absolute z-50 mt-2 {{ $width }} rounded-md shadow-lg {{ $alignmentClasses }} {{ $dropdownClasses }}"
-            style="display: none;"
-            @click="open = false">
+            {!! $closeOnClick ? 'x-on:click="open = false"' : '' !!}
+            style="display: none;">
         <div class="rounded-md ring-1 ring-black ring-opacity-5 {{ $contentClasses }}">
             {{ $content }}
         </div>


### PR DESCRIPTION
`closeOnClick` prop to prevent the closing of dropdown when any item is clicked.

useful when the dropdown items are non link item and require the dropdown to stay opened even after click, for example a delete action button that shows a pair of confirm / cancel buttons.

Usage:
```html
<x-jet-dropdown :close-on-click="false" ...>
  ...
</x-jet-dropdown>
```

Exaple:
![ezgif com-gif-maker](https://user-images.githubusercontent.com/26733312/160277404-1ef579d5-051e-4e93-8a25-6357e0d72204.gif)

