### PR TITLE
[2.x] Not require `Ziggy` on `ShareInertiaData` middleware.

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -511,6 +511,8 @@ EOF;
                 $this->output->write($output);
             });
 
+        copy(__DIR__.'/../../stubs/inertia/app/Http/Middleware/HandleInertiaRequests.php', app_path('Http/Middleware/HandleInertiaRequests.php'));
+
         $this->replaceInFile("'enabled' => false", "'enabled' => true", config_path('inertia.php'));
         $this->replaceInFile('mix --production', 'mix --production --mix-config=webpack.ssr.mix.js && mix --production', base_path('package.json'));
     }

--- a/src/Http/Middleware/ShareInertiaData.php
+++ b/src/Http/Middleware/ShareInertiaData.php
@@ -7,7 +7,6 @@ use Illuminate\Support\Facades\Session;
 use Inertia\Inertia;
 use Laravel\Fortify\Features;
 use Laravel\Jetstream\Jetstream;
-use Tightenco\Ziggy\Ziggy;
 
 class ShareInertiaData
 {
@@ -56,9 +55,6 @@ class ShareInertiaData
                 return collect(optional(Session::get('errors'))->getBags() ?: [])->mapWithKeys(function ($bag, $key) {
                     return [$key => $bag->messages()];
                 })->all();
-            },
-            'ziggy' => function () {
-                return (new Ziggy)->toArray();
             },
         ]));
 

--- a/stubs/inertia/app/Http/Middleware/HandleInertiaRequests.php
+++ b/stubs/inertia/app/Http/Middleware/HandleInertiaRequests.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Illuminate\Http\Request;
+use Inertia\Middleware;
+use Tightenco\Ziggy\Ziggy;
+
+class HandleInertiaRequests extends Middleware
+{
+    /**
+     * The root template that is loaded on the first page visit.
+     *
+     * @var string
+     */
+    protected $rootView = 'app';
+
+    /**
+     * Determine the current asset version.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return string|null
+     */
+    public function version(Request $request)
+    {
+        return parent::version($request);
+    }
+
+    /**
+     * Define the props that are shared by default.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function share(Request $request)
+    {
+        return array_merge(parent::share($request), [
+            'ziggy' => function () {
+                return (new Ziggy)->toArray();
+            },
+        ]);
+    }
+}


### PR DESCRIPTION
This PR fixes #1023

Removes the addition of `Ziggy` on the `ShareInertiaData` middleware, and only add `Ziggy` to the `HandleInertiaData` stub if `--ssr` is passed, so that way if anyone wants to remove, they have the full control.

Thanks,
Francisco