### PR TITLE
Solve the problem that the banner cannot be displayed again after ref…

### DIFF
--- a/stubs/inertia/resources/js/Jetstream/Banner.vue
+++ b/stubs/inertia/resources/js/Jetstream/Banner.vue
@@ -1,10 +1,17 @@
 <script setup>
-import { computed, ref } from 'vue';
+import { onUpdated, computed, ref } from 'vue';
 import { usePage } from '@inertiajs/inertia-vue3';
 
 const show = ref(true);
 const style = computed(() => usePage().props.value.jetstream.flash?.bannerStyle || 'success');
 const message = computed(() => usePage().props.value.jetstream.flash?.banner || '');
+
+onUpdated(() => {
+    if (false === show.value) {
+        show.value = true
+        usePage().props.value.jetstream.flash = null
+    }
+})
 </script>
 
 <template>


### PR DESCRIPTION
> Solve the problem that the banner cannot be displayed again after refreshing the same page after closing the banner

Case:

Scenario: User Management Page

Requirement: Click the user delete button to delete the user

Function description: After the deletion is successful, return to the current page and display the word "success" through the Banner.

Problem: At this point, click the banner's close button to close it, and then delete a user again, the banner will no longer be displayed.