### PR TITLE
Use Alpine's @click.prevent for switching teams

### DIFF
--- a/resources/views/components/switchable-team.blade.php
+++ b/resources/views/components/switchable-team.blade.php
@@ -1,13 +1,13 @@
 @props(['team', 'component' => 'jet-dropdown-link'])
 
-<form method="POST" action="{{ route('current-team.update') }}">
+<form method="POST" action="{{ route('current-team.update') }}" x-data>
     @method('PUT')
     @csrf
 
     <!-- Hidden Team ID -->
     <input type="hidden" name="team_id" value="{{ $team->id }}">
 
-    <x-dynamic-component :component="$component" href="#" onclick="event.preventDefault(); this.closest('form').submit();">
+    <x-dynamic-component :component="$component" href="#" @click.prevent="$root.submit();">
         <div class="flex items-center">
             @if (Auth::user()->isCurrentTeam($team))
                 <svg class="mr-2 h-5 w-5 text-green-400" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" stroke="currentColor" viewBox="0 0 24 24"><path d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>


### PR DESCRIPTION
This PR will switch the `switchable-team` component in the Livewire stack from vanilla JS to Alpine's `@click.prevent` directive, like my previous PR #989 for the log out link.