### PR TITLE
[2.x] Fix: if user logs out when viewing the 2FA Form

### DIFF
--- a/stubs/inertia/resources/js/Pages/Profile/Partials/TwoFactorAuthenticationForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/Partials/TwoFactorAuthenticationForm.vue
@@ -27,7 +27,7 @@ const confirmationForm = useForm({
 });
 
 const twoFactorEnabled = computed(
-    () => ! enabling.value && usePage().props.value.user.two_factor_enabled,
+    () => ! enabling.value && usePage().props.value.user?.two_factor_enabled,
 );
 
 watch(twoFactorEnabled, () => {


### PR DESCRIPTION
This PR fixes the error when logging out when the TwoFactorAuthenticationForm component is loaded and the watcher is working.

Fixes or is a follow up on https://github.com/laravel/jetstream/issues/1030
