### PR TITLE
[2.x] Fix confirm password circumvention

### DIFF
--- a/stubs/inertia/resources/js/Pages/Profile/Partials/TwoFactorAuthenticationForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/Partials/TwoFactorAuthenticationForm.vue
@@ -165,7 +165,6 @@ const disableTwoFactorAuthentication = () => {
                             inputmode="numeric"
                             autofocus
                             autocomplete="one-time-code"
-                            @keyup.enter="confirmTwoFactorAuthentication"
                         />
 
                         <JetInputError :message="confirmationForm.errors.code" class="mt-2" />

--- a/stubs/livewire/resources/views/profile/two-factor-authentication-form.blade.php
+++ b/stubs/livewire/resources/views/profile/two-factor-authentication-form.blade.php
@@ -53,8 +53,7 @@
                         <x-jet-label for="code" value="{{ __('Code') }}" />
 
                         <x-jet-input id="code" type="text" name="code" class="block mt-1 w-1/2" inputmode="numeric" autofocus autocomplete="one-time-code"
-                            wire:model.defer="code"
-                            wire:keydown.enter="confirmTwoFactorAuthentication" />
+                            wire:model.defer="code" />
 
                         <x-jet-input-error for="code" class="mt-2" />
                     </div>


### PR DESCRIPTION
This PR removes the ability to submit the two factor form by pressing the enter key in the code fields as those can be used to circumvent the password confirmation (which is only tied to the submit button). It seems removing the enter key press is the easiest solution. Otherwise we'll have to tie the same logic within the password confirm buttons to the key press listeners.

See https://github.com/laravel/jetstream/issues/1033