### PR TITLE
2.x hotfix: Add Messaging In Install For Edge Cases

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -110,7 +110,7 @@ class InstallCommand extends Command
             }
         })->filter()->whenEmpty(function () {
             $this->info(<<<'END_OF_INFO'
-                \nJetstream attempted to update .env, .env.local, and .env.example to ensure the session driver is
+                Jetstream attempted to update .env, .env.local, and .env.example to ensure the session driver is
                 set to "database", but could not find one. Jetstream works best with database sessions, for more
                 information see: https://jetstream.laravel.com/2.x/features/browser-sessions.html
                 END_OF_INFO


### PR DESCRIPTION
When running `artisan jetstream:install livewire` on a project that had its `.env.example` already moved, it kills the install with the following message:

```
# artisan jetstream:install livewire
Migration created successfully.

   ErrorException

  file_get_contents(/app/.env.example): Failed to open stream: No such file or directory

  at vendor/laravel/jetstream/src/Console/InstallCommand.php:687
    683▕      * @return void
    684▕      */
    685▕     protected function replaceInFile($search, $replace, $path)
    686▕     {
  ➜ 687▕         file_put_contents($path, str_replace($search, $replace, file_get_contents($path)));
```

This PR solves that specific problem, but also adds messaging that alerts the installer that database sessions are preferable, and links to the manual with more information.

**Possible addition?** I think in an ideal world, any `replaceInFile` should have some output to call out what is being changed and why, to be more transparent.