### PR TITLE
Fix banner not showing again if dismissed by the user

### DIFF
--- a/stubs/inertia/resources/js/Jetstream/Banner.vue
+++ b/stubs/inertia/resources/js/Jetstream/Banner.vue
@@ -1,10 +1,14 @@
 <script setup>
-import { computed, ref } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { usePage } from '@inertiajs/inertia-vue3';
 
 const show = ref(true);
 const style = computed(() => usePage().props.value.jetstream.flash?.bannerStyle || 'success');
 const message = computed(() => usePage().props.value.jetstream.flash?.banner || '');
+
+watch(message, async () => {
+  show.value = true;
+});
 </script>
 
 <template>


### PR DESCRIPTION
This fixes a long-standing bug, see #696 (and rejected PRs #826 and #1026).

How to reproduce:

1. Flash a banner.
2. The user acknowledges the banner and clicks on the `x` button.
3. Flash another banner.
4. No banners will be shown again, unless the user manually reloads the page or does a non-Inertia navigation.

As suggested by @claudiodekker, this PR adds a simple `watch` that displays the banner again when a new message is flashed by the application.