### PR TITLE
[2.x] Fix space in link

### DIFF
--- a/stubs/inertia/resources/js/Pages/Auth/VerifyEmail.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/VerifyEmail.vue
@@ -45,8 +45,7 @@ const verificationLinkSent = computed(() => props.status === 'verification-link-
                         :href="route('profile.show')"
                         class="underline text-sm text-gray-600 hover:text-gray-900"
                     >
-                        Edit Profile
-                    </Link>
+                        Edit Profile</Link>
 
                     <Link
                         :href="route('logout')"

--- a/stubs/livewire/resources/views/auth/verify-email.blade.php
+++ b/stubs/livewire/resources/views/auth/verify-email.blade.php
@@ -30,8 +30,7 @@
                     href="{{ route('profile.show') }}"
                     class="underline text-sm text-gray-600 hover:text-gray-900"
                 >
-                    {{ __('Edit Profile') }}
-                </a>
+                    {{ __('Edit Profile') }}</a>
 
                 <form method="POST" action="{{ route('logout') }}" class="inline">
                     @csrf


### PR DESCRIPTION
This fixes a space after the link which was well spotted by a community member. Although I'm unsure why this happens for the edit profile link and not the logout link...

<img width="202" alt="Screenshot 2022-05-10 at 14 59 58" src="https://user-images.githubusercontent.com/594614/167634152-1827e199-7c38-4187-ad47-f49e401dfdd7.png">
