### PR TITLE
Fixed an issue causing warning when clicking on Manage Permissions or Delete on created token.

### DIFF
--- a/stubs/inertia/resources/js/Pages/API/Partials/ApiTokenManager.vue
+++ b/stubs/inertia/resources/js/Pages/API/Partials/ApiTokenManager.vue
@@ -194,7 +194,7 @@ const deleteApiToken = () => {
         </JetDialogModal>
 
         <!-- API Token Permissions Modal -->
-        <JetDialogModal :show="managingPermissionsFor" @close="managingPermissionsFor = null">
+        <JetDialogModal :show="managingPermissionsFor != null" @close="managingPermissionsFor = null">
             <template #title>
                 API Token Permissions
             </template>
@@ -227,7 +227,7 @@ const deleteApiToken = () => {
         </JetDialogModal>
 
         <!-- Delete Token Confirmation Modal -->
-        <JetConfirmationModal :show="apiTokenBeingDeleted" @close="apiTokenBeingDeleted = null">
+        <JetConfirmationModal :show="apiTokenBeingDeleted != null" @close="apiTokenBeingDeleted = null">
             <template #title>
                 Delete API Token
             </template>


### PR DESCRIPTION
DialogModal component's show prop expect boolean value but in ApiTokenManager component object was passed, although it works, it generates the warning in the console.
