### PR TITLE
[2.x] Switch to ESM imports

### DIFF
--- a/stubs/inertia/resources/js/app.js
+++ b/stubs/inertia/resources/js/app.js
@@ -1,4 +1,4 @@
-require('./bootstrap');
+import './bootstrap';
 
 import { createApp, h } from 'vue';
 import { createInertiaApp } from '@inertiajs/inertia-vue3';

--- a/stubs/livewire/resources/js/app.js
+++ b/stubs/livewire/resources/js/app.js
@@ -1,4 +1,4 @@
-require('./bootstrap');
+import './bootstrap';
 
 import Alpine from 'alpinejs';
 


### PR DESCRIPTION
Carrying on from the PR at https://github.com/laravel/laravel/pull/5895, this replaces `require` statements with `import` statements where possible in the JS resources in order to smooth the transition for Vite users.

Note that with Inertia there is one remaining dynamic `require` that does not have a replacement that works with webpack _and_ Vite.