### PR TITLE
[2.x] Simplify Tailwind installation

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -142,7 +142,6 @@ class InstallCommand extends Command
                 '@tailwindcss/forms' => '^0.4.0',
                 '@tailwindcss/typography' => '^0.5.0',
                 'alpinejs' => '^3.0.6',
-                'postcss-import' => '^14.0.1',
                 'tailwindcss' => '^3.0.0',
             ] + $packages;
         });
@@ -303,7 +302,6 @@ EOF;
                 '@inertiajs/progress' => '^0.2.7',
                 '@tailwindcss/forms' => '^0.5.0',
                 '@tailwindcss/typography' => '^0.5.2',
-                'postcss-import' => '^14.0.2',
                 'tailwindcss' => '^3.0.0',
                 'vue' => '^3.2.31',
                 '@vue/compiler-sfc' => '^3.2.31',

--- a/stubs/inertia/webpack.mix.js
+++ b/stubs/inertia/webpack.mix.js
@@ -13,7 +13,6 @@ const mix = require('laravel-mix');
 
 mix.js('resources/js/app.js', 'public/js').vue()
     .postCss('resources/css/app.css', 'public/css', [
-        require('postcss-import'),
         require('tailwindcss'),
     ])
     .alias({

--- a/stubs/livewire/webpack.mix.js
+++ b/stubs/livewire/webpack.mix.js
@@ -13,7 +13,6 @@ const mix = require('laravel-mix');
 
 mix.js('resources/js/app.js', 'public/js')
     .postCss('resources/css/app.css', 'public/css', [
-        require('postcss-import'),
         require('tailwindcss'),
     ]);
 

--- a/stubs/resources/css/app.css
+++ b/stubs/resources/css/app.css
@@ -1,3 +1,3 @@
-@import 'tailwindcss/base';
-@import 'tailwindcss/components';
-@import 'tailwindcss/utilities';
+@tailwind base;
+@tailwind components;
+@tailwind utilities;


### PR DESCRIPTION
This PR simplifies the Tailwind installation in Jetstream and is the counterpart of [this Breeze PR](https://github.com/laravel/breeze/pull/155):

* Uses the `@tailwind` directive instead of `@import`, per the standard [installation guide](https://tailwindcss.com/docs/guides/laravel).
* Removes the unnecessary `postcss-import` dependency and Mix configuration.