### PR TITLE
Bump tailwindcss/forms to 0.5.0

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -139,7 +139,7 @@ class InstallCommand extends Command
         // NPM Packages...
         $this->updateNodePackages(function ($packages) {
             return [
-                '@tailwindcss/forms' => '^0.4.0',
+                '@tailwindcss/forms' => '^0.5.0',
                 '@tailwindcss/typography' => '^0.5.0',
                 'alpinejs' => '^3.0.6',
                 'postcss-import' => '^14.0.1',


### PR DESCRIPTION
This is to make it on par with the Jetstream stack as well as remove the current compilation warnings.
