### PR TITLE
[2.x] Display available stack options

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -16,7 +16,7 @@ class InstallCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'jetstream:install {stack : The development stack that should be installed}
+    protected $signature = 'jetstream:install {stack : The development stack that should be installed (inertia,livewire)}
                                               {--teams : Indicates if team support should be installed}
                                               {--api : Indicates if API support should be installed}
                                               {--verification : Indicates if email verification support should be installed}


### PR DESCRIPTION
Just a small one to add the available stacks to the install command signature.

This also brings it in line with [Breeze's install command](https://github.com/laravel/breeze/blob/ac34e1d9667106dfa751750606acb479018a0392/src/Console/InstallCommand.php#L20
).