### PR TITLE
Skip tests for team invitations if disabled

### DIFF
--- a/stubs/pest-tests/inertia/InviteTeamMemberTest.php
+++ b/stubs/pest-tests/inertia/InviteTeamMemberTest.php
@@ -2,6 +2,7 @@
 
 use App\Models\User;
 use Illuminate\Support\Facades\Mail;
+use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Mail\TeamInvitation;
 
 test('team members can be invited to team', function () {
@@ -17,7 +18,9 @@ test('team members can be invited to team', function () {
     Mail::assertSent(TeamInvitation::class);
 
     expect($user->currentTeam->fresh()->teamInvitations)->toHaveCount(1);
-});
+})->skip(function () {
+    return ! Features::sendsTeamInvitations();
+}, 'Team invitations not enabled.');
 
 test('team member invitations can be cancelled', function () {
     Mail::fake();
@@ -32,4 +35,6 @@ test('team member invitations can be cancelled', function () {
     $response = $this->delete('/team-invitations/'.$invitation->id);
 
     expect($user->currentTeam->fresh()->teamInvitations)->toHaveCount(0);
-});
+})->skip(function () {
+    return ! Features::sendsTeamInvitations();
+}, 'Team invitations not enabled.');

--- a/stubs/pest-tests/livewire/InviteTeamMemberTest.php
+++ b/stubs/pest-tests/livewire/InviteTeamMemberTest.php
@@ -2,6 +2,7 @@
 
 use App\Models\User;
 use Illuminate\Support\Facades\Mail;
+use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Http\Livewire\TeamMemberManager;
 use Laravel\Jetstream\Mail\TeamInvitation;
 use Livewire\Livewire;
@@ -20,7 +21,9 @@ test('team members can be invited to team', function () {
     Mail::assertSent(TeamInvitation::class);
 
     expect($user->currentTeam->fresh()->teamInvitations)->toHaveCount(1);
-});
+})->skip(function () {
+    return ! Features::sendsTeamInvitations();
+}, 'Team invitations not enabled.');
 
 test('team member invitations can be cancelled', function () {
     Mail::fake();
@@ -40,4 +43,6 @@ test('team member invitations can be cancelled', function () {
     $component->call('cancelTeamInvitation', $invitationId);
 
     expect($user->currentTeam->fresh()->teamInvitations)->toHaveCount(0);
-});
+})->skip(function () {
+    return ! Features::sendsTeamInvitations();
+}, 'Team invitations not enabled.');

--- a/stubs/tests/inertia/InviteTeamMemberTest.php
+++ b/stubs/tests/inertia/InviteTeamMemberTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Mail;
+use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Mail\TeamInvitation;
 use Tests\TestCase;
 
@@ -14,6 +15,10 @@ class InviteTeamMemberTest extends TestCase
 
     public function test_team_members_can_be_invited_to_team()
     {
+        if (! Features::sendsTeamInvitations()) {
+            return $this->markTestSkipped('Team invitations not enabled.');
+        }
+
         Mail::fake();
 
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
@@ -30,6 +35,10 @@ class InviteTeamMemberTest extends TestCase
 
     public function test_team_member_invitations_can_be_cancelled()
     {
+        if (! Features::sendsTeamInvitations()) {
+            return $this->markTestSkipped('Team invitations not enabled.');
+        }
+
         Mail::fake();
 
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());

--- a/stubs/tests/livewire/InviteTeamMemberTest.php
+++ b/stubs/tests/livewire/InviteTeamMemberTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Mail;
+use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Http\Livewire\TeamMemberManager;
 use Laravel\Jetstream\Mail\TeamInvitation;
 use Livewire\Livewire;
@@ -16,6 +17,10 @@ class InviteTeamMemberTest extends TestCase
 
     public function test_team_members_can_be_invited_to_team()
     {
+        if (! Features::sendsTeamInvitations()) {
+            return $this->markTestSkipped('Team invitations not enabled.');
+        }
+
         Mail::fake();
 
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
@@ -33,6 +38,10 @@ class InviteTeamMemberTest extends TestCase
 
     public function test_team_member_invitations_can_be_cancelled()
     {
+        if (! Features::sendsTeamInvitations()) {
+            return $this->markTestSkipped('Team invitations not enabled.');
+        }
+
         Mail::fake();
 
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());


### PR DESCRIPTION
This fixes a case I ran into where I wanted to disable the team invitation emails.  
The default test stubs that came with the Jetstream install were failing because they were still running trying to
assert the disabled behaviour.
