### PR TITLE
Display role for pending invitations

### DIFF
--- a/stubs/inertia/resources/js/Pages/Teams/Partials/TeamMemberManager.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/Partials/TeamMemberManager.vue
@@ -200,6 +200,9 @@ const displayableRole = (role) => {
                             <div class="text-gray-600">
                                 {{ invitation.email }}
                             </div>
+                            <div class="text-gray-400">
+                                {{ displayableRole(invitation.role) }}
+                            </div>
 
                             <div class="flex items-center">
                                 <!-- Cancel Team Invitation -->

--- a/stubs/livewire/resources/views/teams/team-member-manager.blade.php
+++ b/stubs/livewire/resources/views/teams/team-member-manager.blade.php
@@ -93,6 +93,7 @@
                         @foreach ($team->teamInvitations as $invitation)
                             <div class="flex items-center justify-between">
                                 <div class="text-gray-600">{{ $invitation->email }}</div>
+                                <div class="text-gray-400">{{ Laravel\Jetstream\Jetstream::findRole($invitation->role)->name }}</div>
 
                                 <div class="flex items-center">
                                     @if (Gate::check('removeTeamMember', $team))


### PR DESCRIPTION
I've found it useful to display the role for pending team invites. This PR adds this to the core because I thought
others might find it useful as well.

This is what it looks like: 
![Screen Shot 2022-06-01 at 19 47 31](https://user-images.githubusercontent.com/6128798/171397714-ce5d51bf-30f2-4744-b7a6-cdd4e0fa89cb.png)

