### PR TITLE
Profile photo picker accepts jpg, jpeg and png only

### DIFF
--- a/stubs/inertia/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
@@ -93,6 +93,7 @@ const clearPhotoFileInput = () => {
                 <input
                     ref="photoInput"
                     type="file"
+                    accept="image/jpg, image/jpeg, image/png"
                     class="hidden"
                     @change="updatePhotoPreview"
                 >

--- a/stubs/livewire/resources/views/profile/update-profile-information-form.blade.php
+++ b/stubs/livewire/resources/views/profile/update-profile-information-form.blade.php
@@ -12,7 +12,7 @@
         @if (Laravel\Jetstream\Jetstream::managesProfilePhotos())
             <div x-data="{photoName: null, photoPreview: null}" class="col-span-6 sm:col-span-4">
                 <!-- Profile Photo File Input -->
-                <input type="file" class="hidden"
+                <input type="file" accept="image/jpg, image/jpeg, image/png" class="hidden"
                             wire:model="photo"
                             x-ref="photo"
                             x-on:change="


### PR DESCRIPTION
In [backend](https://github.com/laravel/jetstream/blob/c25d17ddca6d197a8035a9bc160e716b7e0a07cf/stubs/app/Actions/Fortify/UpdateUserProfileInformation.php#L24) we are expecting image to be `jpg,jpeg,png` then why not do it on frontend too.