### PR TITLE
Bump TailwindCSS to 3.1

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -142,7 +142,7 @@ class InstallCommand extends Command
                 '@tailwindcss/forms' => '^0.5.0',
                 '@tailwindcss/typography' => '^0.5.0',
                 'alpinejs' => '^3.0.6',
-                'tailwindcss' => '^3.0.0',
+                'tailwindcss' => '^3.1.0',
             ] + $packages;
         });
 
@@ -302,7 +302,7 @@ EOF;
                 '@inertiajs/progress' => '^0.2.7',
                 '@tailwindcss/forms' => '^0.5.0',
                 '@tailwindcss/typography' => '^0.5.2',
-                'tailwindcss' => '^3.0.0',
+                'tailwindcss' => '^3.1.0',
                 'vue' => '^3.2.31',
                 '@vue/compiler-sfc' => '^3.2.31',
                 'vue-loader' => '^17.0.0',

--- a/stubs/inertia/tailwind.config.js
+++ b/stubs/inertia/tailwind.config.js
@@ -1,3 +1,4 @@
+/** @type {import('tailwindcss').Config} */
 const defaultTheme = require('tailwindcss/defaultTheme');
 
 module.exports = {

--- a/stubs/livewire/tailwind.config.js
+++ b/stubs/livewire/tailwind.config.js
@@ -1,3 +1,4 @@
+/** @type {import('tailwindcss').Config} */
 const defaultTheme = require('tailwindcss/defaultTheme');
 
 module.exports = {


### PR DESCRIPTION
Hey Laravel Team,

this PR updates TailwindCSS to the new 3.1 release and adds the new FirstParty TypeScript types to the tailwind.config.js.

https://tailwindcss.com/blog/tailwindcss-v3-1