### PR TITLE
[2.x] Fix Inertia SSR usage with Ziggy route function in setup()

### DIFF
--- a/stubs/inertia/resources/js/app.js
+++ b/stubs/inertia/resources/js/app.js
@@ -2,6 +2,7 @@ import './bootstrap';
 
 import { createApp, h } from 'vue';
 import { createInertiaApp } from '@inertiajs/inertia-vue3';
+import { ZiggyVue } from "ziggy";
 import { InertiaProgress } from '@inertiajs/progress';
 
 const appName = window.document.getElementsByTagName('title')[0]?.innerText || 'Laravel';
@@ -12,7 +13,7 @@ createInertiaApp({
     setup({ el, app, props, plugin }) {
         return createApp({ render: () => h(app, props) })
             .use(plugin)
-            .mixin({ methods: { route } })
+            .use(ZiggyVue, Ziggy)
             .mount(el);
     },
 });

--- a/stubs/inertia/resources/js/app.js
+++ b/stubs/inertia/resources/js/app.js
@@ -2,7 +2,7 @@ import './bootstrap';
 
 import { createApp, h } from 'vue';
 import { createInertiaApp } from '@inertiajs/inertia-vue3';
-import { ZiggyVue } from "ziggy";
+import { ZiggyVue } from 'ziggy';
 import { InertiaProgress } from '@inertiajs/progress';
 
 const appName = window.document.getElementsByTagName('title')[0]?.innerText || 'Laravel';

--- a/stubs/inertia/resources/js/app.js
+++ b/stubs/inertia/resources/js/app.js
@@ -2,8 +2,8 @@ import './bootstrap';
 
 import { createApp, h } from 'vue';
 import { createInertiaApp } from '@inertiajs/inertia-vue3';
-import { ZiggyVue } from 'ziggy';
 import { InertiaProgress } from '@inertiajs/progress';
+import { ZiggyVue } from 'ziggy';
 
 const appName = window.document.getElementsByTagName('title')[0]?.innerText || 'Laravel';
 

--- a/stubs/inertia/resources/js/ssr.js
+++ b/stubs/inertia/resources/js/ssr.js
@@ -2,7 +2,7 @@ import { createSSRApp, h } from 'vue';
 import { renderToString } from '@vue/server-renderer';
 import { createInertiaApp } from '@inertiajs/inertia-vue3';
 import createServer from '@inertiajs/server';
-import route from 'ziggy';
+import { ZiggyVue } from 'ziggy';
 
 const appName = 'Laravel';
 
@@ -15,15 +15,9 @@ createServer((page) =>
         setup({ app, props, plugin }) {
             return createSSRApp({ render: () => h(app, props) })
                 .use(plugin)
-                .mixin({
-                    methods: {
-                        route: (name, params, absolute) => {
-                            return route(name, params, absolute, {
-                                ...page.props.ziggy,
-                                location: new URL(page.props.ziggy.url),
-                            });
-                        },
-                    },
+                .use(ZiggyVue, {
+                    ...page.props.ziggy,
+                    location: new URL(page.props.ziggy.url),
                 });
         },
     })

--- a/stubs/inertia/webpack.mix.js
+++ b/stubs/inertia/webpack.mix.js
@@ -17,6 +17,7 @@ mix.js('resources/js/app.js', 'public/js').vue()
     ])
     .alias({
         '@': 'resources/js',
+        ziggy: "vendor/tightenco/ziggy/dist/vue",
     });
 
 if (mix.inProduction()) {

--- a/stubs/inertia/webpack.ssr.mix.js
+++ b/stubs/inertia/webpack.ssr.mix.js
@@ -9,7 +9,7 @@ mix.js('resources/js/ssr.js', 'public/js')
     })
     .alias({
         '@': 'resources/js',
-        ziggy: 'vendor/tightenco/ziggy/dist/index',
+        ziggy: 'vendor/tightenco/ziggy/dist/vue',
     })
     .webpackConfig({
         target: 'node',


### PR DESCRIPTION
This PR fixes an error where the Ziggy `route()` helper is undefined when `route()` is used in the `setup()` function and Inertia SSR is being used. 

### Steps to Reproduce

1. Install Jetstream with Inertia SSR `php artisan jetstream:install inertia --ssr`
2. In the `Welcome.vue` file, for example, use the route function inside `<script setup>`:
```js
const test = route('login')
```
3. Display the result in the template somewhere:
     ` {{ test }}`
4. Compile ssr.js `npx mix --mix-config=webpack.ssr.mix.js`
5. Compile app.js `npm run dev`
6. Start the SSR service `node public/js/ssr.js`
7. Upon visiting the page, there will be an error in the node terminal (and the page will fall back to client-side rendering):
     `ReferenceError: route is not defined`

### Proposed Solution

Using `route()` in the setup function will work using client-side rendering by default, because the `@routes` blade directive defines it globally. According to [this answer](https://github.com/tighten/ziggy/discussions/564#discussioncomment-2828066), the route function should be injected when being used in a setup function. However, for the route function to be [provided](https://github.com/tighten/ziggy/commit/5661ec32937b7b84012a1d075f5a9c4d1954e9ce), the [Ziggy Vue](https://github.com/tighten/ziggy#vue) plugin must be used.

To do this in `ssr.js`, we would use `ZiggyVue` instead of the route mixin. This would keep `route()` available in all templates, and would make it available in setup functions if we inject it:
```js
import { inject } from 'vue'
const route = inject('route')
const test = route('login')
```

This now works under SSR, but not when the page is client-side rendered: `inject('route')` will be undefined because we aren't using the `ZiggyVue` plugin in `app.js`.

Therefore, the route mixin also needs to be removed from `app.js` and replaced with:
```js
import { ZiggyVue } from "ziggy";
//...
.use(ZiggyVue, Ziggy)
```
`Ziggy` refers to the definition `const Ziggy` by the `@routes` blade directive in `<head>`. 

### Breaking Changes

It doesn't seem like these changes will break anything in new Jetstream projects, whether using Inertia SSR or not. When only using client-side rendering, the route function can still be used in templates, setup, functions, etc. without being injected. The route function only needs to be injected when it's being used in the setup function and the page is being server-side rendered. 

I wish there was a more elegant solution as I don't love having to `const route = inject('route')` where route is needed in script setup/computed functions/etc, so please let me know if there are any other ideas. I'm also not sure if this problem is big enough to warrant a change but wanted to put it out there in case others are having this issue

