### PR TITLE
fix TailwindCSS first party TypeScript types weren't working right

### DIFF
--- a/stubs/inertia/tailwind.config.js
+++ b/stubs/inertia/tailwind.config.js
@@ -1,6 +1,6 @@
-/** @type {import('tailwindcss').Config} */
 const defaultTheme = require('tailwindcss/defaultTheme');
 
+/** @type {import('tailwindcss').Config} */
 module.exports = {
     content: [
         './vendor/laravel/framework/src/Illuminate/Pagination/resources/views/*.blade.php',

--- a/stubs/livewire/tailwind.config.js
+++ b/stubs/livewire/tailwind.config.js
@@ -1,6 +1,6 @@
-/** @type {import('tailwindcss').Config} */
 const defaultTheme = require('tailwindcss/defaultTheme');
 
+/** @type {import('tailwindcss').Config} */
 module.exports = {
     content: [
         './vendor/laravel/framework/src/Illuminate/Pagination/resources/views/*.blade.php',


### PR DESCRIPTION
This PR fixes the new TailwindCSS 3.1 First-party TypeScript types feature.

This Bug was introduced with.
https://github.com/laravel/jetstream/pull/1066

Thanks to @martinvadel who recognized it.