### PR TITLE
[2.x] Update inertia version to check for the Vite manifest

### DIFF
--- a/stubs/inertia/app/Http/Middleware/HandleInertiaRequests.php
+++ b/stubs/inertia/app/Http/Middleware/HandleInertiaRequests.php
@@ -21,9 +21,17 @@ class HandleInertiaRequests extends Middleware
      * @param  \Illuminate\Http\Request  $request
      * @return string|null
      */
-    public function version(Request $request)
+    public function version(Request $request): ?string
     {
-        return parent::version($request);
+        if (config('app.asset_url')) {
+            return md5(config('app.asset_url'));
+        }
+
+        if (file_exists($manifest = public_path('build/manifest.json'))) {
+            return md5_file($manifest);
+        }
+
+        return null;
     }
 
     /**

--- a/stubs/inertia/app/Http/Middleware/HandleInertiaRequests.php
+++ b/stubs/inertia/app/Http/Middleware/HandleInertiaRequests.php
@@ -21,7 +21,7 @@ class HandleInertiaRequests extends Middleware
      * @param  \Illuminate\Http\Request  $request
      * @return string|null
      */
-    public function version(Request $request): ?string
+    public function version(Request $request)
     {
         if (config('app.asset_url')) {
             return md5(config('app.asset_url'));
@@ -30,8 +30,6 @@ class HandleInertiaRequests extends Middleware
         if (file_exists($manifest = public_path('build/manifest.json'))) {
             return md5_file($manifest);
         }
-
-        return null;
     }
 
     /**


### PR DESCRIPTION
I have been testing the Vite integration prior to it's release next week and had to change the version method on the `HandlesInertiaRequests` middleware to check the new Vite manifest file. A simple swap from `mix-manifest.json` to `build/manifest.json` was enough to force a refresh for users on old production assets.

This obviously doesn't matter and won't make a difference during local development as the hot reload handles everything. But, in production, users who are using your site as a new deployment happens will need to refresh manually to get the changes unless this method is updated.

With Vite becoming the default, I thought it would make sense to add this change so new installs are already prepared.

I'm not sure if this is also worth mentioning in the upgrade guide for anyone switching from Laravel Mix. https://github.com/laravel/vite-plugin/blob/main/UPGRADE.md#migrating-from-laravel-mix-to-vite