### PR TITLE
Fix ziggy location instead of base url

### DIFF
--- a/stubs/inertia/app/Http/Middleware/HandleInertiaRequests.php
+++ b/stubs/inertia/app/Http/Middleware/HandleInertiaRequests.php
@@ -35,8 +35,10 @@ class HandleInertiaRequests extends Middleware
     public function share(Request $request)
     {
         return array_merge(parent::share($request), [
-            'ziggy' => function () {
-                return (new Ziggy)->toArray();
+            'ziggy' => function () use ($request) {
+                return array_merge((new Ziggy)->toArray(), [
+                    'location' => $request->url(),
+                ]);
             },
         ]);
     }

--- a/stubs/inertia/resources/js/ssr.js
+++ b/stubs/inertia/resources/js/ssr.js
@@ -18,7 +18,7 @@ createServer((page) =>
                 .use(plugin)
                 .use(ZiggyVue, {
                     ...page.props.ziggy,
-                    location: new URL(page.props.ziggy.url),
+                    location: new URL(page.props.ziggy.location),
                 });
         },
     })


### PR DESCRIPTION
I've noticed that using the URL property to handle the active route on Ziggy in SSR is not correct. Indeed, we need to know the current URL and the URL property returns the base URL of the application.

To reproduce the bug, just disable the JS and find that the active route in the menu does not work. With JS, it works because the client re-hydrates the server-generated DOM.

So, I think we need to get current URL via request and totally replace window.location so.