### PR TITLE
Use @import instead of @tailwind

### DIFF
--- a/stubs/resources/css/app.css
+++ b/stubs/resources/css/app.css
@@ -1,3 +1,3 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import 'tailwindcss/base';
+@import 'tailwindcss/components';
+@import 'tailwindcss/utilities';


### PR DESCRIPTION
I've also made this change proposal in Breeze: https://github.com/laravel/breeze/pull/165
This was changed in this PR: https://github.com/laravel/jetstream/pull/1060

But I think packages can benefit more from using the postcss-import style in the main TailwindCSS setup.

In the Rich Text Laravel package, for instance, I dump some CSS file to the `resources/css/` folder and in order to be able to add the `@import "./_trix.css";` line to the main CSS file, I'd need to swap the entire file for a version of it using `@import`, which can be problematic assuming the user 

If this was webpack, we would have to install the `postcss-import` plugin and require it ourselves, but I've tested this with the new Vite setup and it looks like just works. Not sure if there's anything to do.