### PR TITLE
[2.x] Add default view / routes reloading to jetstream stacks

### DIFF
--- a/stubs/inertia/vite.config.js
+++ b/stubs/inertia/vite.config.js
@@ -6,6 +6,7 @@ export default defineConfig({
     plugins: [
         laravel({
             input: 'resources/js/app.js',
+            refresh: true,
         }),
         vue({
             template: {

--- a/stubs/livewire/vite.config.js
+++ b/stubs/livewire/vite.config.js
@@ -3,9 +3,12 @@ import laravel from 'laravel-vite-plugin';
 
 export default defineConfig({
     plugins: [
-        laravel([
-            'resources/css/app.css',
-            'resources/js/app.js',
-        ]),
+        laravel({
+            input: [
+                'resources/css/app.css',
+                'resources/js/app.js',
+            ],
+            refresh: true,
+        }),
     ],
 });


### PR DESCRIPTION
This PR makes both the jetstream stacks come with the default Laravel watching configuration out of the box.

As it stands, this will perform a full page refresh while running `npm run dev` and saving files within the following directories:

```
resources/views/**
routes/**
```

The configured directories can still be manually configured if needed.

Tested stacks:

- Inertia
- Inertia --ssr
- Livewire

See: https://github.com/laravel/vite-plugin/pull/43