### PR TITLE
[2.x] Add livewire component paths to default refresh paths for livewire stack

### DIFF
--- a/stubs/livewire/vite.config.js
+++ b/stubs/livewire/vite.config.js
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vite';
-import laravel from 'laravel-vite-plugin';
+import laravel, { refreshPaths } from 'laravel-vite-plugin';
 
 export default defineConfig({
     plugins: [
@@ -8,7 +8,10 @@ export default defineConfig({
                 'resources/css/app.css',
                 'resources/js/app.js',
             ],
-            refresh: true,
+            refresh: [
+                ...refreshPaths,
+                'app/Http/Livewire/**',
+            ],
         }),
     ],
 });


### PR DESCRIPTION
This is dependent on merging and tagging of: 

- ~https://github.com/laravel/vite-plugin/pull/55~
- https://github.com/laravel/laravel/pull/5932

so the tests are currently failing, however this has been tested locally.

This PR additionally watches `app/Http/Livewire/**` in the Livewire stack, as "inline" components contain all their view logic there. When files there change, the browser will perform a full page refresh.


Test script...

```
composer create-project laravel/laravel:9.x-dev jetstream-test \
  && cd jetstream-test \
  && composer require laravel/jetstream:livewire-refresh-dev \
  && php artisan jetstream:install livewire \
  && sed -i "s/SESSION_DRIVER=database/SESSION_DRIVER=file/" .env \
  && npm install \
  && npm run dev

php artisan serve

php artisan make:livewire Counter --inline
```

Put the following in your `welcome.blade.php`
```blade
<!DOCTYPE html>
<html>
    <head>
        @vite(['resources/js/app.js', 'resources/css/app.css'])
    </head>
    <body>
        <livewire:counter />
    </body>
</html>

```

Then put the following in your Livewire component...

```php
<?php

namespace App\Http\Livewire;

use Livewire\Component;

class Counter extends Component
{
    public function render()
    {
        return <<<'blade'
            <div>
                hello world.
            </div>
        blade;
    }
}
```

You should not be able to edit the Livewire component and see the browser refresh and show the new content.