### PR TITLE
[2.x] Drop Laravel 8.x support (and PHP < 8)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,13 +13,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.3, 7.4, '8.0', 8.1]
-        laravel: [8, 9]
-        exclude:
-          - php: 7.3
-            laravel: 9
-          - php: 7.4
-            laravel: 9
+        php: ['8.0', 8.1]
+        laravel: [9]
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,9 @@
         "orchestra/testbench": "^6.0|^7.0",
         "phpunit/phpunit": "^9.3"
     },
+    "conflict": {
+        "laravel/framework": "<9.19.0"
+    },
     "autoload": {
         "psr-4": {
             "Laravel\\Jetstream\\": "src/"

--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
         }
     ],
     "require": {
-        "php": "^7.3|^8.0",
+        "php": "^8.0",
         "ext-json": "*",
-        "illuminate/support": "^8.37|^9.0",
+        "illuminate/support": "^9.0",
         "jenssegers/agent": "^2.6",
         "laravel/fortify": "^1.12"
     },

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.0.2",
         "ext-json": "*",
         "illuminate/support": "^9.0",
         "jenssegers/agent": "^2.6",


### PR DESCRIPTION
Dropping Laravel 8.x support as:

- Jetstream is only meant to be installed on ["new applications"](https://jetstream.laravel.com/2.x/installation.html). I interpret this as meaning `composer create-project laravel/laravel app`.

Adding conflict as:

- Vite is only supported in `laravel/framework:^9.19.0`.

Dropping support for PHP < 8.0.2 as:

- The current version of Laravel 9.x only supports `PHP:^8.0.2`.

I'm also not sure how Laravel approaches dropping version support with SemVer - especially when it comes to these started kits. I'm pretty sure dropping version support is not a "breaking change" in SemVer world.

Alternatively, we could back port Vite but this would probably also include ongoing feature improvements in `laravel/framework` around Vite as well.

Testing script:

```sh
composer create-project laravel/laravel jetstream-test \
  && cd jetstream-test \
  && composer require laravel/jetstream:drop-8.x-support-dev \
  && php artisan jetstream:install inertia \
  && sed -i "s/SESSION_DRIVER=database/SESSION_DRIVER=file/" .env \
  && npm install && npm run dev

php artisan serve
```

See also: https://github.com/laravel/breeze/pull/167