### PR TITLE
[2.x] Update SSR directory

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -525,7 +525,7 @@ EOF;
 
         $this->replaceInFile("'enabled' => false", "'enabled' => true", config_path('inertia.php'));
         $this->replaceInFile('vite build', 'vite build && vite build --ssr', base_path('package.json'));
-        $this->replaceInFile('/storage/*.key', '/storage/ssr'.PHP_EOL.'/storage/*.key', base_path('.gitignore'));
+        $this->replaceInFile('/node_modules', '/bootstrap/ssr'.PHP_EOL.'/node_modules', base_path('.gitignore'));
     }
 
     /**


### PR DESCRIPTION
This PR updates the `.gitignore` entry that we add for the SSR build directory to use the new location from https://github.com/laravel/vite-plugin/pull/70.

We should hold off releasing this until the new version of `laravel-vite-plugin` has also been released.