### PR TITLE
Change position of Livewire Style

### DIFF
--- a/stubs/livewire/resources/views/layouts/app.blade.php
+++ b/stubs/livewire/resources/views/layouts/app.blade.php
@@ -10,11 +10,11 @@
         <!-- Fonts -->
         <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap">
 
-        <!-- Styles -->
-        @livewireStyles
-
         <!-- Scripts -->
         @vite(['resources/css/app.css', 'resources/js/app.js'])
+
+        <!-- Styles -->
+        @livewireStyles
     </head>
     <body class="font-sans antialiased">
         <x-jet-banner />
@@ -25,7 +25,7 @@
             <!-- Page Heading -->
             @if (isset($header))
                 <header class="bg-white shadow">
-                    <div class="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
+                    <div class="px-4 py-6 mx-auto max-w-7xl sm:px-6 lg:px-8">
                         {{ $header }}
                     </div>
                 </header>

--- a/stubs/livewire/resources/views/layouts/app.blade.php
+++ b/stubs/livewire/resources/views/layouts/app.blade.php
@@ -25,7 +25,7 @@
             <!-- Page Heading -->
             @if (isset($header))
                 <header class="bg-white shadow">
-                    <div class="px-4 py-6 mx-auto max-w-7xl sm:px-6 lg:px-8">
+                    <div class="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
                         {{ $header }}
                     </div>
                 </header>


### PR DESCRIPTION
Changed the position where the Livewire styles got loaded, from before, to after the Vite injection.
This is to prevent missleading behaivor of Livewire as discussed in the Livewire Discord:
![image](https://user-images.githubusercontent.com/695535/179862343-0ff7b670-79dc-408f-b8ac-22ff14eece3f.png)
![image](https://user-images.githubusercontent.com/695535/179862373-e3324b4f-2732-457f-8be9-dbc2b5e6d19c.png)
