### PR TITLE
Skip two factor authentication tests when the feature is disabled

### DIFF
--- a/stubs/pest-tests/inertia/TwoFactorAuthenticationSettingsTest.php
+++ b/stubs/pest-tests/inertia/TwoFactorAuthenticationSettingsTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\User;
+use Laravel\Fortify\Features;
 
 test('two factor authentication can be enabled', function () {
     $this->actingAs($user = User::factory()->create());
@@ -11,7 +12,9 @@ test('two factor authentication can be enabled', function () {
 
     expect($user->fresh()->two_factor_secret)->not->toBeNull();
     expect($user->fresh()->recoveryCodes())->toHaveCount(8);
-});
+})->skip(function () {
+    return ! Features::canManageTwoFactorAuthentication();
+}, 'Two factor authentication is not enabled.');
 
 test('recovery codes can be regenerated', function () {
     $this->actingAs($user = User::factory()->create());
@@ -27,7 +30,9 @@ test('recovery codes can be regenerated', function () {
 
     expect($user->recoveryCodes())->toHaveCount(8);
     expect(array_diff($user->recoveryCodes(), $user->fresh()->recoveryCodes()))->toHaveCount(8);
-});
+})->skip(function () {
+    return ! Features::canManageTwoFactorAuthentication();
+}, 'Two factor authentication is not enabled.');
 
 test('two factor authentication can be disabled', function () {
     $this->actingAs($user = User::factory()->create());
@@ -41,4 +46,6 @@ test('two factor authentication can be disabled', function () {
     $this->delete('/user/two-factor-authentication');
 
     expect($user->fresh()->two_factor_secret)->toBeNull();
-});
+})->skip(function () {
+    return ! Features::canManageTwoFactorAuthentication();
+}, 'Two factor authentication is not enabled.');

--- a/stubs/pest-tests/livewire/TwoFactorAuthenticationSettingsTest.php
+++ b/stubs/pest-tests/livewire/TwoFactorAuthenticationSettingsTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\User;
+use Laravel\Fortify\Features;
 use Laravel\Jetstream\Http\Livewire\TwoFactorAuthenticationForm;
 use Livewire\Livewire;
 
@@ -16,7 +17,9 @@ test('two factor authentication can be enabled', function () {
 
     expect($user->two_factor_secret)->not->toBeNull();
     expect($user->recoveryCodes())->toHaveCount(8);
-});
+})->skip(function () {
+    return ! Features::canManageTwoFactorAuthentication();
+}, 'Two factor authentication is not enabled.');
 
 test('recovery codes can be regenerated', function () {
     $this->actingAs($user = User::factory()->create());
@@ -33,7 +36,9 @@ test('recovery codes can be regenerated', function () {
 
     expect($user->recoveryCodes())->toHaveCount(8);
     expect(array_diff($user->recoveryCodes(), $user->fresh()->recoveryCodes()))->toHaveCount(8);
-});
+})->skip(function () {
+    return ! Features::canManageTwoFactorAuthentication();
+}, 'Two factor authentication is not enabled.');
 
 test('two factor authentication can be disabled', function () {
     $this->actingAs($user = User::factory()->create());
@@ -48,4 +53,6 @@ test('two factor authentication can be disabled', function () {
     $component->call('disableTwoFactorAuthentication');
 
     expect($user->fresh()->two_factor_secret)->toBeNull();
-});
+})->skip(function () {
+    return ! Features::canManageTwoFactorAuthentication();
+}, 'Two factor authentication is not enabled.');

--- a/stubs/tests/inertia/TwoFactorAuthenticationSettingsTest.php
+++ b/stubs/tests/inertia/TwoFactorAuthenticationSettingsTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Fortify\Features;
 use Tests\TestCase;
 
 class TwoFactorAuthenticationSettingsTest extends TestCase
@@ -12,6 +13,10 @@ class TwoFactorAuthenticationSettingsTest extends TestCase
 
     public function test_two_factor_authentication_can_be_enabled()
     {
+        if (! Features::canManageTwoFactorAuthentication()) {
+            return $this->markTestSkipped('Two factor authentication is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->create());
 
         $this->withSession(['auth.password_confirmed_at' => time()]);
@@ -24,6 +29,10 @@ class TwoFactorAuthenticationSettingsTest extends TestCase
 
     public function test_recovery_codes_can_be_regenerated()
     {
+        if (! Features::canManageTwoFactorAuthentication()) {
+            return $this->markTestSkipped('Two factor authentication is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->create());
 
         $this->withSession(['auth.password_confirmed_at' => time()]);
@@ -41,6 +50,10 @@ class TwoFactorAuthenticationSettingsTest extends TestCase
 
     public function test_two_factor_authentication_can_be_disabled()
     {
+        if (! Features::canManageTwoFactorAuthentication()) {
+            return $this->markTestSkipped('Two factor authentication is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->create());
 
         $this->withSession(['auth.password_confirmed_at' => time()]);

--- a/stubs/tests/livewire/TwoFactorAuthenticationSettingsTest.php
+++ b/stubs/tests/livewire/TwoFactorAuthenticationSettingsTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Fortify\Features;
 use Laravel\Jetstream\Http\Livewire\TwoFactorAuthenticationForm;
 use Livewire\Livewire;
 use Tests\TestCase;
@@ -14,6 +15,10 @@ class TwoFactorAuthenticationSettingsTest extends TestCase
 
     public function test_two_factor_authentication_can_be_enabled()
     {
+        if (! Features::canManageTwoFactorAuthentication()) {
+            return $this->markTestSkipped('Two factor authentication is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->create());
 
         $this->withSession(['auth.password_confirmed_at' => time()]);
@@ -29,6 +34,10 @@ class TwoFactorAuthenticationSettingsTest extends TestCase
 
     public function test_recovery_codes_can_be_regenerated()
     {
+        if (! Features::canManageTwoFactorAuthentication()) {
+            return $this->markTestSkipped('Two factor authentication is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->create());
 
         $this->withSession(['auth.password_confirmed_at' => time()]);
@@ -47,6 +56,10 @@ class TwoFactorAuthenticationSettingsTest extends TestCase
 
     public function test_two_factor_authentication_can_be_disabled()
     {
+        if (! Features::canManageTwoFactorAuthentication()) {
+            return $this->markTestSkipped('Two factor authentication is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->create());
 
         $this->withSession(['auth.password_confirmed_at' => time()]);


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

If you change the behavior of the Inertia stack you're expected to update the Livewire stack as well and vice versa.
-->

On a fresh install, many of the test stubs include checks for disabled features and those tests are skipped when appropriate.  This isn't the case for the two factor authentication feature tests, so I propose adding those feature checks to the test stubs.

I realize this was suggested in #793 last year but IMO the two factor authentication checks not having these checks while the others do is an inconsistent behavior and it can be somewhat surprising to see failures for a disabled feature because of the missing checks.