### PR TITLE
[2.x] Adds Expired At Input To Api Token Create

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require-dev": {
         "inertiajs/inertia-laravel": "^0.5.2",
-        "laravel/sanctum": "^2.7",
+        "laravel/sanctum": "^3.0",
         "mockery/mockery": "^1.0",
         "orchestra/testbench": "^7.0",
         "phpunit/phpunit": "^9.3"

--- a/src/Http/Controllers/Inertia/ApiTokenController.php
+++ b/src/Http/Controllers/Inertia/ApiTokenController.php
@@ -4,6 +4,7 @@ namespace Laravel\Jetstream\Http\Controllers\Inertia;
 
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Carbon;
 use Laravel\Jetstream\Jetstream;
 
 class ApiTokenController extends Controller
@@ -37,11 +38,13 @@ class ApiTokenController extends Controller
     {
         $request->validate([
             'name' => ['required', 'string', 'max:255'],
+            'expires_at' => ['nullable', 'date', 'date_format:Y-m-d', 'after:today'],
         ]);
 
         $token = $request->user()->createToken(
             $request->name,
-            Jetstream::validPermissions($request->input('permissions', []))
+            Jetstream::validPermissions($request->input('permissions', [])),
+            $request->expires_at ? Carbon::parse($request->expires_at) : null
         );
 
         return back()->with('flash', [

--- a/src/Http/Livewire/ApiTokenManager.php
+++ b/src/Http/Livewire/ApiTokenManager.php
@@ -101,7 +101,7 @@ class ApiTokenManager extends Component
         $this->displayTokenValue($this->user->createToken(
             $this->createApiTokenForm['name'],
             Jetstream::validPermissions($this->createApiTokenForm['permissions']),
-            $this->createApiTokenForm['name'] ? Carbon::parse($this->createApiTokenForm['name']) : null
+            $this->createApiTokenForm['expires_at'] ? Carbon::parse($this->createApiTokenForm['expires_at']) : null
         ));
 
         $this->createApiTokenForm['name'] = '';

--- a/src/Http/Livewire/ApiTokenManager.php
+++ b/src/Http/Livewire/ApiTokenManager.php
@@ -106,7 +106,7 @@ class ApiTokenManager extends Component
         ));
 
         $this->createApiTokenForm['name'] = '';
-        $this->createApiTokenForm['expires_at'] = '';
+        $this->createApiTokenForm['expires_at'] = null;
         $this->createApiTokenForm['permissions'] = Jetstream::$defaultPermissions;
 
         $this->emit('created');

--- a/src/Http/Livewire/ApiTokenManager.php
+++ b/src/Http/Livewire/ApiTokenManager.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Jetstream\Http\Livewire;
 
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Validator;
 use Laravel\Jetstream\Jetstream;
@@ -91,16 +92,20 @@ class ApiTokenManager extends Component
 
         Validator::make([
             'name' => $this->createApiTokenForm['name'],
+            'expires_at' => $this->createApiTokenForm['expires_at'],
         ], [
             'name' => ['required', 'string', 'max:255'],
+            'expires_at' => ['nullable', 'date', 'date_format:Y-m-d', 'after:today'],
         ])->validateWithBag('createApiToken');
 
         $this->displayTokenValue($this->user->createToken(
             $this->createApiTokenForm['name'],
-            Jetstream::validPermissions($this->createApiTokenForm['permissions'])
+            Jetstream::validPermissions($this->createApiTokenForm['permissions']),
+            $this->createApiTokenForm['name'] ? Carbon::parse($this->createApiTokenForm['name']) : null
         ));
 
         $this->createApiTokenForm['name'] = '';
+        $this->createApiTokenForm['expires_at'] = '';
         $this->createApiTokenForm['permissions'] = Jetstream::$defaultPermissions;
 
         $this->emit('created');

--- a/src/Http/Livewire/ApiTokenManager.php
+++ b/src/Http/Livewire/ApiTokenManager.php
@@ -17,6 +17,7 @@ class ApiTokenManager extends Component
      */
     public $createApiTokenForm = [
         'name' => '',
+        'expires_at' => null,
         'permissions' => [],
     ];
 

--- a/stubs/inertia/resources/js/Pages/API/Partials/ApiTokenManager.vue
+++ b/stubs/inertia/resources/js/Pages/API/Partials/ApiTokenManager.vue
@@ -23,6 +23,7 @@ const props = defineProps({
 
 const createApiTokenForm = useForm({
     name: '',
+    expires_at: '',
     permissions: props.defaultPermissions,
 });
 
@@ -96,6 +97,19 @@ const deleteApiToken = () => {
                         autofocus
                     />
                     <JetInputError :message="createApiTokenForm.errors.name" class="mt-2" />
+                </div>
+
+                <!-- Token Expires At -->
+                <div class="col-span-6 sm:col-span-4">
+                    <JetLabel for="expires_at" value="Token Expiration Date" />
+                    <JetInput
+                        id="expires_at"
+                        v-model="createApiTokenForm.expires_at"
+                        type="date"
+                        class="block w-full mt-1"
+                        autofocus
+                    />
+                    <JetInputError :message="createApiTokenForm.errors.expires_at" class="mt-2" />
                 </div>
 
                 <!-- Token Permissions -->

--- a/stubs/livewire/resources/views/api/api-token-manager.blade.php
+++ b/stubs/livewire/resources/views/api/api-token-manager.blade.php
@@ -17,6 +17,13 @@
                 <x-jet-input-error for="name" class="mt-2" />
             </div>
 
+            <!-- Token Expires At -->
+            <div class="col-span-6 sm:col-span-4">
+                <x-jet-label for="expires_at" value="{{ __('Token Expiration Date') }}" />
+                <x-jet-input id="expires_at" type="date" class="mt-1 block w-full" wire:model.defer="createApiTokenForm.expires_at" autofocus />
+                <x-jet-input-error for="expires_at" class="mt-2" />
+            </div>
+
             <!-- Token Permissions -->
             @if (Laravel\Jetstream\Jetstream::hasPermissions())
                 <div class="col-span-6">

--- a/stubs/pest-tests/inertia/CreateApiTokenTest.php
+++ b/stubs/pest-tests/inertia/CreateApiTokenTest.php
@@ -30,7 +30,6 @@ test('api tokens can be created', function () {
     return ! Features::hasApiFeatures();
 }, 'API support is not enabled.');
 
-
 test('api tokens can be created with expires at date', function () {
     if (Features::hasTeamFeatures()) {
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());

--- a/stubs/pest-tests/inertia/CreateApiTokenTest.php
+++ b/stubs/pest-tests/inertia/CreateApiTokenTest.php
@@ -46,8 +46,8 @@ test('api tokens can be created with expires at date', function () {
         ],
     ]);
 
-    expect($user->fresh()->tokens)->toHaveCount(2);
-    expect($user->fresh()->tokens->latest()->first())
+    expect($user->fresh()->tokens)->toHaveCount(1);
+    expect($user->fresh()->tokens->first())
         ->name->toEqual('Test Token With Expires At')
         ->expires_at->toEqual(Carbon::parse(now()->addDay()->format('Y-m-d')))
         ->can('read')->toBeTrue()

--- a/stubs/pest-tests/inertia/CreateApiTokenTest.php
+++ b/stubs/pest-tests/inertia/CreateApiTokenTest.php
@@ -2,6 +2,7 @@
 
 use App\Models\User;
 use Laravel\Jetstream\Features;
+use Illuminate\Support\Carbon;
 
 test('api tokens can be created', function () {
     if (Features::hasTeamFeatures()) {
@@ -49,7 +50,7 @@ test('api tokens can be created with expires at date', function () {
     expect($user->fresh()->tokens)->toHaveCount(1);
     expect($user->fresh()->tokens->first())
         ->name->toEqual('Test Token')
-        ->expires_at->toBeLike(now()->addDay())
+        ->expires_at->toEqual(Carbon::parse(now()->addDays(1)->format('Y-m-d')))
         ->can('read')->toBeTrue()
         ->can('delete')->toBeFalse();
 })->skip(function () {

--- a/stubs/pest-tests/inertia/CreateApiTokenTest.php
+++ b/stubs/pest-tests/inertia/CreateApiTokenTest.php
@@ -12,6 +12,7 @@ test('api tokens can be created', function () {
 
     $response = $this->post('/user/api-tokens', [
         'name' => 'Test Token',
+        'expires_at' => null,
         'permissions' => [
             'read',
             'update',
@@ -21,6 +22,34 @@ test('api tokens can be created', function () {
     expect($user->fresh()->tokens)->toHaveCount(1);
     expect($user->fresh()->tokens->first())
         ->name->toEqual('Test Token')
+        ->expires_at->toBeNull()
+        ->can('read')->toBeTrue()
+        ->can('delete')->toBeFalse();
+})->skip(function () {
+    return ! Features::hasApiFeatures();
+}, 'API support is not enabled.');
+
+
+test('api tokens can be created with expires at date', function () {
+    if (Features::hasTeamFeatures()) {
+        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+    } else {
+        $this->actingAs($user = User::factory()->create());
+    }
+
+    $response = $this->post('/user/api-tokens', [
+        'name' => 'Test Token',
+        'expires_at' => now()->addDay()->format('Y-m-d'),
+        'permissions' => [
+            'read',
+            'update',
+        ],
+    ]);
+
+    expect($user->fresh()->tokens)->toHaveCount(1);
+    expect($user->fresh()->tokens->first())
+        ->name->toEqual('Test Token')
+        ->expires_at->toBeLike(now()->addDay())
         ->can('read')->toBeTrue()
         ->can('delete')->toBeFalse();
 })->skip(function () {

--- a/stubs/pest-tests/inertia/CreateApiTokenTest.php
+++ b/stubs/pest-tests/inertia/CreateApiTokenTest.php
@@ -1,8 +1,8 @@
 <?php
 
 use App\Models\User;
-use Laravel\Jetstream\Features;
 use Illuminate\Support\Carbon;
+use Laravel\Jetstream\Features;
 
 test('api tokens can be created', function () {
     if (Features::hasTeamFeatures()) {

--- a/stubs/pest-tests/inertia/CreateApiTokenTest.php
+++ b/stubs/pest-tests/inertia/CreateApiTokenTest.php
@@ -38,7 +38,7 @@ test('api tokens can be created with expires at date', function () {
     }
 
     $response = $this->post('/user/api-tokens', [
-        'name' => 'Test Token',
+        'name' => 'Test Token With Expires At',
         'expires_at' => now()->addDay()->format('Y-m-d'),
         'permissions' => [
             'read',
@@ -46,10 +46,10 @@ test('api tokens can be created with expires at date', function () {
         ],
     ]);
 
-    expect($user->fresh()->tokens)->toHaveCount(1);
-    expect($user->fresh()->tokens->first())
-        ->name->toEqual('Test Token')
-        ->expires_at->toEqual(Carbon::parse(now()->addDays(1)->format('Y-m-d')))
+    expect($user->fresh()->tokens)->toHaveCount(2);
+    expect($user->fresh()->tokens->latest()->first())
+        ->name->toEqual('Test Token With Expires At')
+        ->expires_at->toEqual(Carbon::parse(now()->addDay()->format('Y-m-d')))
         ->can('read')->toBeTrue()
         ->can('delete')->toBeFalse();
 })->skip(function () {

--- a/stubs/pest-tests/livewire/CreateApiTokenTest.php
+++ b/stubs/pest-tests/livewire/CreateApiTokenTest.php
@@ -1,10 +1,10 @@
 <?php
 
 use App\Models\User;
+use Illuminate\Support\Carbon;
 use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Http\Livewire\ApiTokenManager;
 use Livewire\Livewire;
-use Illuminate\Support\Carbon;
 
 test('api tokens can be created', function () {
     if (Features::hasTeamFeatures()) {

--- a/stubs/pest-tests/livewire/CreateApiTokenTest.php
+++ b/stubs/pest-tests/livewire/CreateApiTokenTest.php
@@ -4,6 +4,7 @@ use App\Models\User;
 use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Http\Livewire\ApiTokenManager;
 use Livewire\Livewire;
+use Illuminate\Support\Carbon;
 
 test('api tokens can be created', function () {
     if (Features::hasTeamFeatures()) {
@@ -52,7 +53,7 @@ test('api tokens can be created with expires at date', function () {
     expect($user->fresh()->tokens)->toHaveCount(1);
     expect($user->fresh()->tokens->first())
         ->name->toEqual('Test Token')
-        ->expires_at->toBeLike(now()->addDay())
+        ->expires_at->toEqual(Carbon::parse(now()->addDays(1)->format('Y-m-d')))
         ->can('read')->toBeTrue()
         ->can('delete')->toBeFalse();
 })->skip(function () {

--- a/stubs/pest-tests/livewire/CreateApiTokenTest.php
+++ b/stubs/pest-tests/livewire/CreateApiTokenTest.php
@@ -34,28 +34,28 @@ test('api tokens can be created', function () {
     return ! Features::hasApiFeatures();
 }, 'API support is not enabled.');
 
-// test('api tokens can be created with expires at date', function () {
-//     if (Features::hasTeamFeatures()) {
-//         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
-//     } else {
-//         $this->actingAs($user = User::factory()->create());
-//     }
+test('api tokens can be created with expires at date', function () {
+    if (Features::hasTeamFeatures()) {
+        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+    } else {
+        $this->actingAs($user = User::factory()->create());
+    }
 
-//     $response = $this->post('/user/api-tokens', [
-//         'name' => 'Test Token With Expires At',
-//         'expires_at' => now()->addDay()->format('Y-m-d'),
-//         'permissions' => [
-//             'read',
-//             'update',
-//         ],
-//     ]);
+    $response = $this->post('/user/api-tokens', [
+        'name' => 'Test Token With Expires At',
+        'expires_at' => now()->addDay()->format('Y-m-d'),
+        'permissions' => [
+            'read',
+            'update',
+        ],
+    ]);
 
-//     expect($user->fresh()->tokens)->toHaveCount(1);
-//     expect($user->fresh()->tokens->first())
-//         ->name->toEqual('Test Token With Expires At')
-//         ->expires_at->toEqual(Carbon::parse(now()->addDay()->format('Y-m-d')))
-//         ->can('read')->toBeTrue()
-//         ->can('delete')->toBeFalse();
-// })->skip(function () {
-//     return ! Features::hasApiFeatures();
-// }, 'API support is not enabled.');
+    expect($user->fresh()->tokens)->toHaveCount(1);
+    expect($user->fresh()->tokens->first())
+        ->name->toEqual('Test Token With Expires At')
+        ->expires_at->toEqual(Carbon::parse(now()->addDay()->format('Y-m-d')))
+        ->can('read')->toBeTrue()
+        ->can('delete')->toBeFalse();
+})->skip(function () {
+    return ! Features::hasApiFeatures();
+}, 'API support is not enabled.');

--- a/stubs/pest-tests/livewire/CreateApiTokenTest.php
+++ b/stubs/pest-tests/livewire/CreateApiTokenTest.php
@@ -34,28 +34,28 @@ test('api tokens can be created', function () {
     return ! Features::hasApiFeatures();
 }, 'API support is not enabled.');
 
-test('api tokens can be created with expires at date', function () {
-    if (Features::hasTeamFeatures()) {
-        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
-    } else {
-        $this->actingAs($user = User::factory()->create());
-    }
+// test('api tokens can be created with expires at date', function () {
+//     if (Features::hasTeamFeatures()) {
+//         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+//     } else {
+//         $this->actingAs($user = User::factory()->create());
+//     }
 
-    $response = $this->post('/user/api-tokens', [
-        'name' => 'Test Token With Expires At',
-        'expires_at' => now()->addDay()->format('Y-m-d'),
-        'permissions' => [
-            'read',
-            'update',
-        ],
-    ]);
+//     $response = $this->post('/user/api-tokens', [
+//         'name' => 'Test Token With Expires At',
+//         'expires_at' => now()->addDay()->format('Y-m-d'),
+//         'permissions' => [
+//             'read',
+//             'update',
+//         ],
+//     ]);
 
-    expect($user->fresh()->tokens)->toHaveCount(2);
-    expect($user->fresh()->tokens->latest()->first())
-        ->name->toEqual('Test Token With Expires At')
-        ->expires_at->toEqual(Carbon::parse(now()->addDay()->format('Y-m-d')))
-        ->can('read')->toBeTrue()
-        ->can('delete')->toBeFalse();
-})->skip(function () {
-    return ! Features::hasApiFeatures();
-}, 'API support is not enabled.');
+//     expect($user->fresh()->tokens)->toHaveCount(1);
+//     expect($user->fresh()->tokens->first())
+//         ->name->toEqual('Test Token With Expires At')
+//         ->expires_at->toEqual(Carbon::parse(now()->addDay()->format('Y-m-d')))
+//         ->can('read')->toBeTrue()
+//         ->can('delete')->toBeFalse();
+// })->skip(function () {
+//     return ! Features::hasApiFeatures();
+// }, 'API support is not enabled.');

--- a/stubs/pest-tests/livewire/CreateApiTokenTest.php
+++ b/stubs/pest-tests/livewire/CreateApiTokenTest.php
@@ -42,7 +42,7 @@ test('api tokens can be created with expires at date', function () {
     }
 
     $response = $this->post('/user/api-tokens', [
-        'name' => 'Test Token',
+        'name' => 'Test Token With Expires At',
         'expires_at' => now()->addDay()->format('Y-m-d'),
         'permissions' => [
             'read',
@@ -50,10 +50,10 @@ test('api tokens can be created with expires at date', function () {
         ],
     ]);
 
-    expect($user->fresh()->tokens)->toHaveCount(1);
-    expect($user->fresh()->tokens->first())
-        ->name->toEqual('Test Token')
-        ->expires_at->toEqual(Carbon::parse(now()->addDays(1)->format('Y-m-d')))
+    expect($user->fresh()->tokens)->toHaveCount(2);
+    expect($user->fresh()->tokens->latest()->first())
+        ->name->toEqual('Test Token With Expires At')
+        ->expires_at->toEqual(Carbon::parse(now()->addDay()->format('Y-m-d')))
         ->can('read')->toBeTrue()
         ->can('delete')->toBeFalse();
 })->skip(function () {

--- a/stubs/pest-tests/livewire/CreateApiTokenTest.php
+++ b/stubs/pest-tests/livewire/CreateApiTokenTest.php
@@ -15,6 +15,7 @@ test('api tokens can be created', function () {
     Livewire::test(ApiTokenManager::class)
                 ->set(['createApiTokenForm' => [
                     'name' => 'Test Token',
+                    'expires_at' => null,
                     'permissions' => [
                         'read',
                         'update',
@@ -25,6 +26,33 @@ test('api tokens can be created', function () {
     expect($user->fresh()->tokens)->toHaveCount(1);
     expect($user->fresh()->tokens->first())
         ->name->toEqual('Test Token')
+        ->expires_at->toBeNull()
+        ->can('read')->toBeTrue()
+        ->can('delete')->toBeFalse();
+})->skip(function () {
+    return ! Features::hasApiFeatures();
+}, 'API support is not enabled.');
+
+test('api tokens can be created with expires at date', function () {
+    if (Features::hasTeamFeatures()) {
+        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+    } else {
+        $this->actingAs($user = User::factory()->create());
+    }
+
+    $response = $this->post('/user/api-tokens', [
+        'name' => 'Test Token',
+        'expires_at' => now()->addDay()->format('Y-m-d'),
+        'permissions' => [
+            'read',
+            'update',
+        ],
+    ]);
+
+    expect($user->fresh()->tokens)->toHaveCount(1);
+    expect($user->fresh()->tokens->first())
+        ->name->toEqual('Test Token')
+        ->expires_at->toBeLike(now()->addDay())
         ->can('read')->toBeTrue()
         ->can('delete')->toBeFalse();
 })->skip(function () {

--- a/stubs/tests/inertia/CreateApiTokenTest.php
+++ b/stubs/tests/inertia/CreateApiTokenTest.php
@@ -52,10 +52,10 @@ class CreateApiTokenTest extends TestCase
             ],
         ]);
 
-        $this->assertCount(2, $user->fresh()->tokens);
-        $this->assertEquals('Test Token With Expires At', $user->fresh()->tokens->latest()->first()->name);
-        $this->assertEquals(now()->addDay()->format('Y-m-d'), $user->fresh()->tokens->latest()->first()->expires_at->format('Y-m-d'));
-        $this->assertTrue($user->fresh()->tokens->latest()->first()->can('read'));
-        $this->assertFalse($user->fresh()->tokens->latest()->first()->can('delete'));
+        $this->assertCount(1, $user->fresh()->tokens);
+        $this->assertEquals('Test Token With Expires At', $user->fresh()->tokens->first()->name);
+        $this->assertEquals(now()->addDay()->format('Y-m-d'), $user->fresh()->tokens->first()->expires_at->format('Y-m-d'));
+        $this->assertTrue($user->fresh()->tokens->first()->can('read'));
+        $this->assertFalse($user->fresh()->tokens->first()->can('delete'));
     }
 }

--- a/stubs/tests/inertia/CreateApiTokenTest.php
+++ b/stubs/tests/inertia/CreateApiTokenTest.php
@@ -52,10 +52,10 @@ class CreateApiTokenTest extends TestCase
             ],
         ]);
 
-        $this->assertCount(1, $user->fresh()->tokens);
-        $this->assertEquals('Test Token With Expires At', $user->fresh()->tokens->first()->name);
-        $this->assertEquals(now()->addDay()->format('Y-m-d'), $user->fresh()->tokens->first()->expires_at->format('Y-m-d'));
-        $this->assertTrue($user->fresh()->tokens->first()->can('read'));
-        $this->assertFalse($user->fresh()->tokens->first()->can('delete'));
+        $this->assertCount(2, $user->fresh()->tokens);
+        $this->assertEquals('Test Token With Expires At', $user->fresh()->tokens->latest()->first()->name);
+        $this->assertEquals(now()->addDay()->format('Y-m-d'), $user->fresh()->tokens->latest()->first()->expires_at->format('Y-m-d'));
+        $this->assertTrue($user->fresh()->tokens->latest()->first()->can('read'));
+        $this->assertFalse($user->fresh()->tokens->latest()->first()->can('delete'));
     }
 }

--- a/stubs/tests/livewire/CreateApiTokenTest.php
+++ b/stubs/tests/livewire/CreateApiTokenTest.php
@@ -39,29 +39,29 @@ class CreateApiTokenTest extends TestCase
         $this->assertFalse($user->fresh()->tokens->first()->can('delete'));
     }
 
-    // public function test_api_tokens_can_be_created_with_expires_at_date()
-    // {
-    //     if (! Features::hasApiFeatures()) {
-    //         return $this->markTestSkipped('API support is not enabled.');
-    //     }
+    public function test_api_tokens_can_be_created_with_expires_at_date()
+    {
+        if (! Features::hasApiFeatures()) {
+            return $this->markTestSkipped('API support is not enabled.');
+        }
 
-    //     $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
-    //     Livewire::test(ApiTokenManager::class)
-    //                 ->set(['createApiTokenForm' => [
-    //                     'name' => 'Test Token With Expires At',
-    //                     'expires_at' => now()->addDay()->format('Y-m-d'),
-    //                     'permissions' => [
-    //                         'read',
-    //                         'update',
-    //                     ],
-    //                 ]])
-    //                 ->call('createApiToken');
+        Livewire::test(ApiTokenManager::class)
+                    ->set(['createApiTokenForm' => [
+                        'name' => 'Test Token With Expires At',
+                        'expires_at' => now()->addDay()->format('Y-m-d'),
+                        'permissions' => [
+                            'read',
+                            'update',
+                        ],
+                    ]])
+                    ->call('createApiToken');
 
-    //     $this->assertCount(1, $user->fresh()->tokens);
-    //     $this->assertEquals('Test Token With Expires At', $user->fresh()->tokens->first()->name);
-    //     $this->assertEquals(now()->addDay()->format('Y-m-d'), $user->fresh()->tokens->first()->expires_at->format('Y-m-d'));
-    //     $this->assertTrue($user->fresh()->tokens->first()->can('read'));
-    //     $this->assertFalse($user->fresh()->tokens->first()->can('delete'));
-    // }
+        $this->assertCount(1, $user->fresh()->tokens);
+        $this->assertEquals('Test Token With Expires At', $user->fresh()->tokens->first()->name);
+        $this->assertEquals(now()->addDay()->format('Y-m-d'), $user->fresh()->tokens->first()->expires_at->format('Y-m-d'));
+        $this->assertTrue($user->fresh()->tokens->first()->can('read'));
+        $this->assertFalse($user->fresh()->tokens->first()->can('delete'));
+    }
 }

--- a/stubs/tests/livewire/CreateApiTokenTest.php
+++ b/stubs/tests/livewire/CreateApiTokenTest.php
@@ -24,6 +24,7 @@ class CreateApiTokenTest extends TestCase
         Livewire::test(ApiTokenManager::class)
                     ->set(['createApiTokenForm' => [
                         'name' => 'Test Token',
+                        'expires_at' => null,
                         'permissions' => [
                             'read',
                             'update',
@@ -33,6 +34,33 @@ class CreateApiTokenTest extends TestCase
 
         $this->assertCount(1, $user->fresh()->tokens);
         $this->assertEquals('Test Token', $user->fresh()->tokens->first()->name);
+        $this->assertNull($user->fresh()->tokens->first()->expires_at);
+        $this->assertTrue($user->fresh()->tokens->first()->can('read'));
+        $this->assertFalse($user->fresh()->tokens->first()->can('delete'));
+    }
+
+    public function test_api_tokens_can_be_created_with_expires_at_date()
+    {
+        if (! Features::hasApiFeatures()) {
+            return $this->markTestSkipped('API support is not enabled.');
+        }
+
+        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+
+        Livewire::test(ApiTokenManager::class)
+                    ->set(['createApiTokenForm' => [
+                        'name' => 'Test Token With Expires At',
+                        'expires_at' => now()->addDay()->format('Y-m-d'),
+                        'permissions' => [
+                            'read',
+                            'update',
+                        ],
+                    ]])
+                    ->call('createApiToken');
+
+        $this->assertCount(1, $user->fresh()->tokens);
+        $this->assertEquals('Test Token With Expires At', $user->fresh()->tokens->first()->name);
+        $this->assertEquals(now()->addDay()->format('Y-m-d'), $user->fresh()->tokens->first()->expires_at->format('Y-m-d'));
         $this->assertTrue($user->fresh()->tokens->first()->can('read'));
         $this->assertFalse($user->fresh()->tokens->first()->can('delete'));
     }

--- a/stubs/tests/livewire/CreateApiTokenTest.php
+++ b/stubs/tests/livewire/CreateApiTokenTest.php
@@ -58,10 +58,10 @@ class CreateApiTokenTest extends TestCase
                     ]])
                     ->call('createApiToken');
 
-        $this->assertCount(1, $user->fresh()->tokens);
-        $this->assertEquals('Test Token With Expires At', $user->fresh()->tokens->first()->name);
-        $this->assertEquals(now()->addDay()->format('Y-m-d'), $user->fresh()->tokens->first()->expires_at->format('Y-m-d'));
-        $this->assertTrue($user->fresh()->tokens->first()->can('read'));
-        $this->assertFalse($user->fresh()->tokens->first()->can('delete'));
+        $this->assertCount(2, $user->fresh()->tokens);
+        $this->assertEquals('Test Token With Expires At', $user->fresh()->tokens->latest()->first()->name);
+        $this->assertEquals(now()->addDay()->format('Y-m-d'), $user->fresh()->tokens->latest()->first()->expires_at->format('Y-m-d'));
+        $this->assertTrue($user->fresh()->tokens->latest()->first()->can('read'));
+        $this->assertFalse($user->fresh()->tokens->latest()->first()->can('delete'));
     }
 }

--- a/stubs/tests/livewire/CreateApiTokenTest.php
+++ b/stubs/tests/livewire/CreateApiTokenTest.php
@@ -39,29 +39,29 @@ class CreateApiTokenTest extends TestCase
         $this->assertFalse($user->fresh()->tokens->first()->can('delete'));
     }
 
-    public function test_api_tokens_can_be_created_with_expires_at_date()
-    {
-        if (! Features::hasApiFeatures()) {
-            return $this->markTestSkipped('API support is not enabled.');
-        }
+    // public function test_api_tokens_can_be_created_with_expires_at_date()
+    // {
+    //     if (! Features::hasApiFeatures()) {
+    //         return $this->markTestSkipped('API support is not enabled.');
+    //     }
 
-        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+    //     $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
-        Livewire::test(ApiTokenManager::class)
-                    ->set(['createApiTokenForm' => [
-                        'name' => 'Test Token With Expires At',
-                        'expires_at' => now()->addDay()->format('Y-m-d'),
-                        'permissions' => [
-                            'read',
-                            'update',
-                        ],
-                    ]])
-                    ->call('createApiToken');
+    //     Livewire::test(ApiTokenManager::class)
+    //                 ->set(['createApiTokenForm' => [
+    //                     'name' => 'Test Token With Expires At',
+    //                     'expires_at' => now()->addDay()->format('Y-m-d'),
+    //                     'permissions' => [
+    //                         'read',
+    //                         'update',
+    //                     ],
+    //                 ]])
+    //                 ->call('createApiToken');
 
-        $this->assertCount(2, $user->fresh()->tokens);
-        $this->assertEquals('Test Token With Expires At', $user->fresh()->tokens->latest()->first()->name);
-        $this->assertEquals(now()->addDay()->format('Y-m-d'), $user->fresh()->tokens->latest()->first()->expires_at->format('Y-m-d'));
-        $this->assertTrue($user->fresh()->tokens->latest()->first()->can('read'));
-        $this->assertFalse($user->fresh()->tokens->latest()->first()->can('delete'));
-    }
+    //     $this->assertCount(1, $user->fresh()->tokens);
+    //     $this->assertEquals('Test Token With Expires At', $user->fresh()->tokens->first()->name);
+    //     $this->assertEquals(now()->addDay()->format('Y-m-d'), $user->fresh()->tokens->first()->expires_at->format('Y-m-d'));
+    //     $this->assertTrue($user->fresh()->tokens->first()->can('read'));
+    //     $this->assertFalse($user->fresh()->tokens->first()->can('delete'));
+    // }
 }


### PR DESCRIPTION
With the latest release of [Sanctum v3](https://github.com/laravel/sanctum/releases/tag/v3.0.0) an expires_at field was added. So this PR adds that additional input so when users are creating tokens they can set that optional field if needed

Here is an example of what the additional input looks like in the Interia/Vue stack
![image](https://user-images.githubusercontent.com/25044744/181788496-d9b9bec2-7207-40b7-b693-01efef65c3ec.png)
