### PR TITLE
[2.x] Fixes pest-plugin's install

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -81,6 +81,7 @@ class InstallCommand extends Command
         $stubs = $this->getTestStubsPath();
 
         if ($this->option('pest')) {
+            $this->addPestToAllowedPlugins();
             $this->requireComposerDevPackages('pestphp/pest:^1.16', 'pestphp/pest-plugin-laravel:^1.1');
 
             copy($stubs.'/Pest.php', base_path('tests/Pest.php'));
@@ -587,6 +588,31 @@ EOF;
         return $this->option('pest')
             ? __DIR__.'/../../stubs/pest-tests'
             : __DIR__.'/../../stubs/tests';
+    }
+
+    /**
+     * Adds pestphp/pest-plugin to composer's allow-plugins
+     *
+     * @return void
+     */
+    protected function addPestToAllowedPlugins()
+    {
+        $composer = $this->option('composer');
+
+        if ($composer !== 'global') {
+            $command = [$this->phpBinary(), $composer, 'config'];
+        }
+
+        $command = array_merge(
+            $command ?? ['composer', 'config'],
+            ['allow-plugins.pestphp/pest-plugin', 'true']
+        );
+
+        (new Process($command, base_path(), ['COMPOSER_MEMORY_LIMIT' => '-1']))
+            ->setTimeout(null)
+            ->run(function ($type, $output) {
+                $this->output->write($output);
+            });
     }
 
     /**


### PR DESCRIPTION
As of Composer 2.2.0, the allow-plugins option adds a layer of security allowing you to restrict which Composer plugins are able to execute code during a Composer run. ([Read More](https://getcomposer.org/doc/06-config.md#allow-plugins))
This produces an error with the pest-plugin composer package, running `php artisan jetstream:install livewire --pest` throws this error:
`pestphp/pest-plugin contains a Composer plugin which is blocked by your allow-plugins config. You may add it to the list if you consider it safe.`
So in order to fix this in the install command, I added a feature to run `composer config allow-plugins.pestphp/pest-plugin true` right before installing Pest packages.