### PR TITLE
[2.x] Switch to fonts.bunny.net instead of Google Fonts

### DIFF
--- a/stubs/inertia/resources/views/app.blade.php
+++ b/stubs/inertia/resources/views/app.blade.php
@@ -7,7 +7,7 @@
         <title inertia>{{ config('app.name', 'Laravel') }}</title>
 
         <!-- Fonts -->
-        <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap">
+        <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Nunito:wght@400;600;700&display=swap">
 
         <!-- Scripts -->
         @routes

--- a/stubs/livewire/resources/views/layouts/app.blade.php
+++ b/stubs/livewire/resources/views/layouts/app.blade.php
@@ -8,7 +8,7 @@
         <title>{{ config('app.name', 'Laravel') }}</title>
 
         <!-- Fonts -->
-        <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap">
+        <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Nunito:wght@400;600;700&display=swap">
 
         <!-- Scripts -->
         @vite(['resources/css/app.css', 'resources/js/app.js'])

--- a/stubs/livewire/resources/views/layouts/guest.blade.php
+++ b/stubs/livewire/resources/views/layouts/guest.blade.php
@@ -8,7 +8,7 @@
         <title>{{ config('app.name', 'Laravel') }}</title>
 
         <!-- Fonts -->
-        <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap">
+        <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Nunito:wght@400;600;700&display=swap">
 
         <!-- Scripts -->
         @vite(['resources/css/app.css', 'resources/js/app.js'])


### PR DESCRIPTION
Similar to https://github.com/laravel/laravel/pull/5952 - a GDPR compliant version can be used for Jetstream for default installations.
