### PR TITLE
[2.x] Allow optional Expires At Token Field To Be Passed

### DIFF
--- a/src/Http/Controllers/Inertia/ApiTokenController.php
+++ b/src/Http/Controllers/Inertia/ApiTokenController.php
@@ -4,6 +4,7 @@ namespace Laravel\Jetstream\Http\Controllers\Inertia;
 
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Carbon;
 use Laravel\Jetstream\Jetstream;
 
 class ApiTokenController extends Controller
@@ -37,11 +38,13 @@ class ApiTokenController extends Controller
     {
         $request->validate([
             'name' => ['required', 'string', 'max:255'],
+            'expires_at' => ['sometimes', 'date', 'date_format:Y-m-d', 'after:today'],
         ]);
 
         $token = $request->user()->createToken(
             $request->name,
-            Jetstream::validPermissions($request->input('permissions', []))
+            Jetstream::validPermissions($request->input('permissions', [])),
+            $request->expires_at ? Carbon::parse($request->expires_at) : null
         );
 
         return back()->with('flash', [

--- a/src/Http/Livewire/ApiTokenManager.php
+++ b/src/Http/Livewire/ApiTokenManager.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Jetstream\Http\Livewire;
 
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Validator;
 use Laravel\Jetstream\Jetstream;
@@ -16,6 +17,7 @@ class ApiTokenManager extends Component
      */
     public $createApiTokenForm = [
         'name' => '',
+        'expires_at' => null,
         'permissions' => [],
     ];
 
@@ -91,16 +93,20 @@ class ApiTokenManager extends Component
 
         Validator::make([
             'name' => $this->createApiTokenForm['name'],
+            'expires_at' => $this->createApiTokenForm['expires_at'],
         ], [
             'name' => ['required', 'string', 'max:255'],
+            'expires_at' => ['sometimes', 'date', 'date_format:Y-m-d', 'after:today'],
         ])->validateWithBag('createApiToken');
 
         $this->displayTokenValue($this->user->createToken(
             $this->createApiTokenForm['name'],
-            Jetstream::validPermissions($this->createApiTokenForm['permissions'])
+            Jetstream::validPermissions($this->createApiTokenForm['permissions']),
+            $this->createApiTokenForm['expires_at'] ? Carbon::parse($this->createApiTokenForm['expires_at']) : null
         ));
 
         $this->createApiTokenForm['name'] = '';
+        $this->createApiTokenForm['expires_at'] = null;
         $this->createApiTokenForm['permissions'] = Jetstream::$defaultPermissions;
 
         $this->emit('created');

--- a/stubs/pest-tests/inertia/CreateApiTokenTest.php
+++ b/stubs/pest-tests/inertia/CreateApiTokenTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\User;
+use Illuminate\Support\Carbon;
 use Laravel\Jetstream\Features;
 
 test('api tokens can be created', function () {
@@ -12,6 +13,7 @@ test('api tokens can be created', function () {
 
     $response = $this->post('/user/api-tokens', [
         'name' => 'Test Token',
+        'expires_at' => null,
         'permissions' => [
             'read',
             'update',
@@ -21,6 +23,33 @@ test('api tokens can be created', function () {
     expect($user->fresh()->tokens)->toHaveCount(1);
     expect($user->fresh()->tokens->first())
         ->name->toEqual('Test Token')
+        ->expires_at->toBeNull()
+        ->can('read')->toBeTrue()
+        ->can('delete')->toBeFalse();
+})->skip(function () {
+    return ! Features::hasApiFeatures();
+}, 'API support is not enabled.');
+
+test('api tokens can be created with expires at date', function () {
+    if (Features::hasTeamFeatures()) {
+        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+    } else {
+        $this->actingAs($user = User::factory()->create());
+    }
+
+    $response = $this->post('/user/api-tokens', [
+        'name' => 'Test Token With Expires At',
+        'expires_at' => now()->addDay()->format('Y-m-d'),
+        'permissions' => [
+            'read',
+            'update',
+        ],
+    ]);
+
+    expect($user->fresh()->tokens)->toHaveCount(1);
+    expect($user->fresh()->tokens->first())
+        ->name->toEqual('Test Token With Expires At')
+        ->expires_at->toEqual(Carbon::parse(now()->addDay()->format('Y-m-d')))
         ->can('read')->toBeTrue()
         ->can('delete')->toBeFalse();
 })->skip(function () {

--- a/stubs/tests/livewire/CreateApiTokenTest.php
+++ b/stubs/tests/livewire/CreateApiTokenTest.php
@@ -24,6 +24,7 @@ class CreateApiTokenTest extends TestCase
         Livewire::test(ApiTokenManager::class)
                     ->set(['createApiTokenForm' => [
                         'name' => 'Test Token',
+                        'expires_at' => null,
                         'permissions' => [
                             'read',
                             'update',
@@ -33,6 +34,33 @@ class CreateApiTokenTest extends TestCase
 
         $this->assertCount(1, $user->fresh()->tokens);
         $this->assertEquals('Test Token', $user->fresh()->tokens->first()->name);
+        $this->assertNull($user->fresh()->tokens->first()->expires_at);
+        $this->assertTrue($user->fresh()->tokens->first()->can('read'));
+        $this->assertFalse($user->fresh()->tokens->first()->can('delete'));
+    }
+
+    public function test_api_tokens_can_be_created_with_expires_at_date()
+    {
+        if (! Features::hasApiFeatures()) {
+            return $this->markTestSkipped('API support is not enabled.');
+        }
+
+        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+
+        Livewire::test(ApiTokenManager::class)
+                    ->set(['createApiTokenForm' => [
+                        'name' => 'Test Token With Expires At',
+                        'expires_at' => now()->addDay()->format('Y-m-d'),
+                        'permissions' => [
+                            'read',
+                            'update',
+                        ],
+                    ]])
+                    ->call('createApiToken');
+
+        $this->assertCount(1, $user->fresh()->tokens);
+        $this->assertEquals('Test Token With Expires At', $user->fresh()->tokens->first()->name);
+        $this->assertEquals(now()->addDay()->format('Y-m-d'), $user->fresh()->tokens->first()->expires_at->format('Y-m-d'));
         $this->assertTrue($user->fresh()->tokens->first()->can('read'));
         $this->assertFalse($user->fresh()->tokens->first()->can('delete'));
     }


### PR DESCRIPTION
Allow Inertia And Livewire BE to accept a `expires_at` field it needed and passed to work with the latest version 3 of Sanctum.

This PR is similar to the [PR](https://github.com/laravel/jetstream/pull/1102) I submitted earlier that was closed, but this time it does not implement any UI changes.


The reason why I re-submitted this PR is because in order to implement using this new feature from V3 of sanctum I have to copy all the provided Jetstream api token routes and `ApiTokenController` (there might be additional or less work needed with liveware but idk I don't use that) just to include the addition of a simple singular field, if it was needed, since by default all tokens need to expire. This is just updating the functionality of if you need those tokens to expire.

[Here in this comment](https://github.com/laravel/jetstream/pull/1102#issuecomment-1199895334) I describe in some more details why this would be very tedious to do, but to summarize unlike in the `JetstreamServiceProvider` if I want to use a different model I can do so simply with something like `Jetstream::useUserModel(User::class);` 

But that does not exist for the `ApiTokenController` I must use what it offers, or if I need to make 1 change I must copy all the routes it uses and handle in my own version of `ApiTokenController`. And in this case the 1 change I need to make is to include passing an optional field that a dependency package of this uses.


A note why the updated tests are not passing is because `composer create-project laravel/laravel:^9 .` does not use the latest version of sanctum, more info about that [here](https://github.com/laravel/jetstream/pull/1102#issuecomment-1199721151) locally the test are all passing when running `./vendor/bin/phpunit`

