### PR TITLE
Validate the stack argument

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -34,10 +34,16 @@ class InstallCommand extends Command
     /**
      * Execute the console command.
      *
-     * @return void
+     * @return int|null
      */
     public function handle()
     {
+        if (! in_array($this->argument('stack'), ['inertia', 'livewire'])) {
+            $this->components->error('The stack must be inertia or livewire.');
+
+            return 1;
+        }
+
         // Publish...
         $this->callSilent('vendor:publish', ['--tag' => 'jetstream-config', '--force' => true]);
         $this->callSilent('vendor:publish', ['--tag' => 'jetstream-migrations', '--force' => true]);


### PR DESCRIPTION
Currently when running `jetstream:install`, if you specify an invalid stack such as "vue", you'll end up with a partial Jetstream install and no error message.

This PR validates that the stack is either `inertia` or `livewire`.

Note that there is no default stack in Jetstream and it already displays an error when the stack is not provided.

Ultimately I'd love to prompt the user if they don't specify a stack, but that raises bigger questions of whether it should prompt for options like `teams` etc.