### PR TITLE
Check current model supports HasTeams before trying to access team information.

### DIFF
--- a/src/Http/Middleware/ShareInertiaData.php
+++ b/src/Http/Middleware/ShareInertiaData.php
@@ -19,12 +19,14 @@ class ShareInertiaData
      */
     public function handle($request, $next)
     {
+        $user = $request->user();
+
         Inertia::share(array_filter([
-            'jetstream' => function () use ($request) {
+            'jetstream' => function () use ($request, $user) {
                 return [
-                    'canCreateTeams' => $request->user() &&
-                                        Jetstream::hasTeamFeatures() &&
-                                        Gate::forUser($request->user())->check('create', Jetstream::newTeamModel()),
+                    'canCreateTeams' => $user &&
+                                        Jetstream::userHasTeamFeatures($user) &&
+                                        Gate::forUser($user)->check('create', Jetstream::newTeamModel()),
                     'canManageTwoFactorAuthentication' => Features::canManageTwoFactorAuthentication(),
                     'canUpdatePassword' => Features::enabled(Features::updatePasswords()),
                     'canUpdateProfileInformation' => Features::canUpdateProfileInformation(),
@@ -37,19 +39,21 @@ class ShareInertiaData
                     'managesProfilePhotos' => Jetstream::managesProfilePhotos(),
                 ];
             },
-            'user' => function () use ($request) {
-                if (! $request->user()) {
+            'user' => function () use ($user) {
+                if (! $user) {
                     return;
                 }
 
-                if (Jetstream::hasTeamFeatures() && $request->user()) {
-                    $request->user()->currentTeam;
+                $userHasTeamFeatures = Jetstream::userHasTeamFeatures($user);
+
+                if ($userHasTeamFeatures && $user) {
+                    $user->currentTeam;
                 }
 
-                return array_merge($request->user()->toArray(), array_filter([
-                    'all_teams' => Jetstream::hasTeamFeatures() ? $request->user()->allTeams()->values() : null,
+                return array_merge($user->toArray(), array_filter([
+                    'all_teams' => $userHasTeamFeatures ? $user->allTeams()->values() : null,
                 ]), [
-                    'two_factor_enabled' => ! is_null($request->user()->two_factor_secret),
+                    'two_factor_enabled' => ! is_null($user->two_factor_secret),
                 ]);
             },
             'errorBags' => function () {

--- a/src/Http/Middleware/ShareInertiaData.php
+++ b/src/Http/Middleware/ShareInertiaData.php
@@ -19,10 +19,10 @@ class ShareInertiaData
      */
     public function handle($request, $next)
     {
-        $user = $request->user();
-
         Inertia::share(array_filter([
-            'jetstream' => function () use ($request, $user) {
+            'jetstream' => function () use ($request) {
+                $user = $request->user();
+
                 return [
                     'canCreateTeams' => $user &&
                                         Jetstream::userHasTeamFeatures($user) &&
@@ -39,8 +39,8 @@ class ShareInertiaData
                     'managesProfilePhotos' => Jetstream::managesProfilePhotos(),
                 ];
             },
-            'user' => function () use ($user) {
-                if (! $user) {
+            'user' => function () use ($request) {
+                if (! $user = $request->user()) {
                     return;
                 }
 

--- a/src/Http/Middleware/ShareInertiaData.php
+++ b/src/Http/Middleware/ShareInertiaData.php
@@ -46,7 +46,7 @@ class ShareInertiaData
 
                 $userHasTeamFeatures = Jetstream::userHasTeamFeatures($user);
 
-                if ($userHasTeamFeatures && $user) {
+                if ($user && $userHasTeamFeatures) {
                     $user->currentTeam;
                 }
 

--- a/src/Jetstream.php
+++ b/src/Jetstream.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Jetstream;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Laravel\Jetstream\Contracts\AddsTeamMembers;
 use Laravel\Jetstream\Contracts\CreatesTeams;
@@ -193,6 +194,16 @@ class Jetstream
     public static function hasTeamFeatures()
     {
         return Features::hasTeamFeatures();
+    }
+
+    /**
+     * Determine if User model is supporting team features.
+     *
+     * @return bool
+     */
+    public static function userHasTeamFeatures(Model $user)
+    {
+        return array_key_exists(HasTeams::class, class_uses_recursive($user)) && static::hasTeamFeatures();
     }
 
     /**

--- a/src/Jetstream.php
+++ b/src/Jetstream.php
@@ -197,13 +197,16 @@ class Jetstream
     }
 
     /**
-     * Determine if User model is supporting team features.
+     * Determine if a given user model utilizes the "HasTeams" trait.
      *
+     * @param  \Illuminate\Database\Eloquent\Model
      * @return bool
      */
-    public static function userHasTeamFeatures(Model $user)
+    public static function userHasTeamFeatures($user)
     {
-        return array_key_exists(HasTeams::class, class_uses_recursive($user)) && static::hasTeamFeatures();
+        return (array_key_exists(HasTeams::class, class_uses_recursive($user)) ||
+                method_exists($user, 'currentTeam')) &&
+                static::hasTeamFeatures();
     }
 
     /**

--- a/tests/Fixtures/Admin.php
+++ b/tests/Fixtures/Admin.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Laravel\Jetstream\Tests\Fixtures;
+
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Laravel\Jetstream\HasProfilePhoto;
+use Laravel\Jetstream\HasTeams;
+use Laravel\Sanctum\HasApiTokens;
+
+class Admin extends Authenticatable
+{
+    use HasApiTokens, HasProfilePhoto;
+
+    /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var array
+     */
+    protected $guarded = [];
+}

--- a/tests/JetstreamTest.php
+++ b/tests/JetstreamTest.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Jetstream\Tests;
 
+use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Jetstream;
 
 class JetstreamTest extends OrchestraTestCase
@@ -48,5 +49,14 @@ class JetstreamTest extends OrchestraTestCase
         $this->assertArrayHasKey('name', $serialized);
         $this->assertArrayHasKey('description', $serialized);
         $this->assertArrayHasKey('permissions', $serialized);
+    }
+
+    /**
+     * @define-env defineHasTeamEnvironment
+     */
+    public function test_user_has_team_feature_can_be_determined_from_the_user()
+    {
+        $this->assertTrue(Jetstream::userHasTeamFeatures(new Fixtures\User));
+        $this->assertFalse(Jetstream::userHasTeamFeatures(new Fixtures\Admin));
     }
 }

--- a/tests/JetstreamTest.php
+++ b/tests/JetstreamTest.php
@@ -51,11 +51,19 @@ class JetstreamTest extends OrchestraTestCase
         $this->assertArrayHasKey('permissions', $serialized);
     }
 
+    public function test_has_team_feature_will_always_return_false_when_team_is_not_enabled()
+    {
+        $this->assertFalse(Jetstream::hasTeamFeatures());
+        $this->assertFalse(Jetstream::userHasTeamFeatures(new Fixtures\User));
+        $this->assertFalse(Jetstream::userHasTeamFeatures(new Fixtures\Admin));
+    }
+
     /**
      * @define-env defineHasTeamEnvironment
      */
-    public function test_user_has_team_feature_can_be_determined_from_the_user()
+    public function test_has_team_feature_can_be_determined_when_team_is_enabled()
     {
+        $this->assertTrue(Jetstream::hasTeamFeatures());
         $this->assertTrue(Jetstream::userHasTeamFeatures(new Fixtures\User));
         $this->assertFalse(Jetstream::userHasTeamFeatures(new Fixtures\Admin));
     }

--- a/tests/OrchestraTestCase.php
+++ b/tests/OrchestraTestCase.php
@@ -17,8 +17,6 @@ abstract class OrchestraTestCase extends TestCase
 
     public function tearDown(): void
     {
-        Mockery::close();
-
         parent::tearDown();
     }
 

--- a/tests/OrchestraTestCase.php
+++ b/tests/OrchestraTestCase.php
@@ -3,6 +3,7 @@
 namespace Laravel\Jetstream\Tests;
 
 use Laravel\Fortify\FortifyServiceProvider;
+use Laravel\Jetstream\Features;
 use Laravel\Jetstream\JetstreamServiceProvider;
 use Mockery;
 use Orchestra\Testbench\TestCase;
@@ -17,6 +18,8 @@ abstract class OrchestraTestCase extends TestCase
     public function tearDown(): void
     {
         Mockery::close();
+
+        parent::tearDown();
     }
 
     protected function getPackageProviders($app)
@@ -24,7 +27,7 @@ abstract class OrchestraTestCase extends TestCase
         return [JetstreamServiceProvider::class, FortifyServiceProvider::class];
     }
 
-    protected function getEnvironmentSetUp($app)
+    protected function defineEnvironment($app)
     {
         $app['migrator']->path(__DIR__.'/../database/migrations');
 
@@ -35,5 +38,14 @@ abstract class OrchestraTestCase extends TestCase
             'database' => ':memory:',
             'prefix'   => '',
         ]);
+    }
+
+    protected function defineHasTeamEnvironment($app)
+    {
+        $features = $app->config->get('jetstream.features', []);
+
+        $features[] = Features::teams(['invitations' => true]);
+
+        $app->config->set('jetstream.features', $features);
     }
 }


### PR DESCRIPTION
This would be useful for applications with multiple user providers and uses Inertia (as `ShareInertiaData` middleware is appended to global web middleware). As an example, this will fix laravel/nova-issues#4683

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>