### PR TITLE
[2.x ] Update inertiajs/inertia-laravel to ^0.6.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "laravel/fortify": "^1.12"
     },
     "require-dev": {
-        "inertiajs/inertia-laravel": "^0.5.2",
+        "inertiajs/inertia-laravel": "^0.6.3",
         "laravel/sanctum": "^3.0",
         "mockery/mockery": "^1.0",
         "orchestra/testbench": "^7.0",

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -301,7 +301,7 @@ EOF;
     protected function installInertiaStack()
     {
         // Install Inertia...
-        $this->requireComposerPackages('inertiajs/inertia-laravel:^0.5.2', 'tightenco/ziggy:^1.0');
+        $this->requireComposerPackages('inertiajs/inertia-laravel:^0.6.3', 'tightenco/ziggy:^1.0');
 
         // Install NPM packages...
         $this->updateNodePackages(function ($packages) {


### PR DESCRIPTION
This updates the Inertia Laravel Adapter to ^0.6.3. The main reason for this is that this release contains logic to utilise the Vite Manifest when cache busting.

https://github.com/inertiajs/inertia-laravel/releases/tag/v0.6.3

With Jetstream now using Vite as the default, I think it makes sense to include the latest version of the Laravel adapter so that no user changes are required to get `HandleInertiaRequests::version` working correctly.

https://github.com/laravel/jetstream/blob/2.x/stubs/inertia/app/Http/Middleware/HandleInertiaRequests.php#L24