### PR TITLE
Update Register.vue

### DIFF
--- a/stubs/inertia/resources/js/Pages/Auth/Register.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/Register.vue
@@ -87,7 +87,7 @@ const submit = () => {
             <div v-if="$page.props.jetstream.hasTermsAndPrivacyPolicyFeature" class="mt-4">
                 <JetLabel for="terms">
                     <div class="flex items-center">
-                        <JetCheckbox id="terms" v-model:checked="form.terms" name="terms" />
+                        <JetCheckbox id="terms" v-model:checked="form.terms" name="terms" required />
 
                         <div class="ml-2">
                             I agree to the <a target="_blank" :href="route('terms.show')" class="underline text-sm text-gray-600 hover:text-gray-900">Terms of Service</a> and <a target="_blank" :href="route('policy.show')" class="underline text-sm text-gray-600 hover:text-gray-900">Privacy Policy</a>

--- a/stubs/inertia/resources/js/Pages/Auth/Register.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/Register.vue
@@ -93,6 +93,7 @@ const submit = () => {
                             I agree to the <a target="_blank" :href="route('terms.show')" class="underline text-sm text-gray-600 hover:text-gray-900">Terms of Service</a> and <a target="_blank" :href="route('policy.show')" class="underline text-sm text-gray-600 hover:text-gray-900">Privacy Policy</a>
                         </div>
                     </div>
+                    <JetInputError class="mt-2" :message="form.errors.terms" />
                 </JetLabel>
             </div>
 


### PR DESCRIPTION
Add 'required' to JetCheckbox 'terms'. 

This is required because terms and conditions should be accepted if this feature has been enabled by the users. 

![Screen Shot 2022-08-21 at 10 08 34 pm](https://user-images.githubusercontent.com/1491451/185790196-d7db5246-04de-4c72-9625-708a889b8077.png)

Also the `<JetInputError class="mt-2" :message="form.errors.terms" />` should show if there is an error relating to the terms. 

![Screen Shot 2022-08-21 at 10 15 15 pm](https://user-images.githubusercontent.com/1491451/185790469-d3b4f4dc-c4ca-4a14-8c38-e4fe69f5836f.png)