### PR TITLE
Call `storage:link` on install

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -53,6 +53,9 @@ class InstallCommand extends Command
         $this->callSilent('vendor:publish', ['--tag' => 'fortify-support', '--force' => true]);
         $this->callSilent('vendor:publish', ['--tag' => 'fortify-migrations', '--force' => true]);
 
+        // Storage...
+        $this->callSilent('storage:link');
+
         // "Home" Route...
         $this->replaceInFile('/home', '/dashboard', app_path('Providers/RouteServiceProvider.php'));
 


### PR DESCRIPTION
Jetstream's profile photos feature requires the `public/storage` symlink to work correctly.

Currently, this is created automatically in the `laravel` installer when you run it with `--jet`, however, the Laravel installer is not documented and is typically run via the `laravel.build` service, which does not support the `--jet` flag.

This PR adds `storage:link` to the install command so that it is always run regardless of which method is used to install Jetstream.