### PR TITLE
[2.x] Remove redundant remove-member link

### DIFF
--- a/stubs/inertia/resources/js/Pages/Teams/Partials/TeamMemberManager.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/Partials/TeamMemberManager.vue
@@ -266,7 +266,7 @@ const displayableRole = (role) => {
 
                                 <!-- Remove Team Member -->
                                 <button
-                                    v-if="userPermissions.canRemoveTeamMembers"
+                                    v-else-if="userPermissions.canRemoveTeamMembers"
                                     class="cursor-pointer ml-6 text-sm text-red-500"
                                     @click="confirmTeamMemberRemoval(user)"
                                 >


### PR DESCRIPTION
In TeamMemberManager.vue, when the leave-team link is shown, the remove-member link is redundant as it does the same thing.

This commit makes them mutually exclusive, which they already are in the Livewire version: https://github.com/laravel/jetstream/blob/2.x/stubs/livewire/resources/views/teams/team-member-manager.blade.php#L157

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

If you change the behavior of the Inertia stack you're expected to update the Livewire stack as well and vice versa.
-->
