### PR TITLE
fix error 'Ziggy' is not defined

### DIFF
--- a/stubs/inertia/resources/js/app.js
+++ b/stubs/inertia/resources/js/app.js
@@ -15,7 +15,7 @@ createInertiaApp({
     setup({ el, app, props, plugin }) {
         return createApp({ render: () => h(app, props) })
             .use(plugin)
-            .use(ZiggyVue, Ziggy)
+            .use(ZiggyVue)
             .mount(el);
     },
 });


### PR DESCRIPTION
For example when running eslint your will get a 'Ziggy' undefined error:

  ..../resources/js/app.js
  16:22  error  'Ziggy' is not defined  no-undef

I'm not super familiar with this code but I assume it was added by mistake, see d33e331ffc7da6c69bdd9452b1b7075e24f0557d
