### PR TITLE
Use existing NPM package manager when installing Jetstream dependencies

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -254,7 +254,7 @@ class InstallCommand extends Command
             }
 
             return 'npm';
-        })(); 
+        })();
 
         // Install and Build NPM Packages...
         $this->line('');
@@ -461,7 +461,7 @@ EOF;
             }
 
             return 'npm';
-        })(); 
+        })();
 
         // Install and Build NPM Packages...
         $this->line('');

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -241,7 +241,25 @@ class InstallCommand extends Command
             $this->installLivewireTeamStack();
         }
 
-        $this->runCommands(['npm install', 'npm run build']);
+        // Get NPM Package Manager...
+        $npmPackageManager = (function () {
+            if ((new Filesystem)->exists(base_path().'/package-lock.json')) {
+                return 'npm';
+            }
+            if ((new Filesystem)->exists(base_path().'/pnpm-lock.yaml')) {
+                return 'pnpm';
+            }
+            if ((new Filesystem)->exists(base_path().'/yarn.lock')) {
+                return 'yarn';
+            }
+
+            return 'npm';
+        })(); 
+
+        // Install and Build NPM Packages...
+        $this->line('');
+        $this->components->info("Installing $npmPackageManager packages.");
+        $this->runCommands(["$npmPackageManager install", "$npmPackageManager run build"]);
 
         $this->line('');
         $this->components->info('Livewire scaffolding installed successfully.');
@@ -430,7 +448,25 @@ EOF;
             $this->installInertiaSsrStack();
         }
 
-        $this->runCommands(['npm install', 'npm run build']);
+        // Get NPM Package Manager...
+        $npmPackageManager = (function () {
+            if ((new Filesystem)->exists(base_path().'/package-lock.json')) {
+                return 'npm';
+            }
+            if ((new Filesystem)->exists(base_path().'/pnpm-lock.yaml')) {
+                return 'pnpm';
+            }
+            if ((new Filesystem)->exists(base_path().'/yarn.lock')) {
+                return 'yarn';
+            }
+
+            return 'npm';
+        })(); 
+
+        // Install and Build NPM Packages...
+        $this->line('');
+        $this->components->info("Installing $npmPackageManager packages.");
+        $this->runCommands(["$npmPackageManager install", "$npmPackageManager run build"]);
 
         $this->line('');
         $this->components->info('Inertia scaffolding installed successfully.');


### PR DESCRIPTION
I also PR'd this to Breeze

PR https://github.com/laravel/jetstream/pull/1119 added functionality to automatically install NPM packages and builds your assets. However, it defaults to using `npm` instead of the package manager you are currently using in your project (like pnpm or yarn).

This PR adds functionality to check if you are already using a package manager for your project and uses that to install Jetstream dependencies. If you aren't using a package manager, it defaults to `npm`.