### PR TITLE
Make .defer optional on @entangle for x-jet-modal

### DIFF
--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -1,4 +1,4 @@
-@props(['id', 'maxWidth'])
+@props(['id', 'maxWidth', 'deferEntangle' => true])
 
 @php
 $id = $id ?? md5($attributes->wire('model'));
@@ -14,7 +14,7 @@ $maxWidth = [
 
 <div
     x-data="{
-        show: @entangle($attributes->wire('model')).defer,
+        show: @entangle($attributes->wire('model')) @if($deferEntangle) .defer @endif,
         focusables() {
             // All focusable element types...
             let selector = 'a, button, input:not([type=\'hidden\']), textarea, select, details, [tabindex]:not([tabindex=\'-1\'])'


### PR DESCRIPTION
There are times when I would like to take an action when a user dismisses the modal window via `esc` or a click outside. This is a backwards-compatible and opt-in change to allow for this. Just call e.g. `<x-jet-modal :deferEntangle="false" wire:model="showModalFlag">`