### PR TITLE
Remove empty properties when submitting 2FA form with Inertia stack

### DIFF
--- a/stubs/inertia/resources/js/Pages/Auth/TwoFactorChallenge.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/TwoFactorChallenge.vue
@@ -1,4 +1,5 @@
 <script setup>
+import {pickBy, property} from 'lodash';
 import { nextTick, ref } from 'vue';
 import { Head, useForm } from '@inertiajs/inertia-vue3';
 import AuthenticationCard from '@/Components/AuthenticationCard.vue';
@@ -33,7 +34,7 @@ const toggleRecovery = async () => {
 };
 
 const submit = () => {
-    form.post(route('two-factor.login'));
+    form.transform((data) => pickBy(data, property)).post(route('two-factor.login'));
 };
 </script>
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

If you change the behavior of the Inertia stack you're expected to update the Livewire stack as well and vice versa.
-->

When using the Inertia stack with Jetstream, there is a bug when submitting the two factor challenge form. Since the form is initialized with both code and recovery_code, it will always submit both values to the server. In the Fortify response class, `Laravel\Fortify\Http\Responses\FailedTwoFactorLoginResponse.php` there is a check that the request has the recovery_code key and does not check if it has a value. It then is setting the invalid field and message accordingly. Because of this check, the inertia stack causes fortify to think that we are using the recovery code to login instead of the standard code.

This PR is one of the possible solutions that fixes #1152 and does not change the current functionality of the Fortify library. This change will remove any empty properties from the form payload before submitting it to the server for processing.