### PR TITLE
Add a tag responsive nav link

### DIFF
--- a/stubs/inertia/resources/js/Components/ResponsiveNavLink.vue
+++ b/stubs/inertia/resources/js/Components/ResponsiveNavLink.vue
@@ -21,6 +21,10 @@ const classes = computed(() => {
             <slot />
         </button>
 
+        <a v-else-if="as =='a'" :href="href" :class="classes">
+            <slot />
+        </a>
+
         <Link v-else :href="href" :class="classes">
             <slot />
         </Link>


### PR DESCRIPTION
Adds `<a>` tag to the `<ResponsiveNavLink>` component.

It's cleaner to do:

    <ResponsiveNavLink as="a" href="https://docs.example.com">
        Documentation
    </ResponsiveNavLink>

Than to add the a link with styling duplication.

The same was already done for the dropdown link component: https://github.com/laravel/jetstream/pull/711