### PR TITLE
Do no blindly read files in UpdateUserProfileInformation

### DIFF
--- a/stubs/app/Actions/Fortify/UpdateUserProfileInformation.php
+++ b/stubs/app/Actions/Fortify/UpdateUserProfileInformation.php
@@ -21,7 +21,7 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
         Validator::make($input, [
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'email', 'max:255', Rule::unique('users')->ignore($user->id)],
-            'photo' => ['nullable', 'mimes:jpg,jpeg,png', 'max:1024'],
+            'photo' => ['nullable', 'mimetypes:image/jpeg,image/png', 'max:1024'],
         ])->validateWithBag('updateProfileInformation');
 
         if (isset($input['photo'])) {

--- a/stubs/inertia/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
@@ -50,8 +50,23 @@ const updatePhotoPreview = () => {
 
     if (! photo) return;
 
-    const reader = new FileReader();
+    const accepted = photoInput.getAttribute('accept').split(',');
+    const mime = photo.type;
+    let isValid = false;
+    let reader;
 
+    for (const accept of accepted) {
+        if (mime !== accept)
+            continue;
+
+        isValid = true;
+        break;
+    }
+
+    if (!isValid)
+        return;
+
+    reader = new FileReader();
     reader.onload = (e) => {
         photoPreview.value = e.target.result;
     };
@@ -93,6 +108,7 @@ const clearPhotoFileInput = () => {
                 <input
                     ref="photoInput"
                     type="file"
+                    accept="image/jpeg,image/png"
                     class="hidden"
                     @change="updatePhotoPreview"
                 >

--- a/stubs/livewire/resources/views/profile/update-profile-information-form.blade.php
+++ b/stubs/livewire/resources/views/profile/update-profile-information-form.blade.php
@@ -12,17 +12,38 @@
         @if (Laravel\Jetstream\Jetstream::managesProfilePhotos())
             <div x-data="{photoName: null, photoPreview: null}" class="col-span-6 sm:col-span-4">
                 <!-- Profile Photo File Input -->
-                <input type="file" class="hidden"
+                <input type="file" class="hidden" accept="image/jpeg,image/png"
                             wire:model="photo"
                             x-ref="photo"
-                            x-on:change="
-                                    photoName = $refs.photo.files[0].name;
-                                    const reader = new FileReader();
-                                    reader.onload = (e) => {
-                                        photoPreview = e.target.result;
-                                    };
-                                    reader.readAsDataURL($refs.photo.files[0]);
-                            " />
+                            x-on:change="() => {
+                                const userfile = $refs.photo.files[0];
+
+                                if (!userfile)
+                                    return;
+
+                                const accepted = $refs.photo.getAttribute('accept').split(',');
+                                const mime = userfile.type;
+                                let isValid = false;
+                                let reader;
+
+                                for (const accept of accepted) {
+                                    if (mime !== accept)
+                                        continue;
+
+                                    isValid = true;
+                                    break;
+                                }
+
+                                if (!isValid)
+                                    return;
+
+                                reader = new FileReader();
+                                photoName = userfile.name;
+                                reader.onload = (e) => {
+                                    photoPreview = e.target.result;
+                                };
+                                reader.readAsDataURL(userfile);
+                            }" />
 
                 <x-jet-label for="photo" value="{{ __('Photo') }}" />
 


### PR DESCRIPTION
there is no check, it will just read whatever the user selected from browser and this is not only wrong but it also may crash the browser tab or just display broken preview since the file is not an image

crashes may occur when, for example, a big mp4 video is selected

with these changes an error is shown when big not valid files are selected and no changes are made to the photo preview if the file is not valid (as you would expect)

also use mimetypes in validation for consistency and to use the list already defined by laravel (eg. the jpeg mimetype lists one more type than the ones in the previous validation list)