### PR TITLE
Add jsconfig.json to Inertia stack

### DIFF
--- a/stubs/inertia/jsconfig.json
+++ b/stubs/inertia/jsconfig.json
@@ -1,0 +1,9 @@
+{
+    "compilerOptions": {
+        "baseUrl": ".",
+        "paths": {
+            "@/*": ["resources/js/*"]
+        }
+    },
+    "exclude": ["node_modules", "public"]
+}


### PR DESCRIPTION
PhpStorm was showing errors in the imports of the components, then I noticed the `jsconfig.json` was missing and adding it solve it. The `jsconfig.json` file is the same as the Breeze inertia Vue stack

Before
<img width="680" alt="Screenshot 2022-10-08 at 3 03 50 PM" src="https://user-images.githubusercontent.com/65756578/194694650-9a8cd5c9-6170-4238-889f-35c66c32e393.png">

After
<img width="654" alt="Screenshot 2022-10-08 at 3 07 26 PM" src="https://user-images.githubusercontent.com/65756578/194694795-388529be-547c-476c-b0e3-4b53c116514f.png">
