### PR TITLE
Fixed tests that fail when Eloquent's "strict mode" is enabled.

### DIFF
--- a/stubs/tests/EmailVerificationTest.php
+++ b/stubs/tests/EmailVerificationTest.php
@@ -21,7 +21,7 @@ class EmailVerificationTest extends TestCase
             return $this->markTestSkipped('Email verification not enabled.');
         }
 
-        $user = User::factory()->withPersonalTeam()->unverified()->create();
+        $user = User::factory()->withPersonalTeam()->unverified()->create()->fresh();
 
         $response = $this->actingAs($user)->get('/email/verify');
 

--- a/stubs/tests/inertia/DeleteTeamTest.php
+++ b/stubs/tests/inertia/DeleteTeamTest.php
@@ -31,7 +31,7 @@ class DeleteTeamTest extends TestCase
 
     public function test_personal_teams_cant_be_deleted()
     {
-        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+        $this->actingAs($user = User::factory()->withPersonalTeam()->create()->fresh());
 
         $response = $this->delete('/teams/'.$user->currentTeam->id);
 

--- a/stubs/tests/inertia/InviteTeamMemberTest.php
+++ b/stubs/tests/inertia/InviteTeamMemberTest.php
@@ -21,7 +21,7 @@ class InviteTeamMemberTest extends TestCase
 
         Mail::fake();
 
-        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+        $this->actingAs($user = User::factory()->withPersonalTeam()->create()->fresh());
 
         $response = $this->post('/teams/'.$user->currentTeam->id.'/members', [
             'email' => 'test@example.com',
@@ -41,7 +41,7 @@ class InviteTeamMemberTest extends TestCase
 
         Mail::fake();
 
-        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+        $this->actingAs($user = User::factory()->withPersonalTeam()->create()->fresh());
 
         $invitation = $user->currentTeam->teamInvitations()->create([
             'email' => 'test@example.com',

--- a/stubs/tests/inertia/RemoveTeamMemberTest.php
+++ b/stubs/tests/inertia/RemoveTeamMemberTest.php
@@ -12,7 +12,7 @@ class RemoveTeamMemberTest extends TestCase
 
     public function test_team_members_can_be_removed_from_teams()
     {
-        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+        $this->actingAs($user = User::factory()->withPersonalTeam()->create()->fresh());
 
         $user->currentTeam->users()->attach(
             $otherUser = User::factory()->create(), ['role' => 'admin']

--- a/stubs/tests/inertia/UpdateTeamMemberRoleTest.php
+++ b/stubs/tests/inertia/UpdateTeamMemberRoleTest.php
@@ -12,7 +12,7 @@ class UpdateTeamMemberRoleTest extends TestCase
 
     public function test_team_member_roles_can_be_updated()
     {
-        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+        $this->actingAs($user = User::factory()->withPersonalTeam()->create()->fresh());
 
         $user->currentTeam->users()->attach(
             $otherUser = User::factory()->create(), ['role' => 'admin']

--- a/stubs/tests/inertia/UpdateTeamNameTest.php
+++ b/stubs/tests/inertia/UpdateTeamNameTest.php
@@ -12,7 +12,7 @@ class UpdateTeamNameTest extends TestCase
 
     public function test_team_names_can_be_updated()
     {
-        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+        $this->actingAs($user = User::factory()->withPersonalTeam()->create()->fresh());
 
         $response = $this->put('/teams/'.$user->currentTeam->id, [
             'name' => 'Test Team',

--- a/stubs/tests/livewire/CreateTeamTest.php
+++ b/stubs/tests/livewire/CreateTeamTest.php
@@ -14,7 +14,7 @@ class CreateTeamTest extends TestCase
 
     public function test_teams_can_be_created()
     {
-        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+        $this->actingAs($user = User::factory()->withPersonalTeam()->create()->fresh());
 
         Livewire::test(CreateTeamForm::class)
                     ->set(['state' => ['name' => 'Test Team']])

--- a/stubs/tests/livewire/DeleteTeamTest.php
+++ b/stubs/tests/livewire/DeleteTeamTest.php
@@ -15,7 +15,7 @@ class DeleteTeamTest extends TestCase
 
     public function test_teams_can_be_deleted()
     {
-        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+        $this->actingAs($user = User::factory()->withPersonalTeam()->create()->fresh());
 
         $user->ownedTeams()->save($team = Team::factory()->make([
             'personal_team' => false,

--- a/stubs/tests/livewire/InviteTeamMemberTest.php
+++ b/stubs/tests/livewire/InviteTeamMemberTest.php
@@ -23,7 +23,7 @@ class InviteTeamMemberTest extends TestCase
 
         Mail::fake();
 
-        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+        $this->actingAs($user = User::factory()->withPersonalTeam()->create()->fresh());
 
         $component = Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])
                         ->set('addTeamMemberForm', [
@@ -44,7 +44,7 @@ class InviteTeamMemberTest extends TestCase
 
         Mail::fake();
 
-        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+        $this->actingAs($user = User::factory()->withPersonalTeam()->create()->fresh());
 
         // Add the team member...
         $component = Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])

--- a/stubs/tests/livewire/LeaveTeamTest.php
+++ b/stubs/tests/livewire/LeaveTeamTest.php
@@ -17,7 +17,7 @@ class LeaveTeamTest extends TestCase
         $user = User::factory()->withPersonalTeam()->create();
 
         $user->currentTeam->users()->attach(
-            $otherUser = User::factory()->create(), ['role' => 'admin']
+            $otherUser = User::factory()->create()->fresh(), ['role' => 'admin']
         );
 
         $this->actingAs($otherUser);
@@ -30,7 +30,7 @@ class LeaveTeamTest extends TestCase
 
     public function test_team_owners_cant_leave_their_own_team()
     {
-        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+        $this->actingAs($user = User::factory()->withPersonalTeam()->create()->fresh());
 
         $component = Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])
                         ->call('leaveTeam')

--- a/stubs/tests/livewire/ProfileInformationTest.php
+++ b/stubs/tests/livewire/ProfileInformationTest.php
@@ -14,7 +14,7 @@ class ProfileInformationTest extends TestCase
 
     public function test_current_profile_information_is_available()
     {
-        $this->actingAs($user = User::factory()->create());
+        $this->actingAs($user = User::factory()->create()->fresh());
 
         $component = Livewire::test(UpdateProfileInformationForm::class);
 
@@ -24,7 +24,7 @@ class ProfileInformationTest extends TestCase
 
     public function test_profile_information_can_be_updated()
     {
-        $this->actingAs($user = User::factory()->create());
+        $this->actingAs($user = User::factory()->create()->fresh());
 
         Livewire::test(UpdateProfileInformationForm::class)
                 ->set('state', ['name' => 'Test Name', 'email' => 'test@example.com'])

--- a/stubs/tests/livewire/RemoveTeamMemberTest.php
+++ b/stubs/tests/livewire/RemoveTeamMemberTest.php
@@ -14,7 +14,7 @@ class RemoveTeamMemberTest extends TestCase
 
     public function test_team_members_can_be_removed_from_teams()
     {
-        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+        $this->actingAs($user = User::factory()->withPersonalTeam()->create()->fresh());
 
         $user->currentTeam->users()->attach(
             $otherUser = User::factory()->create(), ['role' => 'admin']

--- a/stubs/tests/livewire/TwoFactorAuthenticationSettingsTest.php
+++ b/stubs/tests/livewire/TwoFactorAuthenticationSettingsTest.php
@@ -19,7 +19,7 @@ class TwoFactorAuthenticationSettingsTest extends TestCase
             return $this->markTestSkipped('Two factor authentication is not enabled.');
         }
 
-        $this->actingAs($user = User::factory()->create());
+        $this->actingAs($user = User::factory()->create()->fresh());
 
         $this->withSession(['auth.password_confirmed_at' => time()]);
 
@@ -38,7 +38,7 @@ class TwoFactorAuthenticationSettingsTest extends TestCase
             return $this->markTestSkipped('Two factor authentication is not enabled.');
         }
 
-        $this->actingAs($user = User::factory()->create());
+        $this->actingAs($user = User::factory()->create()->fresh());
 
         $this->withSession(['auth.password_confirmed_at' => time()]);
 
@@ -60,7 +60,7 @@ class TwoFactorAuthenticationSettingsTest extends TestCase
             return $this->markTestSkipped('Two factor authentication is not enabled.');
         }
 
-        $this->actingAs($user = User::factory()->create());
+        $this->actingAs($user = User::factory()->create()->fresh());
 
         $this->withSession(['auth.password_confirmed_at' => time()]);
 

--- a/stubs/tests/livewire/UpdateTeamMemberRoleTest.php
+++ b/stubs/tests/livewire/UpdateTeamMemberRoleTest.php
@@ -14,7 +14,7 @@ class UpdateTeamMemberRoleTest extends TestCase
 
     public function test_team_member_roles_can_be_updated()
     {
-        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+        $this->actingAs($user = User::factory()->withPersonalTeam()->create()->fresh());
 
         $user->currentTeam->users()->attach(
             $otherUser = User::factory()->create(), ['role' => 'admin']
@@ -32,10 +32,10 @@ class UpdateTeamMemberRoleTest extends TestCase
 
     public function test_only_team_owner_can_update_team_member_roles()
     {
-        $user = User::factory()->withPersonalTeam()->create();
+        $user = User::factory()->withPersonalTeam()->create()->fresh();
 
         $user->currentTeam->users()->attach(
-            $otherUser = User::factory()->create(), ['role' => 'admin']
+            $otherUser = User::factory()->create()->fresh(), ['role' => 'admin']
         );
 
         $this->actingAs($otherUser);

--- a/stubs/tests/livewire/UpdateTeamNameTest.php
+++ b/stubs/tests/livewire/UpdateTeamNameTest.php
@@ -14,7 +14,7 @@ class UpdateTeamNameTest extends TestCase
 
     public function test_team_names_can_be_updated()
     {
-        $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+        $this->actingAs($user = User::factory()->withPersonalTeam()->create()->fresh());
 
         Livewire::test(UpdateTeamNameForm::class, ['team' => $user->currentTeam])
                     ->set(['state' => ['name' => 'Test Team']])


### PR DESCRIPTION
Hey! This PR makes some really small updates to the tests that are copied into fresh applications when installing Jetstream.

With the new "strict mode" changes in Eloquent, if you enable it in your application, some of the tests will fail because certain attributes don't exist on the model. All I'm doing in the tests is grabbing fresh versions of the models that were causing the errors so that the fields are available.

I'm not entirely sure if what I've done is correct, and if I might be covering up an underlying issue in the new "strict mode" code. If so, apologies, feel free to close this PR! 😄