### PR TITLE
Added missing localization in logout-other-browser-sessions-form.blade.php

### DIFF
--- a/stubs/livewire/resources/views/profile/logout-other-browser-sessions-form.blade.php
+++ b/stubs/livewire/resources/views/profile/logout-other-browser-sessions-form.blade.php
@@ -31,7 +31,7 @@
 
                         <div class="ml-3">
                             <div class="text-sm text-gray-600">
-                                {{ $session->agent->platform() ? $session->agent->platform() : 'Unknown' }} - {{ $session->agent->browser() ? $session->agent->browser() : 'Unknown' }}
+                                {{ $session->agent->platform() ? $session->agent->platform() : __('Unknown') }} - {{ $session->agent->browser() ? $session->agent->browser() : __('Unknown') }}
                             </div>
 
                             <div>


### PR DESCRIPTION
Added missing localization for `Unknown` in [logout-other-browser-sessions-form.blade.php](https://github.com/laravel/jetstream/blob/bb406d8a827b66e372546f2dbc9ce4465609cfa5/stubs/livewire/resources/views/profile/logout-other-browser-sessions-form.blade.php)