### PR TITLE
Skip tests when the feature is disabled

### DIFF
--- a/stubs/pest-tests/inertia/CreateTeamTest.php
+++ b/stubs/pest-tests/inertia/CreateTeamTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\User;
+use Laravel\Jetstream\Features;
 
 test('teams can be created', function () {
     $this->actingAs($user = User::factory()->withPersonalTeam()->create());
@@ -11,4 +12,6 @@ test('teams can be created', function () {
 
     expect($user->fresh()->ownedTeams)->toHaveCount(2);
     expect($user->fresh()->ownedTeams()->latest('id')->first()->name)->toEqual('Test Team');
-});
+})->skip(function () {
+    return ! Features::hasTeamFeatures();
+}, 'Team features are not enabled.');

--- a/stubs/pest-tests/inertia/DeleteTeamTest.php
+++ b/stubs/pest-tests/inertia/DeleteTeamTest.php
@@ -2,6 +2,7 @@
 
 use App\Models\Team;
 use App\Models\User;
+use Laravel\Jetstream\Features;
 
 test('teams can be deleted', function () {
     $this->actingAs($user = User::factory()->withPersonalTeam()->create());
@@ -18,7 +19,9 @@ test('teams can be deleted', function () {
 
     expect($team->fresh())->toBeNull();
     expect($otherUser->fresh()->teams)->toHaveCount(0);
-});
+})->skip(function () {
+    return ! Features::hasTeamFeatures();
+}, 'Team features are not enabled.');
 
 test('personal teams cant be deleted', function () {
     $this->actingAs($user = User::factory()->withPersonalTeam()->create());
@@ -26,4 +29,6 @@ test('personal teams cant be deleted', function () {
     $response = $this->delete('/teams/'.$user->currentTeam->id);
 
     expect($user->currentTeam->fresh())->not->toBeNull();
-});
+})->skip(function () {
+    return ! Features::hasTeamFeatures();
+}, 'Team features are not enabled.');

--- a/stubs/pest-tests/inertia/LeaveTeamTest.php
+++ b/stubs/pest-tests/inertia/LeaveTeamTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\User;
+use Laravel\Jetstream\Features;
 
 test('users can leave teams', function () {
     $user = User::factory()->withPersonalTeam()->create();
@@ -14,7 +15,9 @@ test('users can leave teams', function () {
     $response = $this->delete('/teams/'.$user->currentTeam->id.'/members/'.$otherUser->id);
 
     expect($user->currentTeam->fresh()->users)->toHaveCount(0);
-});
+})->skip(function () {
+    return ! Features::hasTeamFeatures();
+}, 'Team features are not enabled.');
 
 test('team owners cant leave their own team', function () {
     $this->actingAs($user = User::factory()->withPersonalTeam()->create());
@@ -24,4 +27,6 @@ test('team owners cant leave their own team', function () {
     $response->assertSessionHasErrorsIn('removeTeamMember', ['team']);
 
     expect($user->currentTeam->fresh())->not->toBeNull();
-});
+})->skip(function () {
+    return ! Features::hasTeamFeatures();
+}, 'Team features are not enabled.');

--- a/stubs/pest-tests/inertia/ProfileInformationTest.php
+++ b/stubs/pest-tests/inertia/ProfileInformationTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\User;
+use Laravel\Fortify\Features;
 
 test('profile information can be updated', function () {
     $this->actingAs($user = User::factory()->create());
@@ -13,4 +14,6 @@ test('profile information can be updated', function () {
     expect($user->fresh())
         ->name->toEqual('Test Name')
         ->email->toEqual('test@example.com');
-});
+})->skip(function () {
+    return ! Features::enabled(Features::updateProfileInformation());
+}, 'Update profile information is not enabled.');

--- a/stubs/pest-tests/inertia/RemoveTeamMemberTest.php
+++ b/stubs/pest-tests/inertia/RemoveTeamMemberTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\User;
+use Laravel\Jetstream\Features;
 
 test('team members can be removed from teams', function () {
     $this->actingAs($user = User::factory()->withPersonalTeam()->create());
@@ -12,7 +13,9 @@ test('team members can be removed from teams', function () {
     $response = $this->delete('/teams/'.$user->currentTeam->id.'/members/'.$otherUser->id);
 
     expect($user->currentTeam->fresh()->users)->toHaveCount(0);
-});
+})->skip(function () {
+    return ! Features::hasTeamFeatures();
+}, 'Team features are not enabled.');
 
 test('only team owner can remove team members', function () {
     $user = User::factory()->withPersonalTeam()->create();
@@ -26,4 +29,6 @@ test('only team owner can remove team members', function () {
     $response = $this->delete('/teams/'.$user->currentTeam->id.'/members/'.$user->id);
 
     $response->assertStatus(403);
-});
+})->skip(function () {
+    return ! Features::hasTeamFeatures();
+}, 'Team features are not enabled.');

--- a/stubs/pest-tests/inertia/UpdatePasswordTest.php
+++ b/stubs/pest-tests/inertia/UpdatePasswordTest.php
@@ -2,6 +2,7 @@
 
 use App\Models\User;
 use Illuminate\Support\Facades\Hash;
+use Laravel\Fortify\Features;
 
 test('password can be updated', function () {
     $this->actingAs($user = User::factory()->create());
@@ -13,7 +14,9 @@ test('password can be updated', function () {
     ]);
 
     expect(Hash::check('new-password', $user->fresh()->password))->toBeTrue();
-});
+})->skip(function () {
+    return ! Features::enabled(Features::updatePasswords());
+}, 'Password updates are not enabled.');
 
 test('current password must be correct', function () {
     $this->actingAs($user = User::factory()->create());
@@ -27,7 +30,9 @@ test('current password must be correct', function () {
     $response->assertSessionHasErrors();
 
     expect(Hash::check('password', $user->fresh()->password))->toBeTrue();
-});
+})->skip(function () {
+    return ! Features::enabled(Features::updatePasswords());
+}, 'Password updates are not enabled.');
 
 test('new passwords must match', function () {
     $this->actingAs($user = User::factory()->create());
@@ -41,4 +46,6 @@ test('new passwords must match', function () {
     $response->assertSessionHasErrors();
 
     expect(Hash::check('password', $user->fresh()->password))->toBeTrue();
-});
+})->skip(function () {
+    return ! Features::enabled(Features::updatePasswords());
+}, 'Password updates are not enabled.');

--- a/stubs/pest-tests/inertia/UpdateTeamMemberRoleTest.php
+++ b/stubs/pest-tests/inertia/UpdateTeamMemberRoleTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\User;
+use Laravel\Jetstream\Features;
 
 test('team member roles can be updated', function () {
     $this->actingAs($user = User::factory()->withPersonalTeam()->create());
@@ -16,7 +17,9 @@ test('team member roles can be updated', function () {
     expect($otherUser->fresh()->hasTeamRole(
         $user->currentTeam->fresh(), 'editor'
     ))->toBeTrue();
-});
+})->skip(function () {
+    return ! Features::hasTeamFeatures();
+}, 'Team features are not enabled.');
 
 test('only team owner can update team member roles', function () {
     $user = User::factory()->withPersonalTeam()->create();
@@ -34,4 +37,6 @@ test('only team owner can update team member roles', function () {
     expect($otherUser->fresh()->hasTeamRole(
         $user->currentTeam->fresh(), 'admin'
     ))->toBeTrue();
-});
+})->skip(function () {
+    return ! Features::hasTeamFeatures();
+}, 'Team features are not enabled.');

--- a/stubs/pest-tests/inertia/UpdateTeamNameTest.php
+++ b/stubs/pest-tests/inertia/UpdateTeamNameTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\User;
+use Laravel\Jetstream\Features;
 
 test('team names can be updated', function () {
     $this->actingAs($user = User::factory()->withPersonalTeam()->create());
@@ -11,4 +12,6 @@ test('team names can be updated', function () {
 
     expect($user->fresh()->ownedTeams)->toHaveCount(1);
     expect($user->currentTeam->fresh()->name)->toEqual('Test Team');
-});
+})->skip(function () {
+    return ! Features::hasTeamFeatures();
+}, 'Team features are not enabled.');

--- a/stubs/pest-tests/livewire/CreateTeamTest.php
+++ b/stubs/pest-tests/livewire/CreateTeamTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\User;
+use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Http\Livewire\CreateTeamForm;
 use Livewire\Livewire;
 
@@ -13,4 +14,6 @@ test('teams can be created', function () {
 
     expect($user->fresh()->ownedTeams)->toHaveCount(2);
     expect($user->fresh()->ownedTeams()->latest('id')->first()->name)->toEqual('Test Team');
-});
+})->skip(function () {
+    return ! Features::hasTeamFeatures();
+}, 'Team features are not enabled.');

--- a/stubs/pest-tests/livewire/DeleteTeamTest.php
+++ b/stubs/pest-tests/livewire/DeleteTeamTest.php
@@ -2,6 +2,7 @@
 
 use App\Models\Team;
 use App\Models\User;
+use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Http\Livewire\DeleteTeamForm;
 use Livewire\Livewire;
 
@@ -21,7 +22,9 @@ test('teams can be deleted', function () {
 
     expect($team->fresh())->toBeNull();
     expect($otherUser->fresh()->teams)->toHaveCount(0);
-});
+})->skip(function () {
+    return ! Features::hasTeamFeatures();
+}, 'Team features are not enabled.');
 
 test('personal teams cant be deleted', function () {
     $this->actingAs($user = User::factory()->withPersonalTeam()->create());
@@ -31,4 +34,6 @@ test('personal teams cant be deleted', function () {
                             ->assertHasErrors(['team']);
 
     expect($user->currentTeam->fresh())->not->toBeNull();
-});
+})->skip(function () {
+    return ! Features::hasTeamFeatures();
+}, 'Team features are not enabled.');

--- a/stubs/pest-tests/livewire/LeaveTeamTest.php
+++ b/stubs/pest-tests/livewire/LeaveTeamTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\User;
+use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Http\Livewire\TeamMemberManager;
 use Livewire\Livewire;
 
@@ -17,7 +18,9 @@ test('users can leave teams', function () {
                     ->call('leaveTeam');
 
     expect($user->currentTeam->fresh()->users)->toHaveCount(0);
-});
+})->skip(function () {
+    return ! Features::hasTeamFeatures();
+}, 'Team features are not enabled.');
 
 test('team owners cant leave their own team', function () {
     $this->actingAs($user = User::factory()->withPersonalTeam()->create());
@@ -27,4 +30,6 @@ test('team owners cant leave their own team', function () {
                     ->assertHasErrors(['team']);
 
     expect($user->currentTeam->fresh())->not->toBeNull();
-});
+})->skip(function () {
+    return ! Features::hasTeamFeatures();
+}, 'Team features are not enabled.');

--- a/stubs/pest-tests/livewire/ProfileInformationTest.php
+++ b/stubs/pest-tests/livewire/ProfileInformationTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\User;
+use Laravel\Fortify\Features;
 use Laravel\Jetstream\Http\Livewire\UpdateProfileInformationForm;
 use Livewire\Livewire;
 
@@ -11,7 +12,9 @@ test('current profile information is available', function () {
 
     expect($component->state['name'])->toEqual($user->name);
     expect($component->state['email'])->toEqual($user->email);
-});
+})->skip(function () {
+    return ! Features::enabled(Features::updateProfileInformation());
+}, 'Update profile information is not enabled.');
 
 test('profile information can be updated', function () {
     $this->actingAs($user = User::factory()->create());
@@ -23,4 +26,6 @@ test('profile information can be updated', function () {
     expect($user->fresh())
         ->name->toEqual('Test Name')
         ->email->toEqual('test@example.com');
-});
+})->skip(function () {
+    return ! Features::enabled(Features::updateProfileInformation());
+}, 'Update profile information is not enabled.');

--- a/stubs/pest-tests/livewire/RemoveTeamMemberTest.php
+++ b/stubs/pest-tests/livewire/RemoveTeamMemberTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\User;
+use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Http\Livewire\TeamMemberManager;
 use Livewire\Livewire;
 
@@ -16,7 +17,9 @@ test('team members can be removed from teams', function () {
                     ->call('removeTeamMember');
 
     expect($user->currentTeam->fresh()->users)->toHaveCount(0);
-});
+})->skip(function () {
+    return ! Features::hasTeamFeatures();
+}, 'Team features are not enabled.');
 
 test('only team owner can remove team members', function () {
     $user = User::factory()->withPersonalTeam()->create();
@@ -31,4 +34,6 @@ test('only team owner can remove team members', function () {
                     ->set('teamMemberIdBeingRemoved', $user->id)
                     ->call('removeTeamMember')
                     ->assertStatus(403);
-});
+})->skip(function () {
+    return ! Features::hasTeamFeatures();
+}, 'Team features are not enabled.');

--- a/stubs/pest-tests/livewire/UpdatePasswordTest.php
+++ b/stubs/pest-tests/livewire/UpdatePasswordTest.php
@@ -2,6 +2,7 @@
 
 use App\Models\User;
 use Illuminate\Support\Facades\Hash;
+use Laravel\Fortify\Features;
 use Laravel\Jetstream\Http\Livewire\UpdatePasswordForm;
 use Livewire\Livewire;
 
@@ -17,7 +18,9 @@ test('password can be updated', function () {
             ->call('updatePassword');
 
     expect(Hash::check('new-password', $user->fresh()->password))->toBeTrue();
-});
+})->skip(function () {
+    return ! Features::enabled(Features::updatePasswords());
+}, 'Password updates are not enabled.');
 
 test('current password must be correct', function () {
     $this->actingAs($user = User::factory()->create());
@@ -32,7 +35,9 @@ test('current password must be correct', function () {
             ->assertHasErrors(['current_password']);
 
     expect(Hash::check('password', $user->fresh()->password))->toBeTrue();
-});
+})->skip(function () {
+    return ! Features::enabled(Features::updatePasswords());
+}, 'Password updates are not enabled.');
 
 test('new passwords must match', function () {
     $this->actingAs($user = User::factory()->create());
@@ -47,4 +52,6 @@ test('new passwords must match', function () {
             ->assertHasErrors(['password']);
 
     expect(Hash::check('password', $user->fresh()->password))->toBeTrue();
-});
+})->skip(function () {
+    return ! Features::enabled(Features::updatePasswords());
+}, 'Password updates are not enabled.');

--- a/stubs/pest-tests/livewire/UpdateTeamMemberRoleTest.php
+++ b/stubs/pest-tests/livewire/UpdateTeamMemberRoleTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\User;
+use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Http\Livewire\TeamMemberManager;
 use Livewire\Livewire;
 
@@ -19,7 +20,9 @@ test('team member roles can be updated', function () {
     expect($otherUser->fresh()->hasTeamRole(
         $user->currentTeam->fresh(), 'editor'
     ))->toBeTrue();
-});
+})->skip(function () {
+    return ! Features::hasTeamFeatures();
+}, 'Team features are not enabled.');
 
 test('only team owner can update team member roles', function () {
     $user = User::factory()->withPersonalTeam()->create();
@@ -39,4 +42,6 @@ test('only team owner can update team member roles', function () {
     expect($otherUser->fresh()->hasTeamRole(
         $user->currentTeam->fresh(), 'admin'
     ))->toBeTrue();
-});
+})->skip(function () {
+    return ! Features::hasTeamFeatures();
+}, 'Team features are not enabled.');

--- a/stubs/pest-tests/livewire/UpdateTeamNameTest.php
+++ b/stubs/pest-tests/livewire/UpdateTeamNameTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\User;
+use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Http\Livewire\UpdateTeamNameForm;
 use Livewire\Livewire;
 
@@ -13,4 +14,6 @@ test('team names can be updated', function () {
 
     expect($user->fresh()->ownedTeams)->toHaveCount(1);
     expect($user->currentTeam->fresh()->name)->toEqual('Test Team');
-});
+})->skip(function () {
+    return ! Features::hasTeamFeatures();
+}, 'Team features are not enabled.');

--- a/stubs/tests/inertia/CreateTeamTest.php
+++ b/stubs/tests/inertia/CreateTeamTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Jetstream\Features;
 use Tests\TestCase;
 
 class CreateTeamTest extends TestCase
@@ -12,6 +13,10 @@ class CreateTeamTest extends TestCase
 
     public function test_teams_can_be_created()
     {
+        if (! Features::hasTeamFeatures()) {
+            return $this->markTestSkipped('Team features is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $response = $this->post('/teams', [

--- a/stubs/tests/inertia/DeleteTeamTest.php
+++ b/stubs/tests/inertia/DeleteTeamTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Models\Team;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Jetstream\Features;
 use Tests\TestCase;
 
 class DeleteTeamTest extends TestCase
@@ -13,6 +14,10 @@ class DeleteTeamTest extends TestCase
 
     public function test_teams_can_be_deleted()
     {
+        if (! Features::hasTeamFeatures()) {
+            return $this->markTestSkipped('Team features is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $user->ownedTeams()->save($team = Team::factory()->make([
@@ -31,6 +36,10 @@ class DeleteTeamTest extends TestCase
 
     public function test_personal_teams_cant_be_deleted()
     {
+        if (! Features::hasTeamFeatures()) {
+            return $this->markTestSkipped('Team features is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $response = $this->delete('/teams/'.$user->currentTeam->id);

--- a/stubs/tests/inertia/LeaveTeamTest.php
+++ b/stubs/tests/inertia/LeaveTeamTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Jetstream\Features;
 use Tests\TestCase;
 
 class LeaveTeamTest extends TestCase
@@ -12,6 +13,10 @@ class LeaveTeamTest extends TestCase
 
     public function test_users_can_leave_teams()
     {
+        if (! Features::hasTeamFeatures()) {
+            return $this->markTestSkipped('Team features is not enabled.');
+        }
+
         $user = User::factory()->withPersonalTeam()->create();
 
         $user->currentTeam->users()->attach(
@@ -27,6 +32,10 @@ class LeaveTeamTest extends TestCase
 
     public function test_team_owners_cant_leave_their_own_team()
     {
+        if (! Features::hasTeamFeatures()) {
+            return $this->markTestSkipped('Team features is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $response = $this->delete('/teams/'.$user->currentTeam->id.'/members/'.$user->id);

--- a/stubs/tests/inertia/ProfileInformationTest.php
+++ b/stubs/tests/inertia/ProfileInformationTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Fortify\Features;
 use Tests\TestCase;
 
 class ProfileInformationTest extends TestCase
@@ -12,6 +13,10 @@ class ProfileInformationTest extends TestCase
 
     public function test_profile_information_can_be_updated()
     {
+        if (! Features::enabled(Features::updateProfileInformation())) {
+            return $this->markTestSkipped('Update profile information is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->create());
 
         $response = $this->put('/user/profile-information', [

--- a/stubs/tests/inertia/RemoveTeamMemberTest.php
+++ b/stubs/tests/inertia/RemoveTeamMemberTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Jetstream\Features;
 use Tests\TestCase;
 
 class RemoveTeamMemberTest extends TestCase
@@ -12,6 +13,10 @@ class RemoveTeamMemberTest extends TestCase
 
     public function test_team_members_can_be_removed_from_teams()
     {
+        if (! Features::hasTeamFeatures()) {
+            return $this->markTestSkipped('Team features is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $user->currentTeam->users()->attach(
@@ -25,6 +30,10 @@ class RemoveTeamMemberTest extends TestCase
 
     public function test_only_team_owner_can_remove_team_members()
     {
+        if (! Features::hasTeamFeatures()) {
+            return $this->markTestSkipped('Team features is not enabled.');
+        }
+
         $user = User::factory()->withPersonalTeam()->create();
 
         $user->currentTeam->users()->attach(

--- a/stubs/tests/inertia/UpdatePasswordTest.php
+++ b/stubs/tests/inertia/UpdatePasswordTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Hash;
+use Laravel\Fortify\Features;
 use Tests\TestCase;
 
 class UpdatePasswordTest extends TestCase
@@ -13,6 +14,10 @@ class UpdatePasswordTest extends TestCase
 
     public function test_password_can_be_updated()
     {
+        if (! Features::enabled(Features::updatePasswords())) {
+            return $this->markTestSkipped('Password updates are not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->create());
 
         $response = $this->put('/user/password', [
@@ -26,6 +31,10 @@ class UpdatePasswordTest extends TestCase
 
     public function test_current_password_must_be_correct()
     {
+        if (! Features::enabled(Features::updatePasswords())) {
+            return $this->markTestSkipped('Password updates are not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->create());
 
         $response = $this->put('/user/password', [
@@ -41,6 +50,10 @@ class UpdatePasswordTest extends TestCase
 
     public function test_new_passwords_must_match()
     {
+        if (! Features::enabled(Features::updatePasswords())) {
+            return $this->markTestSkipped('Password updates are not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->create());
 
         $response = $this->put('/user/password', [

--- a/stubs/tests/inertia/UpdateTeamMemberRoleTest.php
+++ b/stubs/tests/inertia/UpdateTeamMemberRoleTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Jetstream\Features;
 use Tests\TestCase;
 
 class UpdateTeamMemberRoleTest extends TestCase
@@ -12,6 +13,10 @@ class UpdateTeamMemberRoleTest extends TestCase
 
     public function test_team_member_roles_can_be_updated()
     {
+        if (! Features::hasTeamFeatures()) {
+            return $this->markTestSkipped('Team features is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $user->currentTeam->users()->attach(
@@ -29,6 +34,10 @@ class UpdateTeamMemberRoleTest extends TestCase
 
     public function test_only_team_owner_can_update_team_member_roles()
     {
+        if (! Features::hasTeamFeatures()) {
+            return $this->markTestSkipped('Team features is not enabled.');
+        }
+
         $user = User::factory()->withPersonalTeam()->create();
 
         $user->currentTeam->users()->attach(

--- a/stubs/tests/inertia/UpdateTeamNameTest.php
+++ b/stubs/tests/inertia/UpdateTeamNameTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Jetstream\Features;
 use Tests\TestCase;
 
 class UpdateTeamNameTest extends TestCase
@@ -12,6 +13,10 @@ class UpdateTeamNameTest extends TestCase
 
     public function test_team_names_can_be_updated()
     {
+        if (! Features::hasTeamFeatures()) {
+            return $this->markTestSkipped('Team features is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $response = $this->put('/teams/'.$user->currentTeam->id, [

--- a/stubs/tests/livewire/CreateTeamTest.php
+++ b/stubs/tests/livewire/CreateTeamTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Http\Livewire\CreateTeamForm;
 use Livewire\Livewire;
 use Tests\TestCase;
@@ -14,6 +15,10 @@ class CreateTeamTest extends TestCase
 
     public function test_teams_can_be_created()
     {
+        if (! Features::hasTeamFeatures()) {
+            return $this->markTestSkipped('Team features is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         Livewire::test(CreateTeamForm::class)

--- a/stubs/tests/livewire/DeleteTeamTest.php
+++ b/stubs/tests/livewire/DeleteTeamTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Models\Team;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Http\Livewire\DeleteTeamForm;
 use Livewire\Livewire;
 use Tests\TestCase;
@@ -15,6 +16,10 @@ class DeleteTeamTest extends TestCase
 
     public function test_teams_can_be_deleted()
     {
+        if (! Features::hasTeamFeatures()) {
+            return $this->markTestSkipped('Team features is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $user->ownedTeams()->save($team = Team::factory()->make([
@@ -34,6 +39,10 @@ class DeleteTeamTest extends TestCase
 
     public function test_personal_teams_cant_be_deleted()
     {
+        if (! Features::hasTeamFeatures()) {
+            return $this->markTestSkipped('Team features is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $component = Livewire::test(DeleteTeamForm::class, ['team' => $user->currentTeam])

--- a/stubs/tests/livewire/LeaveTeamTest.php
+++ b/stubs/tests/livewire/LeaveTeamTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Http\Livewire\TeamMemberManager;
 use Livewire\Livewire;
 use Tests\TestCase;
@@ -14,6 +15,10 @@ class LeaveTeamTest extends TestCase
 
     public function test_users_can_leave_teams()
     {
+        if (! Features::hasTeamFeatures()) {
+            return $this->markTestSkipped('Team features is not enabled.');
+        }
+
         $user = User::factory()->withPersonalTeam()->create();
 
         $user->currentTeam->users()->attach(
@@ -30,6 +35,10 @@ class LeaveTeamTest extends TestCase
 
     public function test_team_owners_cant_leave_their_own_team()
     {
+        if (! Features::hasTeamFeatures()) {
+            return $this->markTestSkipped('Team features is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $component = Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])

--- a/stubs/tests/livewire/ProfileInformationTest.php
+++ b/stubs/tests/livewire/ProfileInformationTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Fortify\Features;
 use Laravel\Jetstream\Http\Livewire\UpdateProfileInformationForm;
 use Livewire\Livewire;
 use Tests\TestCase;
@@ -14,6 +15,10 @@ class ProfileInformationTest extends TestCase
 
     public function test_current_profile_information_is_available()
     {
+        if (! Features::enabled(Features::updateProfileInformation())) {
+            return $this->markTestSkipped('Update profile information is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->create());
 
         $component = Livewire::test(UpdateProfileInformationForm::class);
@@ -24,6 +29,10 @@ class ProfileInformationTest extends TestCase
 
     public function test_profile_information_can_be_updated()
     {
+        if (! Features::enabled(Features::updateProfileInformation())) {
+            return $this->markTestSkipped('Update profile information is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->create());
 
         Livewire::test(UpdateProfileInformationForm::class)

--- a/stubs/tests/livewire/RemoveTeamMemberTest.php
+++ b/stubs/tests/livewire/RemoveTeamMemberTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Http\Livewire\TeamMemberManager;
 use Livewire\Livewire;
 use Tests\TestCase;
@@ -14,6 +15,10 @@ class RemoveTeamMemberTest extends TestCase
 
     public function test_team_members_can_be_removed_from_teams()
     {
+        if (! Features::hasTeamFeatures()) {
+            return $this->markTestSkipped('Team features is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $user->currentTeam->users()->attach(
@@ -29,6 +34,10 @@ class RemoveTeamMemberTest extends TestCase
 
     public function test_only_team_owner_can_remove_team_members()
     {
+        if (! Features::hasTeamFeatures()) {
+            return $this->markTestSkipped('Team features is not enabled.');
+        }
+
         $user = User::factory()->withPersonalTeam()->create();
 
         $user->currentTeam->users()->attach(

--- a/stubs/tests/livewire/UpdatePasswordTest.php
+++ b/stubs/tests/livewire/UpdatePasswordTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Hash;
+use Laravel\Fortify\Features;
 use Laravel\Jetstream\Http\Livewire\UpdatePasswordForm;
 use Livewire\Livewire;
 use Tests\TestCase;
@@ -15,6 +16,10 @@ class UpdatePasswordTest extends TestCase
 
     public function test_password_can_be_updated()
     {
+        if (! Features::enabled(Features::updatePasswords())) {
+            return $this->markTestSkipped('Password updates are not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->create());
 
         Livewire::test(UpdatePasswordForm::class)
@@ -30,6 +35,10 @@ class UpdatePasswordTest extends TestCase
 
     public function test_current_password_must_be_correct()
     {
+        if (! Features::enabled(Features::updatePasswords())) {
+            return $this->markTestSkipped('Password updates are not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->create());
 
         Livewire::test(UpdatePasswordForm::class)
@@ -46,6 +55,10 @@ class UpdatePasswordTest extends TestCase
 
     public function test_new_passwords_must_match()
     {
+        if (! Features::enabled(Features::updatePasswords())) {
+            return $this->markTestSkipped('Password updates are not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->create());
 
         Livewire::test(UpdatePasswordForm::class)

--- a/stubs/tests/livewire/UpdateTeamMemberRoleTest.php
+++ b/stubs/tests/livewire/UpdateTeamMemberRoleTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Http\Livewire\TeamMemberManager;
 use Livewire\Livewire;
 use Tests\TestCase;
@@ -14,6 +15,10 @@ class UpdateTeamMemberRoleTest extends TestCase
 
     public function test_team_member_roles_can_be_updated()
     {
+        if (! Features::hasTeamFeatures()) {
+            return $this->markTestSkipped('Team features is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $user->currentTeam->users()->attach(
@@ -32,6 +37,10 @@ class UpdateTeamMemberRoleTest extends TestCase
 
     public function test_only_team_owner_can_update_team_member_roles()
     {
+        if (! Features::hasTeamFeatures()) {
+            return $this->markTestSkipped('Team features is not enabled.');
+        }
+
         $user = User::factory()->withPersonalTeam()->create();
 
         $user->currentTeam->users()->attach(

--- a/stubs/tests/livewire/UpdateTeamNameTest.php
+++ b/stubs/tests/livewire/UpdateTeamNameTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Http\Livewire\UpdateTeamNameForm;
 use Livewire\Livewire;
 use Tests\TestCase;
@@ -14,6 +15,10 @@ class UpdateTeamNameTest extends TestCase
 
     public function test_team_names_can_be_updated()
     {
+        if (! Features::hasTeamFeatures()) {
+            return $this->markTestSkipped('Team features is not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         Livewire::test(UpdateTeamNameForm::class, ['team' => $user->currentTeam])


### PR DESCRIPTION
Added checks to skip the tests if the update profile information, reset password or team feature is disabled.