### PR TITLE
Include all user table columns in the UserFactory

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -30,6 +30,10 @@ class UserFactory extends Factory
             'email_verified_at' => now(),
             'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
             'remember_token' => Str::random(10),
+            'profile_photo_path' => null,
+            'two_factor_secret' => null,
+            'two_factor_confirmed_at' => null,
+            'two_factor_recovery_codes' => null,
         ];
     }
 

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -29,11 +29,11 @@ class UserFactory extends Factory
             'email' => $this->faker->unique()->safeEmail(),
             'email_verified_at' => now(),
             'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
-            'remember_token' => Str::random(10),
-            'profile_photo_path' => null,
             'two_factor_secret' => null,
             'two_factor_confirmed_at' => null,
             'two_factor_recovery_codes' => null,
+            'remember_token' => Str::random(10),
+            'profile_photo_path' => null,
         ];
     }
 


### PR DESCRIPTION
## Background
Jetstream creates migrations to add new columns in the user table, even if Jetstream isn't configured to use teams or profile pictures or 2FA. But because these fields are missing from the `UserFactory` that Jetstream installs, the default Jetstream tests will fail when using the `Model::preventAccessingMissingAttributes()` feature of model strictness.

These test failures are extremely unexpected when you've followed the happy path of Laravel, Jetstream, and then merely enabled model strictness. And the failures are not obvious. People who are new to Laravel seem likely to be very confused by these errors and might be dissuaded from using model strictness (and I do think people should be **encouraged** to use model strictness).

## The Fix
Adding these missing fields to the factory prevents these exceptions, and allows the tests to pass.

## Alternatives Considered
An alternative approach could be doing feature detection to alter the return of the `UserFactory` definition, and also doing feature detection in the templates, such that user data items for unused features aren't accessed. That seems a lot more complicated, when we could just add the default-null columns to the factory and be done.

fixes #1164 