### PR TITLE
Support for the Team Invitation model in the TeamInvitationController

### DIFF
--- a/src/Http/Controllers/TeamInvitationController.php
+++ b/src/Http/Controllers/TeamInvitationController.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Gate;
 use Laravel\Jetstream\Contracts\AddsTeamMembers;
+use Laravel\Jetstream\Jetstream;
 use Laravel\Jetstream\TeamInvitation;
 
 class TeamInvitationController extends Controller
@@ -15,11 +16,13 @@ class TeamInvitationController extends Controller
      * Accept a team invitation.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  \Laravel\Jetstream\TeamInvitation  $invitation
+     * @param  int  $invitationId
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function accept(Request $request, TeamInvitation $invitation)
+    public function accept(Request $request, $invitationId)
     {
+        $invitation = Jetstream::newTeamInvitationModel()->findOrFail($invitationId);
+
         app(AddsTeamMembers::class)->add(
             $invitation->team->owner,
             $invitation->team,
@@ -38,11 +41,13 @@ class TeamInvitationController extends Controller
      * Cancel the given team invitation.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  \Laravel\Jetstream\TeamInvitation  $invitation
+     * @param  int  $invitationId
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function destroy(Request $request, TeamInvitation $invitation)
+    public function destroy(Request $request, $invitationId)
     {
+        $invitation = Jetstream::newTeamInvitationModel()->findOrFail($invitationId);
+
         if (! Gate::forUser($request->user())->check('removeTeamMember', $invitation->team)) {
             throw new AuthorizationException;
         }

--- a/src/Jetstream.php
+++ b/src/Jetstream.php
@@ -355,6 +355,18 @@ class Jetstream
     }
 
     /**
+     * Get a new instance of the team invitation model.
+     *
+     * @return mixed
+     */
+    public static function newTeamInvitationModel()
+    {
+        $model = static::teamInvitationModel();
+
+        return new $model;
+    }
+
+    /**
      * Specify the team invitation model that should be used by Jetstream.
      *
      * @param  string  $model


### PR DESCRIPTION
I noticed that there was the possibility to load the models we want for Jetstream. Which is handy if the models don't use the same database connection as our default connection. However the TeamInvitationController was left behind.
It always uses the model the `Laravel\Jetstream\TeamInvitation` instead of loaded from the `Jetstream::newTeamInvitationModel()` like the CurrentTeamController does for example.

Sorry for my English, I use Google Translate to help me a bit thanks in advance.