### PR TITLE
Use x focus alpine plugin

### DIFF
--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -13,35 +13,9 @@ $maxWidth = [
 @endphp
 
 <div
-    x-data="{
-        show: @entangle($attributes->wire('model')).defer,
-        focusables() {
-            // All focusable element types...
-            let selector = 'a, button, input:not([type=\'hidden\']), textarea, select, details, [tabindex]:not([tabindex=\'-1\'])'
-
-            return [...$el.querySelectorAll(selector)]
-                // All non-disabled elements...
-                .filter(el => ! el.hasAttribute('disabled'))
-        },
-        firstFocusable() { return this.focusables()[0] },
-        lastFocusable() { return this.focusables().slice(-1)[0] },
-        nextFocusable() { return this.focusables()[this.nextFocusableIndex()] || this.firstFocusable() },
-        prevFocusable() { return this.focusables()[this.prevFocusableIndex()] || this.lastFocusable() },
-        nextFocusableIndex() { return (this.focusables().indexOf(document.activeElement) + 1) % (this.focusables().length + 1) },
-        prevFocusableIndex() { return Math.max(0, this.focusables().indexOf(document.activeElement)) -1 },
-    }"
-    x-init="$watch('show', value => {
-        if (value) {
-            document.body.classList.add('overflow-y-hidden');
-            {{ $attributes->has('focusable') ? 'setTimeout(() => firstFocusable().focus(), 100)' : '' }}
-        } else {
-            document.body.classList.remove('overflow-y-hidden');
-        }
-    })"
+    x-data="{ show: @entangle($attributes->wire('model')).defer }"
     x-on:close.stop="show = false"
     x-on:keydown.escape.window="show = false"
-    x-on:keydown.tab.prevent="$event.shiftKey || nextFocusable().focus()"
-    x-on:keydown.shift.tab.prevent="prevFocusable().focus()"
     x-show="show"
     id="{{ $id }}"
     class="jetstream-modal fixed inset-0 overflow-y-auto px-4 py-6 sm:px-0 z-50"
@@ -57,6 +31,7 @@ $maxWidth = [
     </div>
 
     <div x-show="show" class="mb-6 bg-white rounded-lg overflow-hidden shadow-xl transform transition-all sm:w-full {{ $maxWidth }} sm:mx-auto"
+                    x-trap.inert.noscroll="show"
                     x-transition:enter="ease-out duration-300"
                     x-transition:enter-start="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
                     x-transition:enter-end="opacity-100 translate-y-0 sm:scale-100"

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -152,6 +152,7 @@ class InstallCommand extends Command
                 '@tailwindcss/forms' => '^0.5.2',
                 '@tailwindcss/typography' => '^0.5.0',
                 'alpinejs' => '^3.0.6',
+                '@alpinejs/focus' => '^3.10.5',
                 'autoprefixer' => '^10.4.7',
                 'postcss' => '^8.4.14',
                 'tailwindcss' => '^3.1.0',

--- a/stubs/livewire/resources/js/app.js
+++ b/stubs/livewire/resources/js/app.js
@@ -1,7 +1,10 @@
 import './bootstrap';
 
 import Alpine from 'alpinejs';
-
+import focus from '@alpinejs/focus'
+ 
 window.Alpine = Alpine;
+
+Alpine.plugin(focus)
 
 Alpine.start();


### PR DESCRIPTION
This PR replaces the custom focus trapping logic within the Livewire stack's modal with Alpine JS's x-Focus plugin.

The down-side is this does introduce a new dependency. However at the same time it reduces overall code needed to be maintained directly, is cleaner, widely used, all while improving accessibility. 

This improves accessibility bu utilizing the `.inert` modifier when defining the focus trapping (see: https://alpinejs.dev/plugins/focus#inert), which will add an `aria-hidden="true"` property to all elements outside the modal while it is open.

I believe this is a net improvement and worth bringing in the dependency. However if you disagree Taylor, no hard feelings if you close this.