### PR TITLE
Use Default NPM Package Manager of User if Lock File Exists In Base Path

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -242,7 +242,14 @@ class InstallCommand extends Command
             $this->installLivewireTeamStack();
         }
 
-        $this->runCommands(['npm install', 'npm run build']);
+        // Use user's existing package manager if already found (default to npm if not found)
+        if (file_exists(base_path('pnpm-lock.yaml'))) {
+            $this->runCommands(['pnpm install', 'pnpm run build']);
+        } elseif (file_exists(base_path('yarn.lock'))) {
+            $this->runCommands(['yarn install', 'yarn run build']);
+        } else {
+            $this->runCommands(['npm install', 'npm run build']);
+        }
 
         $this->line('');
         $this->components->info('Livewire scaffolding installed successfully.');
@@ -432,7 +439,14 @@ EOF;
             $this->installInertiaSsrStack();
         }
 
-        $this->runCommands(['npm install', 'npm run build']);
+        // Use user's existing package manager if already found (default to npm if not found)
+        if (file_exists(base_path('pnpm-lock.yaml'))) {
+            $this->runCommands(['pnpm install', 'pnpm run build']);
+        } elseif (file_exists(base_path('yarn.lock'))) {
+            $this->runCommands(['yarn install', 'yarn run build']);
+        } else {
+            $this->runCommands(['npm install', 'npm run build']);
+        }
 
         $this->line('');
         $this->components->info('Inertia scaffolding installed successfully.');
@@ -695,6 +709,7 @@ EOF;
         tap(new Filesystem, function ($files) {
             $files->deleteDirectory(base_path('node_modules'));
 
+            $files->delete(base_path('pnpm-lock.yaml'));
             $files->delete(base_path('yarn.lock'));
             $files->delete(base_path('package-lock.json'));
         });


### PR DESCRIPTION
**This PR will fix errors that occur after initial Jetstream installation if a User is using an NPM package manager other than NPM itself**

Many people initially start a fresh Laravel project by configuring their database and using their favorite package manager whether that be npm, yarn, or pnpm. Jetstream's Console InstallCommand.php file autoloads the bundling of assets using npm as the default package manager even while a user may be already using pnpm or yarn.  If a user is already using npm or yarn they will receive an error in their terminal that looks similar to the following:

```
298 error code EUNSUPPORTEDPROTOCOL
299 error Unsupported URL Type "link:": link:./src/types
300 verbose exit 1
301 timing npm Completed in 14690ms
302 verbose unfinished npm timer reify 1670217709459
303 verbose unfinished npm timer reify:loadTrees 1670217709463
304 verbose unfinished npm timer idealTree:buildDeps 1670217709596
305 verbose unfinished npm timer idealTree:node_modules/.pnpm/vite@3.2.4/node_modules/vite 1670217715885
306 verbose code 1
307 error A complete log of this run can be found in:
307 error     C:\Users\andre\AppData\Local\npm-cache\_logs\2022-12-05T05_21_48_152Z-debug-0.log
```
Even though this is an easy fix for the user by just finishing installation and migrating their tables, people who are unexperienced may not know what is going on or may think there is a problem to find and fix in their project... 

A simple fix to this is just adding the following sections of code in the "InstallCommand.php" file. People like to use their default "favorite" package manager and I see no harm in allowing them to. For this reason alone I am submitting this PR...