### PR TITLE
Redirect to the fortify configured logout redirect after deleting user

### DIFF
--- a/src/Http/Livewire/DeleteUserForm.php
+++ b/src/Http/Livewire/DeleteUserForm.php
@@ -69,7 +69,7 @@ class DeleteUserForm extends Component
             $request->session()->regenerateToken();
         }
 
-        return redirect('/');
+        return redirect(config('fortify.redirects.logout', '/'));
     }
 
     /**


### PR DESCRIPTION
Revised after my previous PR, this redirects to the Fortify configured logout redirect instead.