### PR TITLE
use if-else

### DIFF
--- a/src/Http/Controllers/Inertia/Concerns/ConfirmsTwoFactorAuthentication.php
+++ b/src/Http/Controllers/Inertia/Concerns/ConfirmsTwoFactorAuthentication.php
@@ -29,12 +29,12 @@ trait ConfirmsTwoFactorAuthentication
         }
 
         // If was previously totally disabled this session but is now confirming, notate time...
-        else if ($this->hasJustBegunConfirmingTwoFactorAuthentication($request)) {
+        elseif ($this->hasJustBegunConfirmingTwoFactorAuthentication($request)) {
             $request->session()->put('two_factor_confirming_at', $currentTime);
         }
 
         // If the profile is reloaded and is not confirmed but was previously in confirming state, disable...
-        else if ($this->neverFinishedConfirmingTwoFactorAuthentication($request, $currentTime)) {
+        elseif ($this->neverFinishedConfirmingTwoFactorAuthentication($request, $currentTime)) {
             app(DisableTwoFactorAuthentication::class)(Auth::user());
 
             $request->session()->put('two_factor_empty_at', $currentTime);

--- a/src/Http/Controllers/Inertia/Concerns/ConfirmsTwoFactorAuthentication.php
+++ b/src/Http/Controllers/Inertia/Concerns/ConfirmsTwoFactorAuthentication.php
@@ -29,12 +29,12 @@ trait ConfirmsTwoFactorAuthentication
         }
 
         // If was previously totally disabled this session but is now confirming, notate time...
-        if ($this->hasJustBegunConfirmingTwoFactorAuthentication($request)) {
+        else if ($this->hasJustBegunConfirmingTwoFactorAuthentication($request)) {
             $request->session()->put('two_factor_confirming_at', $currentTime);
         }
 
         // If the profile is reloaded and is not confirmed but was previously in confirming state, disable...
-        if ($this->neverFinishedConfirmingTwoFactorAuthentication($request, $currentTime)) {
+        else if ($this->neverFinishedConfirmingTwoFactorAuthentication($request, $currentTime)) {
             app(DisableTwoFactorAuthentication::class)(Auth::user());
 
             $request->session()->put('two_factor_empty_at', $currentTime);

--- a/tests/UserProfileControllerTest.php
+++ b/tests/UserProfileControllerTest.php
@@ -22,9 +22,6 @@ class UserProfileControllerTest extends OrchestraTestCase
     {
         $this->migrate();
 
-        $disable = $this->mock(DisableTwoFactorAuthentication::class);
-        $disable->shouldReceive('__invoke')->once();
-
         Jetstream::$inertiaManager = $inertia = m::mock();
         $inertia->shouldReceive('render')->once();
 


### PR DESCRIPTION
fixes #1192.

The above issue is caused by every conditional inside `ConfirmsTwoFactorAuthentication:: validateTwoFactorAuthenticationState(...)` being checked regardless of whether or not a previous condition was met.

There are two possible solutions to this problem:
1. Change the consecutive `if` conditions to `else if` conditions, meaning they're only checked if the previous check has failed.
2. Add a `return;` statement after each subsequent block if the condition is met

Since the method type hints a `void` return type, I've opted for the first option.