### PR TITLE
Add IDE config folders to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.idea/
+.vscode/
 /vendor
 composer.lock
 /phpunit.xml


### PR DESCRIPTION
This PR adds the `.vscode` and `.idea` IDE generated configuration folders to gitignore.

My reason for this PR is to help reduce the "admin" for contributors that use IDE's that produce these folders when working on a project. Granted, you should be careful when submitting PR's to a project, but having these two folders added does make life a little easier (and saves time 😅).

Not precious about this PR, but I think a few devs might appreciate it.