### PR TITLE
UserFactory team name format

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -61,7 +61,7 @@ class UserFactory extends Factory
         return $this->has(
             Team::factory()
                 ->state(function (array $attributes, User $user) {
-                    return ['name' => $user->name.'\'s Team', 'user_id' => $user->id, 'personal_team' => true];
+                    return ['name' => explode(' ', $user->name, 2)[0]."'s Team", 'user_id' => $user->id, 'personal_team' => true];
                 }),
             'ownedTeams'
         );


### PR DESCRIPTION
Hey!

This commit makes the team name generation in UserFactory same as in the CreateNewUser action.

Right now UserFactory uses user's full name to create a personal team, so this code:
```php
User::factory()
    ->withPersonalTeam()
    ->create([
        'name' => 'John Doe',
        'email' => 'john@doe.com',
    ]);
```
will end up creating `John Doe's Team` team, whereas CreateNewUser creates `John's Team`.