### PR TITLE
Fix english grammar in the Config Stub

### DIFF
--- a/stubs/config/jetstream.php
+++ b/stubs/config/jetstream.php
@@ -53,7 +53,7 @@ return [
     |
     | Some of Jetstream's features are optional. You may disable the features
     | by removing them from this array. You're free to only remove some of
-    | these features or you can even remove all of these if you need to.
+    | these features, or you can even remove all of these if you need to.
     |
     */
 
@@ -71,8 +71,8 @@ return [
     |--------------------------------------------------------------------------
     |
     | This configuration value determines the default disk that will be used
-    | when storing profile photos for your application's users. Typically
-    | this will be the "public" disk but you may adjust this if needed.
+    | when storing profile photos for your application's users. Typically,
+    | this will be the "public" disk, but you may adjust this if needed.
     |
     */
 


### PR DESCRIPTION
* use a comma before 'or'
* A comma missing after the conjunctive/linking adverb 'Typically'
* Use a comma before 'but'
