### PR TITLE
Add configuration option for the view prefix

### DIFF
--- a/config/jetstream.php
+++ b/config/jetstream.php
@@ -7,5 +7,5 @@ return [
     'middleware' => ['web'],
     'features' => [Features::accountDeletion()],
     'profile_photo_disk' => 'public',
-    'view_prefix' => 'auth.'
+    'view_prefix' => 'auth.',
 ];

--- a/config/jetstream.php
+++ b/config/jetstream.php
@@ -7,4 +7,5 @@ return [
     'middleware' => ['web'],
     'features' => [Features::accountDeletion()],
     'profile_photo_disk' => 'public',
+    'view_prefix' => 'auth.'
 ];

--- a/src/JetstreamServiceProvider.php
+++ b/src/JetstreamServiceProvider.php
@@ -69,7 +69,7 @@ class JetstreamServiceProvider extends ServiceProvider
     {
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'jetstream');
 
-        Fortify::viewPrefix('auth.');
+        Fortify::viewPrefix(config('jetstream.view_prefix', 'auth.'));
 
         $this->configureComponents();
         $this->configurePublishing();

--- a/stubs/config/jetstream.php
+++ b/stubs/config/jetstream.php
@@ -78,4 +78,16 @@ return [
 
     'profile_photo_disk' => 'public',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Jetstream View Prefix
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify the view prefix used by Jetstream and Fortify
+    | the default is usually sufficient
+    |
+    */
+
+    'view_prefix' => 'auth.',
+
 ];


### PR DESCRIPTION
`auth.` is fine for most cases but being able to chose is better