### PR TITLE
Fixes publishing jetstream-inertia-auth-pages, that was referencing an old stub path

### DIFF
--- a/src/JetstreamServiceProvider.php
+++ b/src/JetstreamServiceProvider.php
@@ -181,10 +181,9 @@ class JetstreamServiceProvider extends ServiceProvider
 
         $this->publishes([
             __DIR__.'/../stubs/inertia/resources/js/Pages/Auth' => resource_path('js/Pages/Auth'),
-            __DIR__.'/../stubs/inertia/resources/js/Jetstream/AuthenticationCard.vue' => resource_path('js/Jetstream/AuthenticationCard.vue'),
-            __DIR__.'/../stubs/inertia/resources/js/Jetstream/AuthenticationCardLogo.vue' => resource_path('js/Jetstream/AuthenticationCardLogo.vue'),
-            __DIR__.'/../stubs/inertia/resources/js/Jetstream/Checkbox.vue' => resource_path('js/Jetstream/Checkbox.vue'),
-            __DIR__.'/../stubs/inertia/resources/js/Jetstream/ValidationErrors.vue' => resource_path('js/Jetstream/ValidationErrors.vue'),
+            __DIR__.'/../stubs/inertia/resources/js/Components/AuthenticationCard.vue' => resource_path('js/Components/AuthenticationCard.vue'),
+            __DIR__.'/../stubs/inertia/resources/js/Components/AuthenticationCardLogo.vue' => resource_path('js/Components/AuthenticationCardLogo.vue'),
+            __DIR__.'/../stubs/inertia/resources/js/Components/Checkbox.vue' => resource_path('js/Components/Checkbox.vue'),
         ], 'jetstream-inertia-auth-pages');
     }
 


### PR DESCRIPTION
When publishing Inertia assets (`artisan vendor:publish --provider=Laravel\\Jetstream\\JetstreamServiceProvider`, `artisan vendor:publish --tag=jetstream-inertia-auth-pages`, etc), you're presented with an error that some of the paths related to `jetstream-inertia-auth-pages` can't be located.

This is because Jetstream v2.11.0 (more specifically PR #1110) moved the Vue component stubs from `stubs/inertia/resources/js/Jetstream` to `stubs/inertia/resources/js/Components`.

I adjusted those paths in the service provider that registers the publishables.
I also removed the publishing of `stubs/inertia/resources/js/Components/ValidationErrors.vue` entirely, as that component was removed in v2.11.1 (PR #1123).

The Jetstream installation command was already publishing everything correctly.

I've tested against the project where I accidentally noticed this (fresh Laravel repo), and my changes made both publish commands mentioned above work.

<details>
<summary>Screenshot of the error in the terminal</summary>

<img width="1375" alt="ScreenShot 2023-01-04 at 14 48 30" src="https://user-images.githubusercontent.com/76173223/210571232-7db5f8e9-7fe5-418a-831f-f4fe37dd6913.png">
</details>