### PR TITLE
[2.x] Prevent `MissingAttributeException`

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -29,7 +29,11 @@ class UserFactory extends Factory
             'email' => $this->faker->unique()->safeEmail(),
             'email_verified_at' => now(),
             'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
+            'two_factor_secret' => null,
+            'two_factor_recovery_codes' => null,
             'remember_token' => Str::random(10),
+            'profile_photo_path' => null,
+            'current_team_id' => null,
         ];
     }
 

--- a/tests/OrchestraTestCase.php
+++ b/tests/OrchestraTestCase.php
@@ -27,8 +27,6 @@ abstract class OrchestraTestCase extends TestCase
 
     protected function defineEnvironment($app)
     {
-        $app['migrator']->path(__DIR__.'/../database/migrations');
-
         $app['config']->set('database.default', 'testbench');
 
         $app['config']->set('database.connections.testbench', [
@@ -36,6 +34,12 @@ abstract class OrchestraTestCase extends TestCase
             'database' => ':memory:',
             'prefix'   => '',
         ]);
+    }
+
+    protected function defineDatabaseMigrations()
+    {
+        $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
+        $this->loadMigrationsFrom(__DIR__.'/../vendor/laravel/fortify/database/migrations');
     }
 
     protected function defineHasTeamEnvironment($app)

--- a/tests/UserProfileControllerTest.php
+++ b/tests/UserProfileControllerTest.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Jetstream\Tests;
 
-use Illuminate\Support\Facades\Schema;
 use Laravel\Fortify\Actions\DisableTwoFactorAuthentication;
 use Laravel\Fortify\Features;
 use Laravel\Jetstream\Jetstream;
@@ -20,8 +19,6 @@ class UserProfileControllerTest extends OrchestraTestCase
 
     public function test_empty_two_factor_state_is_noted()
     {
-        $this->migrate();
-
         $disable = $this->mock(DisableTwoFactorAuthentication::class);
         $disable->shouldReceive('__invoke')->once();
 
@@ -43,8 +40,6 @@ class UserProfileControllerTest extends OrchestraTestCase
 
     public function test_two_factor_is_not_disabled_if_was_previously_empty_and_currently_confirming()
     {
-        $this->migrate();
-
         $disable = $this->mock(DisableTwoFactorAuthentication::class);
         $disable->shouldReceive('__invoke')->never();
 
@@ -67,8 +62,6 @@ class UserProfileControllerTest extends OrchestraTestCase
 
     public function test_two_factor_is_disabled_if_was_previously_confirming_and_page_is_reloaded()
     {
-        $this->migrate();
-
         $disable = $this->mock(DisableTwoFactorAuthentication::class);
         $disable->shouldReceive('__invoke')->once();
 
@@ -90,16 +83,6 @@ class UserProfileControllerTest extends OrchestraTestCase
                         ->get('/user/profile');
 
         $response->assertStatus(200);
-    }
-
-    protected function migrate()
-    {
-        $this->artisan('migrate', ['--database' => 'testbench'])->run();
-
-        Schema::table('users', function ($table) {
-            $table->string('two_factor_secret')->nullable();
-            $table->timestamp('two_factor_confirmed_at')->nullable();
-        });
     }
 
     protected function getEnvironmentSetUp($app)


### PR DESCRIPTION
Fixes #1164

This is a resubmit of #1168 which was reverted in #1170 due to failing tests. The tests were failing because the `two_factor_*` columns are added by a Fortify migration which was not being run. I have solved this by configuring the Fortify migrations to run during testing. This has the nice side-effect of allowing us to remove manual migration code from one of the tests :tada: