### PR TITLE
[2.x] Make section title to take all available space

### DIFF
--- a/resources/views/components/section-title.blade.php
+++ b/resources/views/components/section-title.blade.php
@@ -1,5 +1,5 @@
 <div class="md:col-span-1 flex justify-between">
-    <div class="flex-grow px-4 sm:px-0">
+    <div class="grow px-4 sm:px-0">
         <h3 class="text-lg font-medium text-gray-900">{{ $title }}</h3>
 
         <p class="mt-1 text-sm text-gray-600">

--- a/resources/views/components/section-title.blade.php
+++ b/resources/views/components/section-title.blade.php
@@ -1,5 +1,5 @@
 <div class="md:col-span-1 flex justify-between">
-    <div class="px-4 sm:px-0">
+    <div class="flex-grow px-4 sm:px-0">
         <h3 class="text-lg font-medium text-gray-900">{{ $title }}</h3>
 
         <p class="mt-1 text-sm text-gray-600">

--- a/stubs/inertia/resources/js/Components/SectionTitle.vue
+++ b/stubs/inertia/resources/js/Components/SectionTitle.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="md:col-span-1 flex justify-between">
-        <div class="px-4 sm:px-0">
+        <div class="flex-grow px-4 sm:px-0">
             <h3 class="text-lg font-medium text-gray-900">
                 <slot name="title" />
             </h3>

--- a/stubs/inertia/resources/js/Components/SectionTitle.vue
+++ b/stubs/inertia/resources/js/Components/SectionTitle.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="md:col-span-1 flex justify-between">
-        <div class="flex-grow px-4 sm:px-0">
+        <div class="grow px-4 sm:px-0">
             <h3 class="text-lg font-medium text-gray-900">
                 <slot name="title" />
             </h3>


### PR DESCRIPTION
With this PR the title+description block take the whole available widthю
Before this it took width according to its content width.

I needed to put in description something with a colorful background and turned out it's impossible without overriding the section-title component. This looks as unexpected behavior.

**Example code:**
```html
<x-jet-form-section submit="updateProfileInformation">
    <x-slot name="title">
        {{ __('Profile Information') }}
    </x-slot>

    <x-slot name="description">
       <!-- The following div should take the whole width of the block -->
       <div class="w-full bg-red-500 text-white">Colorful description</div>
    </x-slot>
    
    <x-slot name="form">...</x-slot>
</x-jet-form-section>
```

**Before:**
![изображение](https://user-images.githubusercontent.com/17148882/211264688-604eaee2-6fee-42af-a913-77d2f2c55092.png)

**After:**
![изображение](https://user-images.githubusercontent.com/17148882/211264730-b65c7e14-b3e4-4a67-9b76-b19e013dcabe.png)

