### PR TITLE
Fixing Stub Tests

### DIFF
--- a/stubs/pest-tests/inertia/CreateTeamTest.php
+++ b/stubs/pest-tests/inertia/CreateTeamTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\User;
+use Laravel\Jetstream\Features;
 
 test('teams can be created', function () {
     $this->actingAs($user = User::factory()->withPersonalTeam()->create());
@@ -11,4 +12,6 @@ test('teams can be created', function () {
 
     expect($user->fresh()->ownedTeams)->toHaveCount(2);
     expect($user->fresh()->ownedTeams()->latest('id')->first()->name)->toEqual('Test Team');
-});
+})->skip(function () {
+    return ! Features::hasTeamFeatures();
+}, 'Team support is not enabled.');

--- a/stubs/pest-tests/inertia/DeleteTeamTest.php
+++ b/stubs/pest-tests/inertia/DeleteTeamTest.php
@@ -2,6 +2,7 @@
 
 use App\Models\Team;
 use App\Models\User;
+use Laravel\Jetstream\Features;
 
 test('teams can be deleted', function () {
     $this->actingAs($user = User::factory()->withPersonalTeam()->create());
@@ -11,14 +12,17 @@ test('teams can be deleted', function () {
     ]));
 
     $team->users()->attach(
-        $otherUser = User::factory()->create(), ['role' => 'test-role']
+        $otherUser = User::factory()->create(),
+        ['role' => 'test-role']
     );
 
     $response = $this->delete('/teams/'.$team->id);
 
     expect($team->fresh())->toBeNull();
     expect($otherUser->fresh()->teams)->toHaveCount(0);
-});
+})->skip(function () {
+    return ! Features::hasTeamFeatures();
+}, 'Team support is not enabled.');
 
 test('personal teams cant be deleted', function () {
     $this->actingAs($user = User::factory()->withPersonalTeam()->create());
@@ -26,4 +30,6 @@ test('personal teams cant be deleted', function () {
     $response = $this->delete('/teams/'.$user->currentTeam->id);
 
     expect($user->currentTeam->fresh())->not->toBeNull();
-});
+})->skip(function () {
+    return ! Features::hasTeamFeatures();
+}, 'Team support is not enabled.');

--- a/stubs/pest-tests/inertia/LeaveTeamTest.php
+++ b/stubs/pest-tests/inertia/LeaveTeamTest.php
@@ -1,12 +1,14 @@
 <?php
 
 use App\Models\User;
+use Laravel\Jetstream\Features;
 
 test('users can leave teams', function () {
     $user = User::factory()->withPersonalTeam()->create();
 
     $user->currentTeam->users()->attach(
-        $otherUser = User::factory()->create(), ['role' => 'admin']
+        $otherUser = User::factory()->create(),
+        ['role' => 'admin']
     );
 
     $this->actingAs($otherUser);
@@ -14,7 +16,9 @@ test('users can leave teams', function () {
     $response = $this->delete('/teams/'.$user->currentTeam->id.'/members/'.$otherUser->id);
 
     expect($user->currentTeam->fresh()->users)->toHaveCount(0);
-});
+})->skip(function () {
+    return ! Features::hasTeamFeatures();
+}, 'Team support is not enabled.');
 
 test('team owners cant leave their own team', function () {
     $this->actingAs($user = User::factory()->withPersonalTeam()->create());
@@ -24,4 +28,6 @@ test('team owners cant leave their own team', function () {
     $response->assertSessionHasErrorsIn('removeTeamMember', ['team']);
 
     expect($user->currentTeam->fresh())->not->toBeNull();
-});
+})->skip(function () {
+    return ! Features::hasTeamFeatures();
+}, 'Team support is not enabled.');

--- a/stubs/pest-tests/inertia/RemoveTeamMemberTest.php
+++ b/stubs/pest-tests/inertia/RemoveTeamMemberTest.php
@@ -1,24 +1,29 @@
 <?php
 
 use App\Models\User;
+use Laravel\Jetstream\Features;
 
 test('team members can be removed from teams', function () {
     $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
     $user->currentTeam->users()->attach(
-        $otherUser = User::factory()->create(), ['role' => 'admin']
+        $otherUser = User::factory()->create(),
+        ['role' => 'admin']
     );
 
     $response = $this->delete('/teams/'.$user->currentTeam->id.'/members/'.$otherUser->id);
 
     expect($user->currentTeam->fresh()->users)->toHaveCount(0);
-});
+})->skip(function () {
+    return ! Features::hasTeamFeatures();
+}, 'Team support is not enabled.');
 
 test('only team owner can remove team members', function () {
     $user = User::factory()->withPersonalTeam()->create();
 
     $user->currentTeam->users()->attach(
-        $otherUser = User::factory()->create(), ['role' => 'admin']
+        $otherUser = User::factory()->create(),
+        ['role' => 'admin']
     );
 
     $this->actingAs($otherUser);
@@ -26,4 +31,6 @@ test('only team owner can remove team members', function () {
     $response = $this->delete('/teams/'.$user->currentTeam->id.'/members/'.$user->id);
 
     $response->assertStatus(403);
-});
+})->skip(function () {
+    return ! Features::hasTeamFeatures();
+}, 'Team support is not enabled.');

--- a/stubs/pest-tests/inertia/UpdateTeamMemberRoleTest.php
+++ b/stubs/pest-tests/inertia/UpdateTeamMemberRoleTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\User;
+use Laravel\Jetstream\Features;
 
 test('team member roles can be updated', function () {
     $this->actingAs($user = User::factory()->withPersonalTeam()->create());
@@ -16,7 +17,9 @@ test('team member roles can be updated', function () {
     expect($otherUser->fresh()->hasTeamRole(
         $user->currentTeam->fresh(), 'editor'
     ))->toBeTrue();
-});
+})->skip(function () {
+    return ! Features::hasTeamFeatures();
+}, 'Team support is not enabled.');
 
 test('only team owner can update team member roles', function () {
     $user = User::factory()->withPersonalTeam()->create();
@@ -34,4 +37,6 @@ test('only team owner can update team member roles', function () {
     expect($otherUser->fresh()->hasTeamRole(
         $user->currentTeam->fresh(), 'admin'
     ))->toBeTrue();
-});
+})->skip(function () {
+    return ! Features::hasTeamFeatures();
+}, 'Team support is not enabled.');

--- a/stubs/pest-tests/inertia/UpdateTeamNameTest.php
+++ b/stubs/pest-tests/inertia/UpdateTeamNameTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\User;
+use Laravel\Jetstream\Features;
 
 test('team names can be updated', function () {
     $this->actingAs($user = User::factory()->withPersonalTeam()->create());
@@ -11,4 +12,6 @@ test('team names can be updated', function () {
 
     expect($user->fresh()->ownedTeams)->toHaveCount(1);
     expect($user->currentTeam->fresh()->name)->toEqual('Test Team');
-});
+})->skip(function () {
+    return ! Features::hasTeamFeatures();
+}, 'Team support is not enabled.');

--- a/stubs/pest-tests/livewire/CreateTeamTest.php
+++ b/stubs/pest-tests/livewire/CreateTeamTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\User;
+use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Http\Livewire\CreateTeamForm;
 use Livewire\Livewire;
 
@@ -13,4 +14,6 @@ test('teams can be created', function () {
 
     expect($user->fresh()->ownedTeams)->toHaveCount(2);
     expect($user->fresh()->ownedTeams()->latest('id')->first()->name)->toEqual('Test Team');
-});
+})->skip(function () {
+    return ! Features::hasTeamFeatures();
+}, 'Team support is not enabled.');

--- a/stubs/pest-tests/livewire/DeleteTeamTest.php
+++ b/stubs/pest-tests/livewire/DeleteTeamTest.php
@@ -2,6 +2,7 @@
 
 use App\Models\Team;
 use App\Models\User;
+use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Http\Livewire\DeleteTeamForm;
 use Livewire\Livewire;
 
@@ -21,7 +22,9 @@ test('teams can be deleted', function () {
 
     expect($team->fresh())->toBeNull();
     expect($otherUser->fresh()->teams)->toHaveCount(0);
-});
+})->skip(function () {
+    return ! Features::hasTeamFeatures();
+}, 'Team support is not enabled.');
 
 test('personal teams cant be deleted', function () {
     $this->actingAs($user = User::factory()->withPersonalTeam()->create());
@@ -31,4 +34,6 @@ test('personal teams cant be deleted', function () {
                             ->assertHasErrors(['team']);
 
     expect($user->currentTeam->fresh())->not->toBeNull();
-});
+})->skip(function () {
+    return ! Features::hasTeamFeatures();
+}, 'Team support is not enabled.');

--- a/stubs/pest-tests/livewire/LeaveTeamTest.php
+++ b/stubs/pest-tests/livewire/LeaveTeamTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\User;
+use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Http\Livewire\TeamMemberManager;
 use Livewire\Livewire;
 
@@ -17,7 +18,9 @@ test('users can leave teams', function () {
                     ->call('leaveTeam');
 
     expect($user->currentTeam->fresh()->users)->toHaveCount(0);
-});
+})->skip(function () {
+    return ! Features::hasTeamFeatures();
+}, 'Team support is not enabled.');
 
 test('team owners cant leave their own team', function () {
     $this->actingAs($user = User::factory()->withPersonalTeam()->create());
@@ -27,4 +30,6 @@ test('team owners cant leave their own team', function () {
                     ->assertHasErrors(['team']);
 
     expect($user->currentTeam->fresh())->not->toBeNull();
-});
+})->skip(function () {
+    return ! Features::hasTeamFeatures();
+}, 'Team support is not enabled.');

--- a/stubs/pest-tests/livewire/RemoveTeamMemberTest.php
+++ b/stubs/pest-tests/livewire/RemoveTeamMemberTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\User;
+use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Http\Livewire\TeamMemberManager;
 use Livewire\Livewire;
 
@@ -16,7 +17,9 @@ test('team members can be removed from teams', function () {
                     ->call('removeTeamMember');
 
     expect($user->currentTeam->fresh()->users)->toHaveCount(0);
-});
+})->skip(function () {
+    return ! Features::hasTeamFeatures();
+}, 'Team support is not enabled.');
 
 test('only team owner can remove team members', function () {
     $user = User::factory()->withPersonalTeam()->create();
@@ -31,4 +34,6 @@ test('only team owner can remove team members', function () {
                     ->set('teamMemberIdBeingRemoved', $user->id)
                     ->call('removeTeamMember')
                     ->assertStatus(403);
-});
+})->skip(function () {
+    return ! Features::hasTeamFeatures();
+}, 'Team support is not enabled.');

--- a/stubs/pest-tests/livewire/UpdateTeamMemberRoleTest.php
+++ b/stubs/pest-tests/livewire/UpdateTeamMemberRoleTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\User;
+use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Http\Livewire\TeamMemberManager;
 use Livewire\Livewire;
 
@@ -19,7 +20,9 @@ test('team member roles can be updated', function () {
     expect($otherUser->fresh()->hasTeamRole(
         $user->currentTeam->fresh(), 'editor'
     ))->toBeTrue();
-});
+})->skip(function () {
+    return ! Features::hasTeamFeatures();
+}, 'Team support is not enabled.');
 
 test('only team owner can update team member roles', function () {
     $user = User::factory()->withPersonalTeam()->create();
@@ -39,4 +42,6 @@ test('only team owner can update team member roles', function () {
     expect($otherUser->fresh()->hasTeamRole(
         $user->currentTeam->fresh(), 'admin'
     ))->toBeTrue();
-});
+})->skip(function () {
+    return ! Features::hasTeamFeatures();
+}, 'Team support is not enabled.');

--- a/stubs/pest-tests/livewire/UpdateTeamNameTest.php
+++ b/stubs/pest-tests/livewire/UpdateTeamNameTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\User;
+use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Http\Livewire\UpdateTeamNameForm;
 use Livewire\Livewire;
 
@@ -13,4 +14,6 @@ test('team names can be updated', function () {
 
     expect($user->fresh()->ownedTeams)->toHaveCount(1);
     expect($user->currentTeam->fresh()->name)->toEqual('Test Team');
-});
+})->skip(function () {
+    return ! Features::hasTeamFeatures();
+}, 'Team support is not enabled.');

--- a/stubs/tests/inertia/CreateTeamTest.php
+++ b/stubs/tests/inertia/CreateTeamTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Jetstream\Features;
 use Tests\TestCase;
 
 class CreateTeamTest extends TestCase
@@ -12,6 +13,12 @@ class CreateTeamTest extends TestCase
 
     public function test_teams_can_be_created(): void
     {
+        if (! Features::hasTeamFeatures()) {
+            $this->markTestSkipped('Team support is not enabled.');
+
+            return;
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $response = $this->post('/teams', [

--- a/stubs/tests/inertia/DeleteTeamTest.php
+++ b/stubs/tests/inertia/DeleteTeamTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Models\Team;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Jetstream\Features;
 use Tests\TestCase;
 
 class DeleteTeamTest extends TestCase
@@ -13,6 +14,12 @@ class DeleteTeamTest extends TestCase
 
     public function test_teams_can_be_deleted(): void
     {
+        if (! Features::hasTeamFeatures()) {
+            $this->markTestSkipped('Team support is not enabled.');
+
+            return;
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $user->ownedTeams()->save($team = Team::factory()->make([
@@ -31,6 +38,12 @@ class DeleteTeamTest extends TestCase
 
     public function test_personal_teams_cant_be_deleted(): void
     {
+        if (! Features::hasTeamFeatures()) {
+            $this->markTestSkipped('Team support is not enabled.');
+
+            return;
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $response = $this->delete('/teams/'.$user->currentTeam->id);

--- a/stubs/tests/inertia/LeaveTeamTest.php
+++ b/stubs/tests/inertia/LeaveTeamTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Jetstream\Features;
 use Tests\TestCase;
 
 class LeaveTeamTest extends TestCase
@@ -12,6 +13,12 @@ class LeaveTeamTest extends TestCase
 
     public function test_users_can_leave_teams(): void
     {
+        if (! Features::hasTeamFeatures()) {
+            $this->markTestSkipped('Team support is not enabled.');
+
+            return;
+        }
+
         $user = User::factory()->withPersonalTeam()->create();
 
         $user->currentTeam->users()->attach(
@@ -27,6 +34,12 @@ class LeaveTeamTest extends TestCase
 
     public function test_team_owners_cant_leave_their_own_team(): void
     {
+        if (! Features::hasTeamFeatures()) {
+            $this->markTestSkipped('Team support is not enabled.');
+
+            return;
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $response = $this->delete('/teams/'.$user->currentTeam->id.'/members/'.$user->id);

--- a/stubs/tests/inertia/RemoveTeamMemberTest.php
+++ b/stubs/tests/inertia/RemoveTeamMemberTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Jetstream\Features;
 use Tests\TestCase;
 
 class RemoveTeamMemberTest extends TestCase
@@ -12,6 +13,12 @@ class RemoveTeamMemberTest extends TestCase
 
     public function test_team_members_can_be_removed_from_teams(): void
     {
+        if (! Features::hasTeamFeatures()) {
+            $this->markTestSkipped('Team support is not enabled.');
+
+            return;
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $user->currentTeam->users()->attach(
@@ -25,6 +32,12 @@ class RemoveTeamMemberTest extends TestCase
 
     public function test_only_team_owner_can_remove_team_members(): void
     {
+        if (! Features::hasTeamFeatures()) {
+            $this->markTestSkipped('Team support is not enabled.');
+
+            return;
+        }
+
         $user = User::factory()->withPersonalTeam()->create();
 
         $user->currentTeam->users()->attach(

--- a/stubs/tests/inertia/UpdateTeamMemberRoleTest.php
+++ b/stubs/tests/inertia/UpdateTeamMemberRoleTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Jetstream\Features;
 use Tests\TestCase;
 
 class UpdateTeamMemberRoleTest extends TestCase
@@ -12,6 +13,12 @@ class UpdateTeamMemberRoleTest extends TestCase
 
     public function test_team_member_roles_can_be_updated(): void
     {
+        if (! Features::hasTeamFeatures()) {
+            $this->markTestSkipped('Team support is not enabled.');
+
+            return;
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $user->currentTeam->users()->attach(
@@ -29,6 +36,12 @@ class UpdateTeamMemberRoleTest extends TestCase
 
     public function test_only_team_owner_can_update_team_member_roles(): void
     {
+        if (! Features::hasTeamFeatures()) {
+            $this->markTestSkipped('Team support is not enabled.');
+
+            return;
+        }
+
         $user = User::factory()->withPersonalTeam()->create();
 
         $user->currentTeam->users()->attach(

--- a/stubs/tests/inertia/UpdateTeamNameTest.php
+++ b/stubs/tests/inertia/UpdateTeamNameTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Jetstream\Features;
 use Tests\TestCase;
 
 class UpdateTeamNameTest extends TestCase
@@ -12,6 +13,12 @@ class UpdateTeamNameTest extends TestCase
 
     public function test_team_names_can_be_updated(): void
     {
+        if (! Features::hasTeamFeatures()) {
+            $this->markTestSkipped('Team support is not enabled.');
+
+            return;
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $response = $this->put('/teams/'.$user->currentTeam->id, [

--- a/stubs/tests/livewire/CreateTeamTest.php
+++ b/stubs/tests/livewire/CreateTeamTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Http\Livewire\CreateTeamForm;
 use Livewire\Livewire;
 use Tests\TestCase;
@@ -14,6 +15,12 @@ class CreateTeamTest extends TestCase
 
     public function test_teams_can_be_created(): void
     {
+        if (! Features::hasTeamFeatures()) {
+            $this->markTestSkipped('Team support is not enabled.');
+
+            return;
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         Livewire::test(CreateTeamForm::class)

--- a/stubs/tests/livewire/DeleteTeamTest.php
+++ b/stubs/tests/livewire/DeleteTeamTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Models\Team;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Http\Livewire\DeleteTeamForm;
 use Livewire\Livewire;
 use Tests\TestCase;
@@ -15,6 +16,12 @@ class DeleteTeamTest extends TestCase
 
     public function test_teams_can_be_deleted(): void
     {
+        if (! Features::hasTeamFeatures()) {
+            $this->markTestSkipped('Team support is not enabled.');
+
+            return;
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $user->ownedTeams()->save($team = Team::factory()->make([
@@ -34,6 +41,12 @@ class DeleteTeamTest extends TestCase
 
     public function test_personal_teams_cant_be_deleted(): void
     {
+        if (! Features::hasTeamFeatures()) {
+            $this->markTestSkipped('Team support is not enabled.');
+
+            return;
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $component = Livewire::test(DeleteTeamForm::class, ['team' => $user->currentTeam])

--- a/stubs/tests/livewire/LeaveTeamTest.php
+++ b/stubs/tests/livewire/LeaveTeamTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Http\Livewire\TeamMemberManager;
 use Livewire\Livewire;
 use Tests\TestCase;
@@ -14,6 +15,12 @@ class LeaveTeamTest extends TestCase
 
     public function test_users_can_leave_teams(): void
     {
+        if (! Features::hasTeamFeatures()) {
+            $this->markTestSkipped('Team support is not enabled.');
+
+            return;
+        }
+
         $user = User::factory()->withPersonalTeam()->create();
 
         $user->currentTeam->users()->attach(
@@ -30,6 +37,12 @@ class LeaveTeamTest extends TestCase
 
     public function test_team_owners_cant_leave_their_own_team(): void
     {
+        if (! Features::hasTeamFeatures()) {
+            $this->markTestSkipped('Team support is not enabled.');
+
+            return;
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $component = Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])

--- a/stubs/tests/livewire/RemoveTeamMemberTest.php
+++ b/stubs/tests/livewire/RemoveTeamMemberTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Http\Livewire\TeamMemberManager;
 use Livewire\Livewire;
 use Tests\TestCase;
@@ -14,6 +15,12 @@ class RemoveTeamMemberTest extends TestCase
 
     public function test_team_members_can_be_removed_from_teams(): void
     {
+        if (! Features::hasTeamFeatures()) {
+            $this->markTestSkipped('Team support is not enabled.');
+
+            return;
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $user->currentTeam->users()->attach(
@@ -29,6 +36,12 @@ class RemoveTeamMemberTest extends TestCase
 
     public function test_only_team_owner_can_remove_team_members(): void
     {
+        if (! Features::hasTeamFeatures()) {
+            $this->markTestSkipped('Team support is not enabled.');
+
+            return;
+        }
+
         $user = User::factory()->withPersonalTeam()->create();
 
         $user->currentTeam->users()->attach(

--- a/stubs/tests/livewire/UpdateTeamMemberRoleTest.php
+++ b/stubs/tests/livewire/UpdateTeamMemberRoleTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Http\Livewire\TeamMemberManager;
 use Livewire\Livewire;
 use Tests\TestCase;
@@ -14,6 +15,12 @@ class UpdateTeamMemberRoleTest extends TestCase
 
     public function test_team_member_roles_can_be_updated(): void
     {
+        if (! Features::hasTeamFeatures()) {
+            $this->markTestSkipped('Team support is not enabled.');
+
+            return;
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         $user->currentTeam->users()->attach(
@@ -32,6 +39,12 @@ class UpdateTeamMemberRoleTest extends TestCase
 
     public function test_only_team_owner_can_update_team_member_roles(): void
     {
+        if (! Features::hasTeamFeatures()) {
+            $this->markTestSkipped('Team support is not enabled.');
+
+            return;
+        }
+
         $user = User::factory()->withPersonalTeam()->create();
 
         $user->currentTeam->users()->attach(

--- a/stubs/tests/livewire/UpdateTeamNameTest.php
+++ b/stubs/tests/livewire/UpdateTeamNameTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Jetstream\Features;
 use Laravel\Jetstream\Http\Livewire\UpdateTeamNameForm;
 use Livewire\Livewire;
 use Tests\TestCase;
@@ -14,6 +15,12 @@ class UpdateTeamNameTest extends TestCase
 
     public function test_team_names_can_be_updated(): void
     {
+        if (! Features::hasTeamFeatures()) {
+            $this->markTestSkipped('Team support is not enabled.');
+
+            return;
+        }
+
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
         Livewire::test(UpdateTeamNameForm::class, ['team' => $user->currentTeam])


### PR DESCRIPTION
# Fix Jetstream Stub Tests

Hello, fellows!

This PR tends to fix stub tests that come with Jetstream.

<table width="100%">
<tr>
<td width="40%" valign="top">

## Problem:

When you have enabled Teams feature but at some point you decide to disable it from `config/jetstream.php` and when you run tests, some of the tests fail. Because they require Teams feature to be enabled.
</td>
<td width="60%"><br>

```php
// This test would fail if the Teams feature is enabled
test('teams can be created', function () {
    $this->actingAs($user = User::factory()->withPersonalTeam()->create());

    $response = $this->post('/teams', [
        'name' => 'Test Team',
    ]);

    expect($user->fresh()->ownedTeams)->toHaveCount(2);
    expect($user->fresh()->ownedTeams()->latest('id')->first()->name)
        ->toEqual('Test Team');
})
```

</td>
</tr>
</table>

<table width="100%">
<tr>
<td width="40%" valign="top">

## Solution:

Similar to other tests, I am adding the skip option to the team tests. So that when you disable the teams feature from `config/jetstream.php`, it would skip those tests.
</td>
<td width="60%"><br>

```php
/**
 * Now that there is a skip method appended to the test,
 * it would not run until you enable Teams feature.
 */
test('teams can be created', function () {
    $this->actingAs($user = User::factory()->withPersonalTeam()->create());

    $response = $this->post('/teams', [
        'name' => 'Test Team',
    ]);

    expect($user->fresh()->ownedTeams)->toHaveCount(2);
    expect($user->fresh()->ownedTeams()->latest('id')->first()->name)
        ->toEqual('Test Team');
})->skip(function () {
    return ! Features::hasTeamFeatures();
}, 'Team support is not enabled.');
```

</td>
</tr>
</table>

<br>
<br>

**NOTE: I have tested this PR heavily and covered all the stub tests, would love for someone else to also double check this.**

Thank you for this amazing starter kit.

Best!

Mansoor Ahmed.
