### PR TITLE
Fix breaking livewire TwoFactorAuthenticationSettingsTest when eloquent strict mode is enabled.

### DIFF
--- a/src/Http/Livewire/TwoFactorAuthenticationForm.php
+++ b/src/Http/Livewire/TwoFactorAuthenticationForm.php
@@ -51,7 +51,7 @@ class TwoFactorAuthenticationForm extends Component
     public function mount()
     {
         if (Features::optionEnabled(Features::twoFactorAuthentication(), 'confirm') &&
-            is_null(Auth::user()->two_factor_confirmed_at)) {
+            isset(Auth::user()->two_factor_confirmed_at)) {
             app(DisableTwoFactorAuthentication::class)(Auth::user());
         }
     }


### PR DESCRIPTION
This is a solution to issue #1220 please refer to it for more details.

This solves the minor bug of TwoFactorAuthenticationSettingsTest failing when eloquent strict mode is enabled. 