### PR TITLE
[2.x] Strip dark classes from welcome component when dark mode isn't selected.

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -262,10 +262,7 @@ class InstallCommand extends Command
             $this->removeDarkClasses((new Finder)
                 ->in(resource_path('views'))
                 ->name('*.blade.php')
-                ->notName('welcome.blade.php')
-                ->append((new Finder)
-                    ->in(resource_path('views/vendor/jetstream/components'))
-                    ->name('welcome.blade.php'))
+                ->filter(fn ($file) => $file->getPathname() !== resource_path('views/welcome.blade.php'))
             );
         }
 

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -263,6 +263,9 @@ class InstallCommand extends Command
                 ->in(resource_path('views'))
                 ->name('*.blade.php')
                 ->notName('welcome.blade.php')
+                ->append((new Finder)
+                    ->in(resource_path('views/vendor/jetstream/components'))
+                    ->name('welcome.blade.php'))
             );
         }
 
@@ -435,7 +438,7 @@ EOF;
             $this->removeDarkClasses((new Finder)
                 ->in(resource_path('js'))
                 ->name('*.vue')
-                ->notName('Welcome.vue')
+                ->notPath('Pages/Welcome.vue')
             );
         }
 


### PR DESCRIPTION
Jetstream has a welcome page and a welcome component. The previous implementation was excluding both when stripping dark classes, but it should only exclude the welcome page so that the welcome component does not end up with dark classes.

Fixes #1223