### PR TITLE
Fixed not redirecting after deleting the user

### DIFF
--- a/src/Http/Livewire/DeleteUserForm.php
+++ b/src/Http/Livewire/DeleteUserForm.php
@@ -69,7 +69,7 @@ class DeleteUserForm extends Component
             $request->session()->regenerateToken();
         }
 
-        return redirect(config('fortify.redirects.logout', '/'));
+        return redirect(config('fortify.redirects.logout') ?? '/');
     }
 
     /**


### PR DESCRIPTION
@riasvdv introduced the ability to redirect to a configurable route using [laravel/fortify](https://github.com/laravel/fortify)'s config (`fortify.redirects.logout`) once the user has been deleted in commit dfc3ffcf490ecf799d54105bd1fae84606d6a947.

The problem here is that even though `fortify.redirects.logout` is `null`, it will not use the default value (`/`) unless the config key doesn't exist at all. Therefore, `return redirect(config('fortify.redirects.logout', '/'));` will return `null` and not redirect the user.

I've replaced the default value with a null coalescing operator so that if `fortify.redirects.logout` is `null`, it will redirect to `/`.
