### PR TITLE
[2.x] Convert Profile Photo URL attribute to newer syntax

### DIFF
--- a/src/HasProfilePhoto.php
+++ b/src/HasProfilePhoto.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Jetstream;
 
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
@@ -55,13 +56,15 @@ trait HasProfilePhoto
     /**
      * Get the URL to the user's profile photo.
      *
-     * @return string
+     * @return \Illuminate\Database\Eloquent\Casts\Attribute
      */
-    public function getProfilePhotoUrlAttribute()
+    public function profilePhotoUrl(): Attribute
     {
-        return $this->profile_photo_path
+        return Attribute::get(function() {
+            return $this->profile_photo_path
                     ? Storage::disk($this->profilePhotoDisk())->url($this->profile_photo_path)
                     : $this->defaultProfilePhotoUrl();
+        });
     }
 
     /**

--- a/src/HasProfilePhoto.php
+++ b/src/HasProfilePhoto.php
@@ -60,7 +60,7 @@ trait HasProfilePhoto
      */
     public function profilePhotoUrl(): Attribute
     {
-        return Attribute::get(function() {
+        return Attribute::get(function () {
             return $this->profile_photo_path
                     ? Storage::disk($this->profilePhotoDisk())->url($this->profile_photo_path)
                     : $this->defaultProfilePhotoUrl();

--- a/src/Http/Livewire/DeleteUserForm.php
+++ b/src/Http/Livewire/DeleteUserForm.php
@@ -69,7 +69,7 @@ class DeleteUserForm extends Component
             $request->session()->regenerateToken();
         }
 
-        return redirect(config('fortify.redirects.logout', '/'));
+        return redirect(config('fortify.redirects.logout') ?? '/');
     }
 
     /**


### PR DESCRIPTION
This will convert the profile photo attribute in ```HasProfilePhoto.php``` to the newer Attribute syntax from Laravel 9. While the function name reads cleaner, the only tradeoff is that it does add a few lines to the file.

This shouldn't be a breaking change since the attribute will still be accessible as ```profile_photo_url``` to both Livewire and Inertia. Also, the composer.json on the 2.x branch points to Laravel 9 and 10; so, it won't affect anyone using Jetstream with Laravel 8.