### PR TITLE
Removes `--verbose` PHPUnit option from tests workflow.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
           composer update --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
-        run: vendor/bin/phpunit --verbose
+        run: vendor/bin/phpunit
 
   stub-tests:
     runs-on: ubuntu-22.04
@@ -88,7 +88,7 @@ jobs:
         run: npm run build
 
       - name: Execute tests
-        run: vendor/bin/phpunit --verbose
+        run: vendor/bin/phpunit
         env:
           DB_CONNECTION: sqlite
           DB_DATABASE: ":memory:"


### PR DESCRIPTION
Removes the `--verbose` PHPUnit option used in CI as this is no longer available when running the workflow against Laravel 10.x.

I noticed my scheduled CI workflows failing because of this on Socialstream, because of `composer create-project laravel/laravel:10.x-dev` in the `Setup Laravel` step in my CI pipeline.

As of PHPUnit 10.0, the `--verbose` option no longer exists (see related issue [here](https://github.com/sebastianbergmann/phpunit/issues/4956)) and since Laravel 10.x requires a PHPUnit version `^10.0`, this will also cause the `Execute tests` step to fail in Jetstream.