### PR TITLE
Import models from the App namespace in stubs

### DIFF
--- a/stubs/app/Providers/JetstreamServiceProvider.php
+++ b/stubs/app/Providers/JetstreamServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use App\Actions\Jetstream\DeleteUser;
+use App\Models\User;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Jetstream\Jetstream;
 
@@ -22,6 +23,8 @@ class JetstreamServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->configurePermissions();
+
+        Jetstream::useUserModel(User::class);
 
         Jetstream::deleteUsersUsing(DeleteUser::class);
     }

--- a/stubs/app/Providers/JetstreamWithTeamsServiceProvider.php
+++ b/stubs/app/Providers/JetstreamWithTeamsServiceProvider.php
@@ -9,6 +9,10 @@ use App\Actions\Jetstream\DeleteUser;
 use App\Actions\Jetstream\InviteTeamMember;
 use App\Actions\Jetstream\RemoveTeamMember;
 use App\Actions\Jetstream\UpdateTeamName;
+use App\Models\Membership;
+use App\Models\Team;
+use App\Models\TeamInvitation;
+use App\Models\User;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Jetstream\Jetstream;
 
@@ -28,6 +32,11 @@ class JetstreamServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->configurePermissions();
+
+        Jetstream::useUserModel(User::class);
+        Jetstream::useTeamModel(Team::class);
+        Jetstream::useTeamInvitationModel(TeamInvitation::class);
+        Jetstream::useMembershipModel(Membership::class);
 
         Jetstream::createTeamsUsing(CreateTeam::class);
         Jetstream::updateTeamNamesUsing(UpdateTeamName::class);


### PR DESCRIPTION
As the actions are already being imported from the `App` namespace, this will apply the same import rule for the model files.