### PR TITLE
Fixes incorrect classes for Laracasts link on Welcome.vue component.

### DIFF
--- a/stubs/inertia/resources/js/Components/Welcome.vue
+++ b/stubs/inertia/resources/js/Components/Welcome.vue
@@ -60,10 +60,10 @@ import ApplicationLogo from '@/Components/ApplicationLogo.vue';
                 </p>
 
                 <p class="mt-4 text-sm">
-                    <a href="https://laracasts.com" class="inline-flex items-center font-semibold fill-indigo-700 fill:text-indigo-300">
+                    <a href="https://laracasts.com" class="inline-flex items-center font-semibold text-indigo-700 dark:text-indigo-300">
                         Start watching Laracasts
 
-                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" class="ml-1 w-5 h-5 stroke-indigo-500 dark:stroke-indigo-200">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" class="ml-1 w-5 h-5 fill-indigo-500 dark:fill-indigo-200">
                             <path fill-rule="evenodd" d="M5 10a.75.75 0 01.75-.75h6.638L10.23 7.29a.75.75 0 111.04-1.08l3.5 3.25a.75.75 0 010 1.08l-3.5 3.25a.75.75 0 11-1.04-1.08l2.158-1.96H5.75A.75.75 0 015 10z" clip-rule="evenodd" />
                         </svg>
                     </a>


### PR DESCRIPTION
The classes for the mentioned link seem to have been reversed with the classes from the svg file.

This pull request fixes the link to the correct layout while still supporting dark mode.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

If you change the behavior of the Inertia stack you're expected to update the Livewire stack as well and vice versa.
-->
