### PR TITLE
[3.x] Ensure CI considers backwards compatibility with Laravel 9

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,7 @@ jobs:
       fail-fast: true
       matrix:
         stack: [inertia, livewire]
-        laravel: [9. 10]
+        laravel: [9, 10]
         php: [ '8.0', 8.1, 8.2 ]
         exclude:
           - php: '8.0'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,9 +52,13 @@ jobs:
       fail-fast: true
       matrix:
         stack: [inertia, livewire]
-        laravel: [10]
+        laravel: [9. 10]
+        php: [ '8.0', 8.1, 8.2 ]
+        exclude:
+          - php: '8.0'
+            laravel: 10
 
-    name: Test Stubs - Laravel ${{ matrix.laravel }} - ${{ matrix.stack }}
+    name: Test Stubs - PHP ${{ matrix.php }} – Laravel ${{ matrix.laravel }} - ${{ matrix.stack }}
 
     steps:
       - name: Setup PHP


### PR DESCRIPTION
This PR updates the `Test Stubs` CI pipeline for Jetstream to ensure backwards compatibility with Laravel ^9.21, as per the `composer.json` minimum requirements.