### PR TITLE
Revert "[3.x] Ensure CI considers backwards compatibility with Laravel 9"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,13 +52,9 @@ jobs:
       fail-fast: true
       matrix:
         stack: [inertia, livewire]
-        laravel: [9, 10]
-        php: [ '8.0', 8.1, 8.2 ]
-        exclude:
-          - php: '8.0'
-            laravel: 10
+        laravel: [10]
 
-    name: Test Stubs - PHP ${{ matrix.php }} – Laravel ${{ matrix.laravel }} - ${{ matrix.stack }}
+    name: Test Stubs - Laravel ${{ matrix.laravel }} - ${{ matrix.stack }}
 
     steps:
       - name: Setup PHP


### PR DESCRIPTION
Reverts laravel/jetstream#1258 as it's not needed. Just testing the latest versions is fine.