### PR TITLE
Fix upgrade for Inertia upgrade docs (line 63)

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -60,7 +60,7 @@ Next, clear your view cache:
 
 #### Accessing The Authenticated User
 
-You should change all references of `$page.props.user` to `$page.props.auth.user` and `usePage().props.user` to `usePage().props.auth.user`.
+You should change all references of `$page.props.user` to `$page.props.auth` and `usePage().props.user` to `usePage().props.auth.user`.
 
 If you are using an Inertia version prior to 1.0, you will need to replace `usePage().props.value.user` with `userPage().props.value.auth.user`.
 


### PR DESCRIPTION
On line 63, I removed the user from the $page.props.auth as adding user to the end will break the welcome page during its check.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

If you change the behavior of the Inertia stack you're expected to update the Livewire stack as well and vice versa.
-->
