### PR TITLE
Change class interface from Rule to ValidationRule

### DIFF
--- a/src/Rules/Role.php
+++ b/src/Rules/Role.php
@@ -2,30 +2,19 @@
 
 namespace Laravel\Jetstream\Rules;
 
-use Illuminate\Contracts\Validation\Rule;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Laravel\Jetstream\Jetstream;
 
-class Role implements Rule
+class Role implements ValidationRule
 {
     /**
-     * Determine if the validation rule passes.
-     *
-     * @param  string  $attribute
-     * @param  mixed  $value
-     * @return bool
+     * Run the validation rule.
      */
-    public function passes($attribute, $value)
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        return in_array($value, array_keys(Jetstream::$roles));
-    }
-
-    /**
-     * Get the validation error message.
-     *
-     * @return string
-     */
-    public function message()
-    {
-        return __('The :attribute must be a valid role.');
+        if (! in_array($value, array_keys(Jetstream::$roles))) {
+            $fail('The :attribute must be a valid role.')->translate();
+        }
     }
 }


### PR DESCRIPTION
The validation class `\Illuminate\Contracts\Validation\Rule` has been marked as @deprecated on commit https://github.com/laravel/framework/commit/22413d4e16080f3fa1a8708bc969af32641b016a

This PR updates the interface (and the implementation) to `\Illuminate\Contracts\Validation\ValidationRule`.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

If you change the behavior of the Inertia stack you're expected to update the Livewire stack as well and vice versa.
-->
