### PR TITLE
Add banner() and dangerBanner() macros to livewire redirector

### DIFF
--- a/src/JetstreamServiceProvider.php
+++ b/src/JetstreamServiceProvider.php
@@ -25,6 +25,7 @@ use Laravel\Jetstream\Http\Livewire\UpdateProfileInformationForm;
 use Laravel\Jetstream\Http\Livewire\UpdateTeamNameForm;
 use Laravel\Jetstream\Http\Middleware\ShareInertiaData;
 use Livewire\Livewire;
+use Livewire\Redirector;
 
 class JetstreamServiceProvider extends ServiceProvider
 {
@@ -86,6 +87,22 @@ class JetstreamServiceProvider extends ServiceProvider
                 'banner' => $message,
             ]);
         });
+
+        if (config('jetstream.stack') === 'livewire') {
+            Redirector::macro('banner', function ($message) {
+                return $this->with('flash', [
+                    'bannerStyle' => 'success',
+                    'banner' => $message,
+                ]);
+            });
+
+            Redirector::macro('dangerBanner', function ($message) {
+                return $this->with('flash', [
+                    'bannerStyle' => 'danger',
+                    'banner' => $message,
+                ]);
+            });
+        }
 
         if (config('jetstream.stack') === 'inertia') {
             $this->bootInertia();

--- a/src/JetstreamServiceProvider.php
+++ b/src/JetstreamServiceProvider.php
@@ -88,7 +88,7 @@ class JetstreamServiceProvider extends ServiceProvider
             ]);
         });
 
-        if (config('jetstream.stack') === 'livewire') {
+        if (config('jetstream.stack') === 'livewire' && class_exists(Livewire::class)) {
             Redirector::macro('banner', function ($message) {
                 return $this->with('flash', [
                     'bannerStyle' => 'success',


### PR DESCRIPTION
This PR enables the use of `redirect()->banner()` and `redirect()->dangerBanner()` macros from Livewire components