### PR TITLE
Fix eloquent strict mode compatibility

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -31,6 +31,7 @@ class UserFactory extends Factory
             'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
             'two_factor_secret' => null,
             'two_factor_recovery_codes' => null,
+            'two_factor_confirmed_at' => null,
             'remember_token' => Str::random(10),
             'profile_photo_path' => null,
             'current_team_id' => null,


### PR DESCRIPTION
If you enable eloquent strict mode the `TwoFactorAuthenticationSettingsTest` tests fail because the `UserFactory` does not include the `two_factor_confirmed_at` attribute