### PR TITLE
[3.x] Removes `@return $this` when returning static

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -39,8 +39,6 @@ class UserFactory extends Factory
 
     /**
      * Indicate that the model's email address should be unverified.
-     *
-     * @return $this
      */
     public function unverified(): static
     {
@@ -53,8 +51,6 @@ class UserFactory extends Factory
 
     /**
      * Indicate that the user should have a personal team.
-     *
-     * @return $this
      */
     public function withPersonalTeam(): static
     {


### PR DESCRIPTION
Based on https://github.com/laravel/laravel/pull/6119, this pull request removes `@return $this` when returning static.