### PR TITLE
Uses Native PHP Return Types & Fixes

### DIFF
--- a/src/Actions/UpdateTeamMemberRole.php
+++ b/src/Actions/UpdateTeamMemberRole.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Jetstream\Actions;
 
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Validator;
 use Laravel\Jetstream\Events\TeamMemberUpdated;
@@ -13,13 +14,9 @@ class UpdateTeamMemberRole
     /**
      * Update the role for the given team member.
      *
-     * @param  mixed  $user
-     * @param  mixed  $team
-     * @param  int  $teamMemberId
-     * @param  string  $role
-     * @return void
+     * @throws AuthorizationException
      */
-    public function update($user, $team, $teamMemberId, string $role)
+    public function update(mixed $user, mixed $team, int $teamMemberId, string $role): void
     {
         Gate::forUser($user)->authorize('updateTeamMember', $team);
 

--- a/src/Actions/ValidateTeamDeletion.php
+++ b/src/Actions/ValidateTeamDeletion.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Jetstream\Actions;
 
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\ValidationException;
 
@@ -10,11 +11,9 @@ class ValidateTeamDeletion
     /**
      * Validate that the team can be deleted by the given user.
      *
-     * @param  mixed  $user
-     * @param  mixed  $team
-     * @return void
+     * @throws AuthorizationException
      */
-    public function validate($user, $team)
+    public function validate(mixed $user, mixed $team): void
     {
         Gate::forUser($user)->authorize('delete', $team);
 

--- a/src/Features.php
+++ b/src/Features.php
@@ -6,23 +6,16 @@ class Features
 {
     /**
      * Determine if the given feature is enabled.
-     *
-     * @param  string  $feature
-     * @return bool
      */
-    public static function enabled(string $feature)
+    public static function enabled(string $feature): bool
     {
         return in_array($feature, config('jetstream.features', []));
     }
 
     /**
      * Determine if the feature is enabled and has a given option enabled.
-     *
-     * @param  string  $feature
-     * @param  string  $option
-     * @return bool
      */
-    public static function optionEnabled(string $feature, string $option)
+    public static function optionEnabled(string $feature, string $option): bool
     {
         return static::enabled($feature) &&
                config("jetstream-options.{$feature}.{$option}") === true;
@@ -30,91 +23,72 @@ class Features
 
     /**
      * Determine if the application is allowing profile photo uploads.
-     *
-     * @return bool
      */
-    public static function managesProfilePhotos()
+    public static function managesProfilePhotos(): bool
     {
         return static::enabled(static::profilePhotos());
     }
 
     /**
      * Determine if the application is using any API features.
-     *
-     * @return bool
      */
-    public static function hasApiFeatures()
+    public static function hasApiFeatures(): bool
     {
         return static::enabled(static::api());
     }
 
     /**
      * Determine if the application is using any team features.
-     *
-     * @return bool
      */
-    public static function hasTeamFeatures()
+    public static function hasTeamFeatures(): bool
     {
         return static::enabled(static::teams());
     }
 
     /**
      * Determine if invitations are sent to team members.
-     *
-     * @return bool
      */
-    public static function sendsTeamInvitations()
+    public static function sendsTeamInvitations(): bool
     {
         return static::optionEnabled(static::teams(), 'invitations');
     }
 
     /**
      * Determine if the application has terms of service / privacy policy confirmation enabled.
-     *
-     * @return bool
      */
-    public static function hasTermsAndPrivacyPolicyFeature()
+    public static function hasTermsAndPrivacyPolicyFeature(): bool
     {
         return static::enabled(static::termsAndPrivacyPolicy());
     }
 
     /**
      * Determine if the application is using any account deletion features.
-     *
-     * @return bool
      */
-    public static function hasAccountDeletionFeatures()
+    public static function hasAccountDeletionFeatures(): bool
     {
         return static::enabled(static::accountDeletion());
     }
 
     /**
      * Enable the profile photo upload feature.
-     *
-     * @return string
      */
-    public static function profilePhotos()
+    public static function profilePhotos(): string
     {
         return 'profile-photos';
     }
 
     /**
      * Enable the API feature.
-     *
-     * @return string
      */
-    public static function api()
+    public static function api(): string
     {
         return 'api';
     }
 
     /**
      * Enable the teams feature.
-     *
-     * @param  array  $options
-     * @return string
      */
-    public static function teams(array $options = [])
+    public static function teams(array $options = []): string
     {
         if (! empty($options)) {
             config(['jetstream-options.teams' => $options]);
@@ -125,20 +99,16 @@ class Features
 
     /**
      * Enable the terms of service and privacy policy feature.
-     *
-     * @return string
      */
-    public static function termsAndPrivacyPolicy()
+    public static function termsAndPrivacyPolicy(): string
     {
         return 'terms';
     }
 
     /**
      * Enable the account deletion feature.
-     *
-     * @return string
      */
-    public static function accountDeletion()
+    public static function accountDeletion(): string
     {
         return 'account-deletion';
     }

--- a/src/HasProfilePhoto.php
+++ b/src/HasProfilePhoto.php
@@ -5,19 +5,13 @@ namespace Laravel\Jetstream;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
-use Illuminate\Support\Str;
-use Laravel\Jetstream\Features;
 
 trait HasProfilePhoto
 {
     /**
      * Update the user's profile photo.
-     *
-     * @param  \Illuminate\Http\UploadedFile  $photo
-     * @param  string  $storagePath
-     * @return void
      */
-    public function updateProfilePhoto(UploadedFile $photo, $storagePath = 'profile-photos')
+    public function updateProfilePhoto(UploadedFile $photo, string $storagePath = 'profile-photos'): void
     {
         tap($this->profile_photo_path, function ($previous) use ($photo, $storagePath) {
             $this->forceFill([
@@ -34,10 +28,8 @@ trait HasProfilePhoto
 
     /**
      * Delete the user's profile photo.
-     *
-     * @return void
      */
-    public function deleteProfilePhoto()
+    public function deleteProfilePhoto(): void
     {
         if (! Features::managesProfilePhotos()) {
             return;
@@ -56,8 +48,6 @@ trait HasProfilePhoto
 
     /**
      * Get the URL to the user's profile photo.
-     *
-     * @return \Illuminate\Database\Eloquent\Casts\Attribute
      */
     public function profilePhotoUrl(): Attribute
     {
@@ -70,24 +60,20 @@ trait HasProfilePhoto
 
     /**
      * Get the default profile photo URL if no profile photo has been uploaded.
-     *
-     * @return string
      */
-    protected function defaultProfilePhotoUrl()
+    protected function defaultProfilePhotoUrl(): string
     {
         $name = trim(collect(explode(' ', $this->name))->map(function ($segment) {
             return mb_substr($segment, 0, 1);
         })->join(' '));
 
-        return 'https://ui-avatars.com/api/?name='.urlencode($name).'&color=7F9CF5&background=EBF4FF';
+        return sprintf('https://ui-avatars.com/api/?name=%s&color=7F9CF5&background=EBF4FF', urlencode($name));
     }
 
     /**
      * Get the disk that profile photos should be stored on.
-     *
-     * @return string
      */
-    protected function profilePhotoDisk()
+    protected function profilePhotoDisk(): string
     {
         return isset($_ENV['VAPOR_ARTIFACT_NAME']) ? 's3' : config('jetstream.profile_photo_disk', 'public');
     }

--- a/src/HasTeams.php
+++ b/src/HasTeams.php
@@ -2,6 +2,11 @@
 
 namespace Laravel\Jetstream;
 
+use App\Models\Team;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Laravel\Sanctum\HasApiTokens;
 
@@ -9,21 +14,16 @@ trait HasTeams
 {
     /**
      * Determine if the given team is the current team.
-     *
-     * @param  mixed  $team
-     * @return bool
      */
-    public function isCurrentTeam($team)
+    public function isCurrentTeam(mixed $team): bool
     {
         return $team->id === $this->currentTeam->id;
     }
 
     /**
      * Get the current team of the user's context.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function currentTeam()
+    public function currentTeam(): BelongsTo
     {
         if (is_null($this->current_team_id) && $this->id) {
             $this->switchTeam($this->personalTeam());
@@ -34,11 +34,8 @@ trait HasTeams
 
     /**
      * Switch the user's context to the given team.
-     *
-     * @param  mixed  $team
-     * @return bool
      */
-    public function switchTeam($team)
+    public function switchTeam(mixed $team): bool
     {
         if (! $this->belongsToTeam($team)) {
             return false;
@@ -54,31 +51,25 @@ trait HasTeams
     }
 
     /**
-     * Get all of the teams the user owns or belongs to.
-     *
-     * @return \Illuminate\Support\Collection
+     * Get all the teams the user owns or belongs to.
      */
-    public function allTeams()
+    public function allTeams(): Collection
     {
         return $this->ownedTeams->merge($this->teams)->sortBy('name');
     }
 
     /**
-     * Get all of the teams the user owns.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     * Get all the teams the user owns.
      */
-    public function ownedTeams()
+    public function ownedTeams(): HasMany
     {
         return $this->hasMany(Jetstream::teamModel());
     }
 
     /**
-     * Get all of the teams the user belongs to.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     * Get all the teams the user belongs to.
      */
-    public function teams()
+    public function teams(): BelongsToMany
     {
         return $this->belongsToMany(Jetstream::teamModel(), Jetstream::membershipModel())
                         ->withPivot('role')
@@ -88,36 +79,28 @@ trait HasTeams
 
     /**
      * Get the user's "personal" team.
-     *
-     * @return \App\Models\Team
      */
-    public function personalTeam()
+    public function personalTeam(): Team
     {
         return $this->ownedTeams->where('personal_team', true)->first();
     }
 
     /**
      * Determine if the user owns the given team.
-     *
-     * @param  mixed  $team
-     * @return bool
      */
-    public function ownsTeam($team)
+    public function ownsTeam(mixed $team): bool
     {
         if (is_null($team)) {
             return false;
         }
 
-        return $this->id == $team->{$this->getForeignKey()};
+        return $this->id === $team->{$this->getForeignKey()};
     }
 
     /**
      * Determine if the user belongs to the given team.
-     *
-     * @param  mixed  $team
-     * @return bool
      */
-    public function belongsToTeam($team)
+    public function belongsToTeam(mixed $team): bool
     {
         if (is_null($team)) {
             return false;
@@ -130,18 +113,15 @@ trait HasTeams
 
     /**
      * Get the role that the user has on the team.
-     *
-     * @param  mixed  $team
-     * @return \Laravel\Jetstream\Role|null
      */
-    public function teamRole($team)
+    public function teamRole(mixed $team): Role|null
     {
         if ($this->ownsTeam($team)) {
             return new OwnerRole;
         }
 
         if (! $this->belongsToTeam($team)) {
-            return;
+            return null;
         }
 
         $role = $team->users
@@ -155,12 +135,8 @@ trait HasTeams
 
     /**
      * Determine if the user has the given role on the given team.
-     *
-     * @param  mixed  $team
-     * @param  string  $role
-     * @return bool
      */
-    public function hasTeamRole($team, string $role)
+    public function hasTeamRole(mixed $team, string $role): bool
     {
         if ($this->ownsTeam($team)) {
             return true;
@@ -173,11 +149,8 @@ trait HasTeams
 
     /**
      * Get the user's permissions for the given team.
-     *
-     * @param  mixed  $team
-     * @return array
      */
-    public function teamPermissions($team)
+    public function teamPermissions(mixed $team): array
     {
         if ($this->ownsTeam($team)) {
             return ['*'];
@@ -192,12 +165,8 @@ trait HasTeams
 
     /**
      * Determine if the user has the given permission on the given team.
-     *
-     * @param  mixed  $team
-     * @param  string  $permission
-     * @return bool
      */
-    public function hasTeamPermission($team, string $permission)
+    public function hasTeamPermission(mixed $team, string $permission): bool
     {
         if ($this->ownsTeam($team)) {
             return true;

--- a/src/Http/Controllers/CurrentTeamController.php
+++ b/src/Http/Controllers/CurrentTeamController.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Jetstream\Http\Controllers;
 
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Laravel\Jetstream\Jetstream;
@@ -10,11 +11,8 @@ class CurrentTeamController extends Controller
 {
     /**
      * Update the authenticated user's current team.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\RedirectResponse
      */
-    public function update(Request $request)
+    public function update(Request $request): RedirectResponse
     {
         $team = Jetstream::newTeamModel()->findOrFail($request->team_id);
 

--- a/src/Http/Controllers/Inertia/ApiTokenController.php
+++ b/src/Http/Controllers/Inertia/ApiTokenController.php
@@ -2,21 +2,20 @@
 
 namespace Laravel\Jetstream\Http\Controllers\Inertia;
 
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Inertia\Response;
 use Laravel\Jetstream\Jetstream;
 
 class ApiTokenController extends Controller
 {
     /**
      * Show the user API token screen.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Inertia\Response
      */
-    public function index(Request $request)
+    public function index(Request $request): Response
     {
-        return Jetstream::inertia()->render($request, 'API/Index', [
+        return Jetstream::inertia()?->render($request, 'API/Index', [
             'tokens' => $request->user()->tokens->map(function ($token) {
                 return $token->toArray() + [
                     'last_used_ago' => optional($token->last_used_at)->diffForHumans(),
@@ -29,11 +28,8 @@ class ApiTokenController extends Controller
 
     /**
      * Create a new API token.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\RedirectResponse
      */
-    public function store(Request $request)
+    public function store(Request $request): RedirectResponse
     {
         $request->validate([
             'name' => ['required', 'string', 'max:255'],
@@ -51,12 +47,8 @@ class ApiTokenController extends Controller
 
     /**
      * Update the given API token's permissions.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  string  $tokenId
-     * @return \Illuminate\Http\RedirectResponse
      */
-    public function update(Request $request, $tokenId)
+    public function update(Request $request, string $tokenId): RedirectResponse
     {
         $request->validate([
             'permissions' => 'array',
@@ -74,12 +66,8 @@ class ApiTokenController extends Controller
 
     /**
      * Delete the given API token.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  string  $tokenId
-     * @return \Illuminate\Http\RedirectResponse
      */
-    public function destroy(Request $request, $tokenId)
+    public function destroy(Request $request, string $tokenId): RedirectResponse
     {
         $request->user()->tokens()->where('id', $tokenId)->first()->delete();
 

--- a/src/Http/Controllers/Inertia/Concerns/ConfirmsTwoFactorAuthentication.php
+++ b/src/Http/Controllers/Inertia/Concerns/ConfirmsTwoFactorAuthentication.php
@@ -10,12 +10,9 @@ use Laravel\Fortify\Features;
 trait ConfirmsTwoFactorAuthentication
 {
     /**
-     * Validate the two factor authentication state for the request.
-     *
-     * @param  \Illuminate\Http\Request
-     * @return void
+     * Validate the two-factor authentication state for the request.
      */
-    protected function validateTwoFactorAuthenticationState(Request $request)
+    protected function validateTwoFactorAuthenticationState(Request $request): void
     {
         if (! Features::optionEnabled(Features::twoFactorAuthentication(), 'confirm')) {
             return;
@@ -43,24 +40,18 @@ trait ConfirmsTwoFactorAuthentication
     }
 
     /**
-     * Determine if two factor authenticatoin is totally disabled.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return bool
+     * Determine if two-factor authentication is totally disabled.
      */
-    protected function twoFactorAuthenticationDisabled(Request $request)
+    protected function twoFactorAuthenticationDisabled(Request $request): bool
     {
         return is_null($request->user()->two_factor_secret) &&
             is_null($request->user()->two_factor_confirmed_at);
     }
 
     /**
-     * Determine if two factor authentication is just now being confirmed within the last request cycle.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return bool
+     * Determine if two-factor authentication is just now being confirmed within the last request cycle.
      */
-    protected function hasJustBegunConfirmingTwoFactorAuthentication(Request $request)
+    protected function hasJustBegunConfirmingTwoFactorAuthentication(Request $request): bool
     {
         return ! is_null($request->user()->two_factor_secret) &&
             is_null($request->user()->two_factor_confirmed_at) &&
@@ -69,16 +60,12 @@ trait ConfirmsTwoFactorAuthentication
     }
 
     /**
-     * Determine if two factor authentication was never totally confirmed once confirmation started.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  int  $currentTime
-     * @return bool
+     * Determine if two-factor authentication was never totally confirmed once confirmation started.
      */
-    protected function neverFinishedConfirmingTwoFactorAuthentication(Request $request, $currentTime)
+    protected function neverFinishedConfirmingTwoFactorAuthentication(Request $request, int $currentTime): bool
     {
         return ! array_key_exists('code', $request->session()->getOldInput()) &&
             is_null($request->user()->two_factor_confirmed_at) &&
-            $request->session()->get('two_factor_confirming_at', 0) != $currentTime;
+            $request->session()->get('two_factor_confirming_at', 0) !== $currentTime;
     }
 }

--- a/src/Http/Controllers/Inertia/CurrentUserController.php
+++ b/src/Http/Controllers/Inertia/CurrentUserController.php
@@ -4,6 +4,7 @@ namespace Laravel\Jetstream\Http\Controllers\Inertia;
 
 use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Illuminate\Routing\Controller;
 use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
@@ -14,12 +15,8 @@ class CurrentUserController extends Controller
 {
     /**
      * Delete the current user.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \Illuminate\Contracts\Auth\StatefulGuard  $guard
-     * @return \Illuminate\Http\Response
      */
-    public function destroy(Request $request, StatefulGuard $guard)
+    public function destroy(Request $request, StatefulGuard $guard): Response
     {
         $confirmed = app(ConfirmPassword::class)(
             $guard, $request->user(), $request->password

--- a/src/Http/Controllers/Inertia/OtherBrowserSessionsController.php
+++ b/src/Http/Controllers/Inertia/OtherBrowserSessionsController.php
@@ -2,7 +2,9 @@
 
 namespace Laravel\Jetstream\Http\Controllers\Inertia;
 
+use Illuminate\Auth\AuthenticationException;
 use Illuminate\Contracts\Auth\StatefulGuard;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\DB;
@@ -14,11 +16,9 @@ class OtherBrowserSessionsController extends Controller
     /**
      * Log out from other browser sessions.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \Illuminate\Contracts\Auth\StatefulGuard  $guard
-     * @return \Illuminate\Http\RedirectResponse
+     * @throws AuthenticationException
      */
-    public function destroy(Request $request, StatefulGuard $guard)
+    public function destroy(Request $request, StatefulGuard $guard): RedirectResponse
     {
         $confirmed = app(ConfirmPassword::class)(
             $guard, $request->user(), $request->password
@@ -39,11 +39,8 @@ class OtherBrowserSessionsController extends Controller
 
     /**
      * Delete the other browser session records from storage.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return void
      */
-    protected function deleteOtherSessionRecords(Request $request)
+    protected function deleteOtherSessionRecords(Request $request): void
     {
         if (config('session.driver') !== 'database') {
             return;

--- a/src/Http/Controllers/Inertia/PrivacyPolicyController.php
+++ b/src/Http/Controllers/Inertia/PrivacyPolicyController.php
@@ -6,17 +6,15 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Str;
 use Inertia\Inertia;
+use Inertia\Response;
 use Laravel\Jetstream\Jetstream;
 
 class PrivacyPolicyController extends Controller
 {
     /**
      * Show the privacy policy for the application.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Inertia\Response
      */
-    public function show(Request $request)
+    public function show(Request $request): Response
     {
         $policyFile = Jetstream::localizedMarkdownPath('policy.md');
 

--- a/src/Http/Controllers/Inertia/ProfilePhotoController.php
+++ b/src/Http/Controllers/Inertia/ProfilePhotoController.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Jetstream\Http\Controllers\Inertia;
 
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 
@@ -9,11 +10,8 @@ class ProfilePhotoController extends Controller
 {
     /**
      * Delete the current user's profile photo.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\RedirectResponse
      */
-    public function destroy(Request $request)
+    public function destroy(Request $request): RedirectResponse
     {
         $request->user()->deleteProfilePhoto();
 

--- a/src/Http/Controllers/Inertia/TeamController.php
+++ b/src/Http/Controllers/Inertia/TeamController.php
@@ -2,10 +2,13 @@
 
 namespace Laravel\Jetstream\Http\Controllers\Inertia;
 
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Illuminate\Routing\Redirector;
 use Illuminate\Support\Facades\Gate;
-use Inertia\Inertia;
+use Inertia\Response;
 use Laravel\Jetstream\Actions\ValidateTeamDeletion;
 use Laravel\Jetstream\Contracts\CreatesTeams;
 use Laravel\Jetstream\Contracts\DeletesTeams;
@@ -19,18 +22,14 @@ class TeamController extends Controller
 
     /**
      * Show the team management screen.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  int  $teamId
-     * @return \Inertia\Response
      */
-    public function show(Request $request, $teamId)
+    public function show(Request $request, int $teamId): Response
     {
         $team = Jetstream::newTeamModel()->findOrFail($teamId);
 
         Gate::authorize('view', $team);
 
-        return Jetstream::inertia()->render($request, 'Teams/Show', [
+        return Jetstream::inertia()?->render($request, 'Teams/Show', [
             'team' => $team->load('owner', 'users', 'teamInvitations'),
             'availableRoles' => array_values(Jetstream::$roles),
             'availablePermissions' => Jetstream::$permissions,
@@ -46,24 +45,18 @@ class TeamController extends Controller
 
     /**
      * Show the team creation screen.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Inertia\Response
      */
-    public function create(Request $request)
+    public function create(Request $request): Response
     {
         Gate::authorize('create', Jetstream::newTeamModel());
 
-        return Jetstream::inertia()->render($request, 'Teams/Create');
+        return Jetstream::inertia()?->render($request, 'Teams/Create');
     }
 
     /**
      * Create a new team.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\RedirectResponse
      */
-    public function store(Request $request)
+    public function store(Request $request): RedirectResponse|Response|Redirector
     {
         $creator = app(CreatesTeams::class);
 
@@ -74,12 +67,8 @@ class TeamController extends Controller
 
     /**
      * Update the given team's name.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  int  $teamId
-     * @return \Illuminate\Http\RedirectResponse
      */
-    public function update(Request $request, $teamId)
+    public function update(Request $request, int $teamId): RedirectResponse
     {
         $team = Jetstream::newTeamModel()->findOrFail($teamId);
 
@@ -91,11 +80,9 @@ class TeamController extends Controller
     /**
      * Delete the given team.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  int  $teamId
-     * @return \Illuminate\Http\RedirectResponse
+     * @throws AuthorizationException
      */
-    public function destroy(Request $request, $teamId)
+    public function destroy(Request $request, int $teamId): RedirectResponse|Response|Redirector
     {
         $team = Jetstream::newTeamModel()->findOrFail($teamId);
 

--- a/src/Http/Controllers/Inertia/TeamMemberController.php
+++ b/src/Http/Controllers/Inertia/TeamMemberController.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Jetstream\Http\Controllers\Inertia;
 
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Laravel\Jetstream\Actions\UpdateTeamMemberRole;
@@ -15,12 +16,8 @@ class TeamMemberController extends Controller
 {
     /**
      * Add a new team member to a team.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  int  $teamId
-     * @return \Illuminate\Http\RedirectResponse
      */
-    public function store(Request $request, $teamId)
+    public function store(Request $request, int $teamId): RedirectResponse
     {
         $team = Jetstream::newTeamModel()->findOrFail($teamId);
 
@@ -45,13 +42,8 @@ class TeamMemberController extends Controller
 
     /**
      * Update the given team member's role.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  int  $teamId
-     * @param  int  $userId
-     * @return \Illuminate\Http\RedirectResponse
      */
-    public function update(Request $request, $teamId, $userId)
+    public function update(Request $request, int $teamId, int $userId): RedirectResponse
     {
         app(UpdateTeamMemberRole::class)->update(
             $request->user(),
@@ -65,13 +57,8 @@ class TeamMemberController extends Controller
 
     /**
      * Remove the given user from the given team.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  int  $teamId
-     * @param  int  $userId
-     * @return \Illuminate\Http\RedirectResponse
      */
-    public function destroy(Request $request, $teamId, $userId)
+    public function destroy(Request $request, int $teamId, int $userId): RedirectResponse
     {
         $team = Jetstream::newTeamModel()->findOrFail($teamId);
 

--- a/src/Http/Controllers/Inertia/TermsOfServiceController.php
+++ b/src/Http/Controllers/Inertia/TermsOfServiceController.php
@@ -6,17 +6,15 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Str;
 use Inertia\Inertia;
+use Inertia\Response;
 use Laravel\Jetstream\Jetstream;
 
 class TermsOfServiceController extends Controller
 {
     /**
      * Show the terms of service for the application.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Inertia\Response
      */
-    public function show(Request $request)
+    public function show(Request $request): Response
     {
         $termsFile = Jetstream::localizedMarkdownPath('terms.md');
 

--- a/src/Http/Controllers/Inertia/UserProfileController.php
+++ b/src/Http/Controllers/Inertia/UserProfileController.php
@@ -5,10 +5,10 @@ namespace Laravel\Jetstream\Http\Controllers\Inertia;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
+use Inertia\Response;
 use Jenssegers\Agent\Agent;
-use Laravel\Fortify\Actions\DisableTwoFactorAuthentication;
 use Laravel\Fortify\Features;
 use Laravel\Jetstream\Jetstream;
 
@@ -18,15 +18,12 @@ class UserProfileController extends Controller
 
     /**
      * Show the general profile settings screen.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Inertia\Response
      */
-    public function show(Request $request)
+    public function show(Request $request): Response
     {
         $this->validateTwoFactorAuthenticationState($request);
 
-        return Jetstream::inertia()->render($request, 'Profile/Show', [
+        return Jetstream::inertia()?->render($request, 'Profile/Show', [
             'confirmsTwoFactorAuthentication' => Features::optionEnabled(Features::twoFactorAuthentication(), 'confirm'),
             'sessions' => $this->sessions($request)->all(),
         ]);
@@ -34,11 +31,8 @@ class UserProfileController extends Controller
 
     /**
      * Get the current sessions.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Support\Collection
      */
-    public function sessions(Request $request)
+    public function sessions(Request $request): Collection
     {
         if (config('session.driver') !== 'database') {
             return collect();
@@ -67,11 +61,8 @@ class UserProfileController extends Controller
 
     /**
      * Create a new agent instance from the given session.
-     *
-     * @param  mixed  $session
-     * @return \Jenssegers\Agent\Agent
      */
-    protected function createAgent($session)
+    protected function createAgent(mixed $session): Agent
     {
         return tap(new Agent, function ($agent) use ($session) {
             $agent->setUserAgent($session->user_agent);

--- a/src/Http/Controllers/Livewire/ApiTokenController.php
+++ b/src/Http/Controllers/Livewire/ApiTokenController.php
@@ -4,16 +4,14 @@ namespace Laravel\Jetstream\Http\Controllers\Livewire;
 
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Illuminate\View\View;
 
 class ApiTokenController extends Controller
 {
     /**
      * Show the user API token screen.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\View\View
      */
-    public function index(Request $request)
+    public function index(Request $request): View
     {
         return view('api.index', [
             'request' => $request,

--- a/src/Http/Controllers/Livewire/PrivacyPolicyController.php
+++ b/src/Http/Controllers/Livewire/PrivacyPolicyController.php
@@ -5,17 +5,15 @@ namespace Laravel\Jetstream\Http\Controllers\Livewire;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Str;
+use Illuminate\View\View;
 use Laravel\Jetstream\Jetstream;
 
 class PrivacyPolicyController extends Controller
 {
     /**
      * Show the privacy policy for the application.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\View\View
      */
-    public function show(Request $request)
+    public function show(Request $request): View
     {
         $policyFile = Jetstream::localizedMarkdownPath('policy.md');
 

--- a/src/Http/Controllers/Livewire/TeamController.php
+++ b/src/Http/Controllers/Livewire/TeamController.php
@@ -5,18 +5,15 @@ namespace Laravel\Jetstream\Http\Controllers\Livewire;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\View\View;
 use Laravel\Jetstream\Jetstream;
 
 class TeamController extends Controller
 {
     /**
      * Show the team management screen.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  int  $teamId
-     * @return \Illuminate\View\View
      */
-    public function show(Request $request, $teamId)
+    public function show(Request $request, $teamId): View
     {
         $team = Jetstream::newTeamModel()->findOrFail($teamId);
 
@@ -32,11 +29,8 @@ class TeamController extends Controller
 
     /**
      * Show the team creation screen.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\View\View
      */
-    public function create(Request $request)
+    public function create(Request $request): View
     {
         Gate::authorize('create', Jetstream::newTeamModel());
 

--- a/src/Http/Controllers/Livewire/TermsOfServiceController.php
+++ b/src/Http/Controllers/Livewire/TermsOfServiceController.php
@@ -5,17 +5,15 @@ namespace Laravel\Jetstream\Http\Controllers\Livewire;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Str;
+use Illuminate\View\View;
 use Laravel\Jetstream\Jetstream;
 
 class TermsOfServiceController extends Controller
 {
     /**
      * Show the terms of service for the application.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\View\View
      */
-    public function show(Request $request)
+    public function show(Request $request): View
     {
         $termsFile = Jetstream::localizedMarkdownPath('terms.md');
 

--- a/src/Http/Controllers/Livewire/UserProfileController.php
+++ b/src/Http/Controllers/Livewire/UserProfileController.php
@@ -4,16 +4,14 @@ namespace Laravel\Jetstream\Http\Controllers\Livewire;
 
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Illuminate\View\View;
 
 class UserProfileController extends Controller
 {
     /**
      * Show the user profile screen.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\View\View
      */
-    public function show(Request $request)
+    public function show(Request $request): View
     {
         return view('profile.show', [
             'request' => $request,

--- a/src/Http/Controllers/TeamInvitationController.php
+++ b/src/Http/Controllers/TeamInvitationController.php
@@ -3,6 +3,7 @@
 namespace Laravel\Jetstream\Http\Controllers;
 
 use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Gate;
@@ -13,12 +14,8 @@ class TeamInvitationController extends Controller
 {
     /**
      * Accept a team invitation.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  int  $invitationId
-     * @return \Illuminate\Http\RedirectResponse
      */
-    public function accept(Request $request, $invitationId)
+    public function accept(Request $request, int $invitationId): RedirectResponse
     {
         $model = Jetstream::teamInvitationModel();
 
@@ -41,11 +38,9 @@ class TeamInvitationController extends Controller
     /**
      * Cancel the given team invitation.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  int  $invitationId
-     * @return \Illuminate\Http\RedirectResponse
+     * @throws AuthorizationException
      */
-    public function destroy(Request $request, $invitationId)
+    public function destroy(Request $request, int $invitationId): RedirectResponse
     {
         $model = Jetstream::teamInvitationModel();
 

--- a/src/Http/Livewire/ApiTokenManager.php
+++ b/src/Http/Livewire/ApiTokenManager.php
@@ -2,90 +2,75 @@
 
 namespace Laravel\Jetstream\Http\Livewire;
 
+use App\Models\User;
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\View\View;
 use Laravel\Jetstream\Jetstream;
+use Laravel\Sanctum\NewAccessToken;
+use Laravel\Sanctum\PersonalAccessToken;
 use Livewire\Component;
 
 class ApiTokenManager extends Component
 {
     /**
      * The create API token form state.
-     *
-     * @var array
      */
-    public $createApiTokenForm = [
+    public array $createApiTokenForm = [
         'name' => '',
         'permissions' => [],
     ];
 
     /**
      * Indicates if the plain text token is being displayed to the user.
-     *
-     * @var bool
      */
-    public $displayingToken = false;
+    public bool $displayingToken = false;
 
     /**
      * The plain text token value.
-     *
-     * @var string|null
      */
-    public $plainTextToken;
+    public string|null $plainTextToken;
 
     /**
      * Indicates if the user is currently managing an API token's permissions.
-     *
-     * @var bool
      */
-    public $managingApiTokenPermissions = false;
+    public bool $managingApiTokenPermissions = false;
 
     /**
      * The token that is currently having its permissions managed.
-     *
-     * @var \Laravel\Sanctum\PersonalAccessToken|null
      */
-    public $managingPermissionsFor;
+    public PersonalAccessToken|null $managingPermissionsFor;
 
     /**
      * The update API token form state.
-     *
-     * @var array
      */
-    public $updateApiTokenForm = [
+    public array $updateApiTokenForm = [
         'permissions' => [],
     ];
 
     /**
      * Indicates if the application is confirming if an API token should be deleted.
-     *
-     * @var bool
      */
-    public $confirmingApiTokenDeletion = false;
+    public bool $confirmingApiTokenDeletion = false;
 
     /**
      * The ID of the API token being deleted.
-     *
-     * @var int
      */
-    public $apiTokenIdBeingDeleted;
+    public int $apiTokenIdBeingDeleted;
 
     /**
      * Mount the component.
-     *
-     * @return void
      */
-    public function mount()
+    public function mount(): void
     {
         $this->createApiTokenForm['permissions'] = Jetstream::$defaultPermissions;
     }
 
     /**
      * Create a new API token.
-     *
-     * @return void
      */
-    public function createApiToken()
+    public function createApiToken(): void
     {
         $this->resetErrorBag();
 
@@ -108,11 +93,8 @@ class ApiTokenManager extends Component
 
     /**
      * Display the token value to the user.
-     *
-     * @param  \Laravel\Sanctum\NewAccessToken  $token
-     * @return void
      */
-    protected function displayTokenValue($token)
+    protected function displayTokenValue(NewAccessToken $token): void
     {
         $this->displayingToken = true;
 
@@ -123,11 +105,8 @@ class ApiTokenManager extends Component
 
     /**
      * Allow the given token's permissions to be managed.
-     *
-     * @param  int  $tokenId
-     * @return void
      */
-    public function manageApiTokenPermissions($tokenId)
+    public function manageApiTokenPermissions(int $tokenId): void
     {
         $this->managingApiTokenPermissions = true;
 
@@ -140,10 +119,8 @@ class ApiTokenManager extends Component
 
     /**
      * Update the API token's permissions.
-     *
-     * @return void
      */
-    public function updateApiToken()
+    public function updateApiToken(): void
     {
         $this->managingPermissionsFor->forceFill([
             'abilities' => Jetstream::validPermissions($this->updateApiTokenForm['permissions']),
@@ -154,11 +131,8 @@ class ApiTokenManager extends Component
 
     /**
      * Confirm that the given API token should be deleted.
-     *
-     * @param  int  $tokenId
-     * @return void
      */
-    public function confirmApiTokenDeletion($tokenId)
+    public function confirmApiTokenDeletion(int $tokenId): void
     {
         $this->confirmingApiTokenDeletion = true;
 
@@ -167,10 +141,8 @@ class ApiTokenManager extends Component
 
     /**
      * Delete the API token.
-     *
-     * @return void
      */
-    public function deleteApiToken()
+    public function deleteApiToken(): void
     {
         $this->user->tokens()->where('id', $this->apiTokenIdBeingDeleted)->first()->delete();
 
@@ -183,20 +155,16 @@ class ApiTokenManager extends Component
 
     /**
      * Get the current user of the application.
-     *
-     * @return mixed
      */
-    public function getUserProperty()
+    public function getUserProperty(): User|Authenticatable|null
     {
         return Auth::user();
     }
 
     /**
      * Render the component.
-     *
-     * @return \Illuminate\View\View
      */
-    public function render()
+    public function render(): View
     {
         return view('api.api-token-manager');
     }

--- a/src/Http/Livewire/CreateTeamForm.php
+++ b/src/Http/Livewire/CreateTeamForm.php
@@ -2,7 +2,13 @@
 
 namespace Laravel\Jetstream\Http\Livewire;
 
+use App\Models\User;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Response;
+use Illuminate\Routing\Redirector;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\View\View;
 use Laravel\Jetstream\Contracts\CreatesTeams;
 use Laravel\Jetstream\RedirectsActions;
 use Livewire\Component;
@@ -13,18 +19,13 @@ class CreateTeamForm extends Component
 
     /**
      * The component's state.
-     *
-     * @var array
      */
-    public $state = [];
+    public array $state = [];
 
     /**
      * Create a new team.
-     *
-     * @param  \Laravel\Jetstream\Contracts\CreatesTeams  $creator
-     * @return void
      */
-    public function createTeam(CreatesTeams $creator)
+    public function createTeam(CreatesTeams $creator): Response|Redirector|RedirectResponse
     {
         $this->resetErrorBag();
 
@@ -35,20 +36,16 @@ class CreateTeamForm extends Component
 
     /**
      * Get the current user of the application.
-     *
-     * @return mixed
      */
-    public function getUserProperty()
+    public function getUserProperty(): User|Authenticatable|null
     {
         return Auth::user();
     }
 
     /**
      * Render the component.
-     *
-     * @return \Illuminate\View\View
      */
-    public function render()
+    public function render(): View
     {
         return view('teams.create-team-form');
     }

--- a/src/Http/Livewire/DeleteTeamForm.php
+++ b/src/Http/Livewire/DeleteTeamForm.php
@@ -2,7 +2,12 @@
 
 namespace Laravel\Jetstream\Http\Livewire;
 
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Response;
+use Illuminate\Routing\Redirector;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\View\View;
 use Laravel\Jetstream\Actions\ValidateTeamDeletion;
 use Laravel\Jetstream\Contracts\DeletesTeams;
 use Laravel\Jetstream\RedirectsActions;
@@ -14,25 +19,18 @@ class DeleteTeamForm extends Component
 
     /**
      * The team instance.
-     *
-     * @var mixed
      */
-    public $team;
+    public mixed $team;
 
     /**
      * Indicates if team deletion is being confirmed.
-     *
-     * @var bool
      */
-    public $confirmingTeamDeletion = false;
+    public bool $confirmingTeamDeletion = false;
 
     /**
      * Mount the component.
-     *
-     * @param  mixed  $team
-     * @return void
      */
-    public function mount($team)
+    public function mount(mixed $team): void
     {
         $this->team = $team;
     }
@@ -40,11 +38,9 @@ class DeleteTeamForm extends Component
     /**
      * Delete the team.
      *
-     * @param  \Laravel\Jetstream\Actions\ValidateTeamDeletion  $validator
-     * @param  \Laravel\Jetstream\Contracts\DeletesTeams  $deleter
-     * @return void
+     * @throws AuthorizationException
      */
-    public function deleteTeam(ValidateTeamDeletion $validator, DeletesTeams $deleter)
+    public function deleteTeam(ValidateTeamDeletion $validator, DeletesTeams $deleter): Response|Redirector|RedirectResponse
     {
         $validator->validate(Auth::user(), $this->team);
 
@@ -55,10 +51,8 @@ class DeleteTeamForm extends Component
 
     /**
      * Render the component.
-     *
-     * @return \Illuminate\View\View
      */
-    public function render()
+    public function render(): View
     {
         return view('teams.delete-team-form');
     }

--- a/src/Http/Livewire/DeleteUserForm.php
+++ b/src/Http/Livewire/DeleteUserForm.php
@@ -3,10 +3,13 @@
 namespace Laravel\Jetstream\Http\Livewire;
 
 use Illuminate\Contracts\Auth\StatefulGuard;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Routing\Redirector;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\ValidationException;
+use Illuminate\View\View;
 use Laravel\Jetstream\Contracts\DeletesUsers;
 use Livewire\Component;
 
@@ -14,24 +17,18 @@ class DeleteUserForm extends Component
 {
     /**
      * Indicates if user deletion is being confirmed.
-     *
-     * @var bool
      */
-    public $confirmingUserDeletion = false;
+    public bool $confirmingUserDeletion = false;
 
     /**
      * The user's current password.
-     *
-     * @var string
      */
-    public $password = '';
+    public string $password = '';
 
     /**
      * Confirm that the user would like to delete their account.
-     *
-     * @return void
      */
-    public function confirmUserDeletion()
+    public function confirmUserDeletion(): void
     {
         $this->resetErrorBag();
 
@@ -44,13 +41,8 @@ class DeleteUserForm extends Component
 
     /**
      * Delete the current user.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \Laravel\Jetstream\Contracts\DeletesUsers  $deleter
-     * @param  \Illuminate\Contracts\Auth\StatefulGuard  $auth
-     * @return \Illuminate\Routing\Redirector|\Illuminate\Http\RedirectResponse
      */
-    public function deleteUser(Request $request, DeletesUsers $deleter, StatefulGuard $auth)
+    public function deleteUser(Request $request, DeletesUsers $deleter, StatefulGuard $auth): Redirector|RedirectResponse
     {
         $this->resetErrorBag();
 
@@ -60,7 +52,7 @@ class DeleteUserForm extends Component
             ]);
         }
 
-        $deleter->delete(Auth::user()->fresh());
+        $deleter->delete(Auth::user()?->fresh());
 
         $auth->logout();
 
@@ -74,10 +66,8 @@ class DeleteUserForm extends Component
 
     /**
      * Render the component.
-     *
-     * @return \Illuminate\View\View
      */
-    public function render()
+    public function render(): View
     {
         return view('profile.delete-user-form');
     }

--- a/src/Http/Livewire/NavigationMenu.php
+++ b/src/Http/Livewire/NavigationMenu.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Jetstream\Http\Livewire;
 
+use Illuminate\View\View;
 use Livewire\Component;
 
 class NavigationMenu extends Component
@@ -9,7 +10,7 @@ class NavigationMenu extends Component
     /**
      * The component's listeners.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $listeners = [
         'refresh-navigation-menu' => '$refresh',
@@ -17,10 +18,8 @@ class NavigationMenu extends Component
 
     /**
      * Render the component.
-     *
-     * @return \Illuminate\View\View
      */
-    public function render()
+    public function render(): View
     {
         return view('navigation-menu');
     }

--- a/src/Http/Livewire/TwoFactorAuthenticationForm.php
+++ b/src/Http/Livewire/TwoFactorAuthenticationForm.php
@@ -2,7 +2,10 @@
 
 namespace Laravel\Jetstream\Http\Livewire;
 
+use App\Models\User;
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\View\View;
 use Laravel\Fortify\Actions\ConfirmTwoFactorAuthentication;
 use Laravel\Fortify\Actions\DisableTwoFactorAuthentication;
 use Laravel\Fortify\Actions\EnableTwoFactorAuthentication;
@@ -16,53 +19,40 @@ class TwoFactorAuthenticationForm extends Component
     use ConfirmsPasswords;
 
     /**
-     * Indicates if two factor authentication QR code is being displayed.
-     *
-     * @var bool
+     * Indicates if two-factor authentication QR code is being displayed.
      */
-    public $showingQrCode = false;
+    public bool $showingQrCode = false;
 
     /**
-     * Indicates if the two factor authentication confirmation input and button are being displayed.
-     *
-     * @var bool
+     * Indicates if the two-factor authentication confirmation input and button are being displayed.
      */
-    public $showingConfirmation = false;
+    public bool $showingConfirmation = false;
 
     /**
-     * Indicates if two factor authentication recovery codes are being displayed.
-     *
-     * @var bool
+     * Indicates if two-factor authentication recovery codes are being displayed.
      */
-    public $showingRecoveryCodes = false;
+    public bool $showingRecoveryCodes = false;
 
     /**
-     * The OTP code for confirming two factor authentication.
-     *
-     * @var string|null
+     * The OTP code for confirming two-factor authentication.
      */
-    public $code;
+    public string|null $code;
 
     /**
      * Mount the component.
-     *
-     * @return void
      */
-    public function mount()
+    public function mount(): void
     {
-        if (Features::optionEnabled(Features::twoFactorAuthentication(), 'confirm') &&
-            is_null(Auth::user()->two_factor_confirmed_at)) {
+        if (is_null(Auth::user()->two_factor_confirmed_at) &&
+            Features::optionEnabled(Features::twoFactorAuthentication(), 'confirm')) {
             app(DisableTwoFactorAuthentication::class)(Auth::user());
         }
     }
 
     /**
-     * Enable two factor authentication for the user.
-     *
-     * @param  \Laravel\Fortify\Actions\EnableTwoFactorAuthentication  $enable
-     * @return void
+     * Enable two-factor authentication for the user.
      */
-    public function enableTwoFactorAuthentication(EnableTwoFactorAuthentication $enable)
+    public function enableTwoFactorAuthentication(EnableTwoFactorAuthentication $enable): void
     {
         if (Features::optionEnabled(Features::twoFactorAuthentication(), 'confirmPassword')) {
             $this->ensurePasswordIsConfirmed();
@@ -80,12 +70,9 @@ class TwoFactorAuthenticationForm extends Component
     }
 
     /**
-     * Confirm two factor authentication for the user.
-     *
-     * @param  \Laravel\Fortify\Actions\ConfirmTwoFactorAuthentication  $confirm
-     * @return void
+     * Confirm two-factor authentication for the user.
      */
-    public function confirmTwoFactorAuthentication(ConfirmTwoFactorAuthentication $confirm)
+    public function confirmTwoFactorAuthentication(ConfirmTwoFactorAuthentication $confirm): void
     {
         if (Features::optionEnabled(Features::twoFactorAuthentication(), 'confirmPassword')) {
             $this->ensurePasswordIsConfirmed();
@@ -100,10 +87,8 @@ class TwoFactorAuthenticationForm extends Component
 
     /**
      * Display the user's recovery codes.
-     *
-     * @return void
      */
-    public function showRecoveryCodes()
+    public function showRecoveryCodes(): void
     {
         if (Features::optionEnabled(Features::twoFactorAuthentication(), 'confirmPassword')) {
             $this->ensurePasswordIsConfirmed();
@@ -114,11 +99,8 @@ class TwoFactorAuthenticationForm extends Component
 
     /**
      * Generate new recovery codes for the user.
-     *
-     * @param  \Laravel\Fortify\Actions\GenerateNewRecoveryCodes  $generate
-     * @return void
      */
-    public function regenerateRecoveryCodes(GenerateNewRecoveryCodes $generate)
+    public function regenerateRecoveryCodes(GenerateNewRecoveryCodes $generate): void
     {
         if (Features::optionEnabled(Features::twoFactorAuthentication(), 'confirmPassword')) {
             $this->ensurePasswordIsConfirmed();
@@ -130,12 +112,9 @@ class TwoFactorAuthenticationForm extends Component
     }
 
     /**
-     * Disable two factor authentication for the user.
-     *
-     * @param  \Laravel\Fortify\Actions\DisableTwoFactorAuthentication  $disable
-     * @return void
+     * Disable two-factor authentication for the user.
      */
-    public function disableTwoFactorAuthentication(DisableTwoFactorAuthentication $disable)
+    public function disableTwoFactorAuthentication(DisableTwoFactorAuthentication $disable): void
     {
         if (Features::optionEnabled(Features::twoFactorAuthentication(), 'confirmPassword')) {
             $this->ensurePasswordIsConfirmed();
@@ -150,30 +129,24 @@ class TwoFactorAuthenticationForm extends Component
 
     /**
      * Get the current user of the application.
-     *
-     * @return mixed
      */
-    public function getUserProperty()
+    public function getUserProperty(): User|Authenticatable|null
     {
         return Auth::user();
     }
 
     /**
-     * Determine if two factor authentication is enabled.
-     *
-     * @return bool
+     * Determine if two-factor authentication is enabled.
      */
-    public function getEnabledProperty()
+    public function getEnabledProperty(): bool
     {
         return ! empty($this->user->two_factor_secret);
     }
 
     /**
      * Render the component.
-     *
-     * @return \Illuminate\View\View
      */
-    public function render()
+    public function render(): View
     {
         return view('profile.two-factor-authentication-form');
     }

--- a/src/Http/Livewire/UpdatePasswordForm.php
+++ b/src/Http/Livewire/UpdatePasswordForm.php
@@ -2,7 +2,10 @@
 
 namespace Laravel\Jetstream\Http\Livewire;
 
+use App\Models\User;
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\View\View;
 use Laravel\Fortify\Contracts\UpdatesUserPasswords;
 use Livewire\Component;
 
@@ -11,7 +14,7 @@ class UpdatePasswordForm extends Component
     /**
      * The component's state.
      *
-     * @var array
+     * @var array<string, mixed>
      */
     public $state = [
         'current_password' => '',
@@ -21,19 +24,16 @@ class UpdatePasswordForm extends Component
 
     /**
      * Update the user's password.
-     *
-     * @param  \Laravel\Fortify\Contracts\UpdatesUserPasswords  $updater
-     * @return void
      */
-    public function updatePassword(UpdatesUserPasswords $updater)
+    public function updatePassword(UpdatesUserPasswords $updater): void
     {
         $this->resetErrorBag();
 
         $updater->update(Auth::user(), $this->state);
 
-        if (request()->hasSession()) {
-            request()->session()->put([
-                'password_hash_'.Auth::getDefaultDriver() => Auth::user()->getAuthPassword(),
+        if (! is_null(session())) {
+            session()->put([
+                'password_hash_'.Auth::getDefaultDriver() => Auth::user()?->getAuthPassword(),
             ]);
         }
 
@@ -48,20 +48,16 @@ class UpdatePasswordForm extends Component
 
     /**
      * Get the current user of the application.
-     *
-     * @return mixed
      */
-    public function getUserProperty()
+    public function getUserProperty(): User|Authenticatable|null
     {
         return Auth::user();
     }
 
     /**
      * Render the component.
-     *
-     * @return \Illuminate\View\View
      */
-    public function render()
+    public function render(): View
     {
         return view('profile.update-password-form');
     }

--- a/src/Http/Livewire/UpdateProfileInformationForm.php
+++ b/src/Http/Livewire/UpdateProfileInformationForm.php
@@ -2,7 +2,12 @@
 
 namespace Laravel\Jetstream\Http\Livewire;
 
+use App\Models\User;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Routing\Redirector;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\View\View;
 use Laravel\Fortify\Contracts\UpdatesUserProfileInformation;
 use Livewire\Component;
 use Livewire\WithFileUploads;
@@ -13,42 +18,31 @@ class UpdateProfileInformationForm extends Component
 
     /**
      * The component's state.
-     *
-     * @var array
      */
-    public $state = [];
+    public array $state = [];
 
     /**
      * The new avatar for the user.
-     *
-     * @var mixed
      */
     public $photo;
 
     /**
      * Determine if the verification email was sent.
-     *
-     * @var bool
      */
-    public $verificationLinkSent = false;
+    public bool $verificationLinkSent = false;
 
     /**
      * Prepare the component.
-     *
-     * @return void
      */
-    public function mount()
+    public function mount(): void
     {
-        $this->state = Auth::user()->withoutRelations()->toArray();
+        $this->state = Auth::user()?->withoutRelations()->toArray();
     }
 
     /**
      * Update the user's profile information.
-     *
-     * @param  \Laravel\Fortify\Contracts\UpdatesUserProfileInformation  $updater
-     * @return void
      */
-    public function updateProfileInformation(UpdatesUserProfileInformation $updater)
+    public function updateProfileInformation(UpdatesUserProfileInformation $updater): Redirector|RedirectResponse
     {
         $this->resetErrorBag();
 
@@ -66,48 +60,42 @@ class UpdateProfileInformationForm extends Component
         $this->emit('saved');
 
         $this->emit('refresh-navigation-menu');
+
+        return redirect()->back(303);
     }
 
     /**
      * Delete user's profile photo.
-     *
-     * @return void
      */
-    public function deleteProfilePhoto()
+    public function deleteProfilePhoto(): void
     {
-        Auth::user()->deleteProfilePhoto();
+        Auth::user()?->deleteProfilePhoto();
 
         $this->emit('refresh-navigation-menu');
     }
 
     /**
      * Sent the email verification.
-     *
-     * @return void
      */
-    public function sendEmailVerification()
+    public function sendEmailVerification(): void
     {
-        Auth::user()->sendEmailVerificationNotification();
+        Auth::user()?->sendEmailVerificationNotification();
 
         $this->verificationLinkSent = true;
     }
 
     /**
      * Get the current user of the application.
-     *
-     * @return mixed
      */
-    public function getUserProperty()
+    public function getUserProperty(): User|Authenticatable|null
     {
         return Auth::user();
     }
 
     /**
      * Render the component.
-     *
-     * @return \Illuminate\View\View
      */
-    public function render()
+    public function render(): View
     {
         return view('profile.update-profile-information-form');
     }

--- a/src/Http/Livewire/UpdateTeamNameForm.php
+++ b/src/Http/Livewire/UpdateTeamNameForm.php
@@ -2,7 +2,10 @@
 
 namespace Laravel\Jetstream\Http\Livewire;
 
+use App\Models\User;
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\View\View;
 use Laravel\Jetstream\Contracts\UpdatesTeamNames;
 use Livewire\Component;
 
@@ -10,25 +13,18 @@ class UpdateTeamNameForm extends Component
 {
     /**
      * The team instance.
-     *
-     * @var mixed
      */
-    public $team;
+    public mixed $team;
 
     /**
      * The component's state.
-     *
-     * @var array
      */
-    public $state = [];
+    public array $state = [];
 
     /**
      * Mount the component.
-     *
-     * @param  mixed  $team
-     * @return void
      */
-    public function mount($team)
+    public function mount(mixed $team): void
     {
         $this->team = $team;
 
@@ -37,11 +33,8 @@ class UpdateTeamNameForm extends Component
 
     /**
      * Update the team's name.
-     *
-     * @param  \Laravel\Jetstream\Contracts\UpdatesTeamNames  $updater
-     * @return void
      */
-    public function updateTeamName(UpdatesTeamNames $updater)
+    public function updateTeamName(UpdatesTeamNames $updater): void
     {
         $this->resetErrorBag();
 
@@ -54,20 +47,16 @@ class UpdateTeamNameForm extends Component
 
     /**
      * Get the current user of the application.
-     *
-     * @return mixed
      */
-    public function getUserProperty()
+    public function getUserProperty(): User|Authenticatable|null
     {
         return Auth::user();
     }
 
     /**
      * Render the component.
-     *
-     * @return \Illuminate\View\View
      */
-    public function render()
+    public function render(): View
     {
         return view('teams.update-team-name-form');
     }

--- a/src/Http/Middleware/AuthenticateSession.php
+++ b/src/Http/Middleware/AuthenticateSession.php
@@ -2,6 +2,8 @@
 
 namespace Laravel\Jetstream\Http\Middleware;
 
+use Illuminate\Contracts\Auth\Factory;
+use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Session\Middleware\AuthenticateSession as BaseAuthenticateSession;
 
@@ -9,10 +11,8 @@ class AuthenticateSession extends BaseAuthenticateSession
 {
     /**
      * Get the guard instance that should be used by the middleware.
-     *
-     * @return \Illuminate\Contracts\Auth\Factory|\Illuminate\Contracts\Auth\Guard
      */
-    protected function guard()
+    protected function guard(): Guard|Factory
     {
         return app(StatefulGuard::class);
     }

--- a/src/InteractsWithBanner.php
+++ b/src/InteractsWithBanner.php
@@ -6,11 +6,8 @@ trait InteractsWithBanner
 {
     /**
      * Update the banner message.
-     *
-     * @param  string  $message
-     * @return void
      */
-    protected function banner($message)
+    protected function banner(string $message): void
     {
         $this->dispatchBrowserEvent('banner-message', [
             'style' => 'success',
@@ -19,12 +16,9 @@ trait InteractsWithBanner
     }
 
     /**
-     * Update the banner message with an danger / error message.
-     *
-     * @param  string  $message
-     * @return void
+     * Update the banner message with a danger / error message.
      */
-    protected function dangerBanner($message)
+    protected function dangerBanner(string $message): void
     {
         $this->dispatchBrowserEvent('banner-message', [
             'style' => 'danger',

--- a/src/Jetstream.php
+++ b/src/Jetstream.php
@@ -57,7 +57,7 @@ class Jetstream
     /**
      * The Inertia manager instance.
      */
-    public static InertiaManager $inertiaManager;
+    public static ?InertiaManager $inertiaManager = null;
 
     /**
      * Determine if Jetstream has registered roles.
@@ -344,7 +344,7 @@ class Jetstream
     /**
      * Manage Jetstream's Inertia settings.
      */
-    public static function inertia(): InertiaManager
+    public static function inertia(): ?InertiaManager
     {
         if (is_null(static::$inertiaManager)) {
             static::$inertiaManager = new InertiaManager;

--- a/src/Jetstream.php
+++ b/src/Jetstream.php
@@ -16,97 +16,69 @@ class Jetstream
 {
     /**
      * Indicates if Jetstream routes will be registered.
-     *
-     * @var bool
      */
-    public static $registersRoutes = true;
+    public static bool $registersRoutes = true;
 
     /**
      * The roles that are available to assign to users.
-     *
-     * @var array
      */
-    public static $roles = [];
+    public static array $roles = [];
 
     /**
      * The permissions that exist within the application.
-     *
-     * @var array
      */
-    public static $permissions = [];
+    public static array $permissions = [];
 
     /**
      * The default permissions that should be available to new entities.
-     *
-     * @var array
      */
-    public static $defaultPermissions = [];
+    public static array $defaultPermissions = [];
 
     /**
      * The user model that should be used by Jetstream.
-     *
-     * @var string
      */
-    public static $userModel = 'App\\Models\\User';
+    public static string $userModel = 'App\\Models\\User';
 
     /**
      * The team model that should be used by Jetstream.
-     *
-     * @var string
      */
-    public static $teamModel = 'App\\Models\\Team';
+    public static string $teamModel = 'App\\Models\\Team';
 
     /**
      * The membership model that should be used by Jetstream.
-     *
-     * @var string
      */
-    public static $membershipModel = 'App\\Models\\Membership';
+    public static string $membershipModel = 'App\\Models\\Membership';
 
     /**
      * The team invitation model that should be used by Jetstream.
-     *
-     * @var string
      */
-    public static $teamInvitationModel = 'App\\Models\\TeamInvitation';
+    public static string $teamInvitationModel = 'App\\Models\\TeamInvitation';
 
     /**
      * The Inertia manager instance.
-     *
-     * @var \Laravel\Jetstream\InertiaManager
      */
-    public static $inertiaManager;
+    public static InertiaManager $inertiaManager;
 
     /**
      * Determine if Jetstream has registered roles.
-     *
-     * @return bool
      */
-    public static function hasRoles()
+    public static function hasRoles(): bool
     {
         return count(static::$roles) > 0;
     }
 
     /**
      * Find the role with the given key.
-     *
-     * @param  string  $key
-     * @return \Laravel\Jetstream\Role
      */
-    public static function findRole(string $key)
+    public static function findRole(string $key): Role|null
     {
         return static::$roles[$key] ?? null;
     }
 
     /**
      * Define a role.
-     *
-     * @param  string  $key
-     * @param  string  $name
-     * @param  array  $permissions
-     * @return \Laravel\Jetstream\Role
      */
-    public static function role(string $key, string $name, array $permissions)
+    public static function role(string $key, string $name, array $permissions): Role
     {
         static::$permissions = collect(array_merge(static::$permissions, $permissions))
                                     ->unique()
@@ -121,21 +93,16 @@ class Jetstream
 
     /**
      * Determine if any permissions have been registered with Jetstream.
-     *
-     * @return bool
      */
-    public static function hasPermissions()
+    public static function hasPermissions(): bool
     {
         return count(static::$permissions) > 0;
     }
 
     /**
      * Define the available API token permissions.
-     *
-     * @param  array  $permissions
-     * @return static
      */
-    public static function permissions(array $permissions)
+    public static function permissions(array $permissions): static
     {
         static::$permissions = $permissions;
 
@@ -144,11 +111,8 @@ class Jetstream
 
     /**
      * Define the default permissions that should be available to new API tokens.
-     *
-     * @param  array  $permissions
-     * @return static
      */
-    public static function defaultApiTokenPermissions(array $permissions)
+    public static function defaultApiTokenPermissions(array $permissions): static
     {
         static::$defaultPermissions = $permissions;
 
@@ -157,52 +121,40 @@ class Jetstream
 
     /**
      * Return the permissions in the given list that are actually defined permissions for the application.
-     *
-     * @param  array  $permissions
-     * @return array
      */
-    public static function validPermissions(array $permissions)
+    public static function validPermissions(array $permissions): array
     {
         return array_values(array_intersect($permissions, static::$permissions));
     }
 
     /**
      * Determine if Jetstream is managing profile photos.
-     *
-     * @return bool
      */
-    public static function managesProfilePhotos()
+    public static function managesProfilePhotos(): bool
     {
         return Features::managesProfilePhotos();
     }
 
     /**
      * Determine if Jetstream is supporting API features.
-     *
-     * @return bool
      */
-    public static function hasApiFeatures()
+    public static function hasApiFeatures(): bool
     {
         return Features::hasApiFeatures();
     }
 
     /**
      * Determine if Jetstream is supporting team features.
-     *
-     * @return bool
      */
-    public static function hasTeamFeatures()
+    public static function hasTeamFeatures(): bool
     {
         return Features::hasTeamFeatures();
     }
 
     /**
      * Determine if a given user model utilizes the "HasTeams" trait.
-     *
-     * @param  \Illuminate\Database\Eloquent\Model
-     * @return bool
      */
-    public static function userHasTeamFeatures($user)
+    public static function userHasTeamFeatures(Model $user): bool
     {
         return (array_key_exists(HasTeams::class, class_uses_recursive($user)) ||
                 method_exists($user, 'currentTeam')) &&
@@ -211,62 +163,48 @@ class Jetstream
 
     /**
      * Determine if the application is using the terms confirmation feature.
-     *
-     * @return bool
      */
-    public static function hasTermsAndPrivacyPolicyFeature()
+    public static function hasTermsAndPrivacyPolicyFeature(): bool
     {
         return Features::hasTermsAndPrivacyPolicyFeature();
     }
 
     /**
      * Determine if the application is using any account deletion features.
-     *
-     * @return bool
      */
-    public static function hasAccountDeletionFeatures()
+    public static function hasAccountDeletionFeatures(): bool
     {
         return Features::hasAccountDeletionFeatures();
     }
 
     /**
      * Find a user instance by the given ID.
-     *
-     * @param  int  $id
-     * @return mixed
      */
-    public static function findUserByIdOrFail($id)
+    public static function findUserByIdOrFail(int $id): mixed
     {
         return static::newUserModel()->where('id', $id)->firstOrFail();
     }
 
     /**
      * Find a user instance by the given email address or fail.
-     *
-     * @param  string  $email
-     * @return mixed
      */
-    public static function findUserByEmailOrFail(string $email)
+    public static function findUserByEmailOrFail(string $email): mixed
     {
         return static::newUserModel()->where('email', $email)->firstOrFail();
     }
 
     /**
      * Get the name of the user model used by the application.
-     *
-     * @return string
      */
-    public static function userModel()
+    public static function userModel(): string
     {
         return static::$userModel;
     }
 
     /**
      * Get a new instance of the user model.
-     *
-     * @return mixed
      */
-    public static function newUserModel()
+    public static function newUserModel(): mixed
     {
         $model = static::userModel();
 
@@ -275,11 +213,8 @@ class Jetstream
 
     /**
      * Specify the user model that should be used by Jetstream.
-     *
-     * @param  string  $model
-     * @return static
      */
-    public static function useUserModel(string $model)
+    public static function useUserModel(string $model): static
     {
         static::$userModel = $model;
 
@@ -288,20 +223,16 @@ class Jetstream
 
     /**
      * Get the name of the team model used by the application.
-     *
-     * @return string
      */
-    public static function teamModel()
+    public static function teamModel(): string
     {
         return static::$teamModel;
     }
 
     /**
      * Get a new instance of the team model.
-     *
-     * @return mixed
      */
-    public static function newTeamModel()
+    public static function newTeamModel(): mixed
     {
         $model = static::teamModel();
 
@@ -310,11 +241,8 @@ class Jetstream
 
     /**
      * Specify the team model that should be used by Jetstream.
-     *
-     * @param  string  $model
-     * @return static
      */
-    public static function useTeamModel(string $model)
+    public static function useTeamModel(string $model): static
     {
         static::$teamModel = $model;
 
@@ -323,21 +251,16 @@ class Jetstream
 
     /**
      * Get the name of the membership model used by the application.
-     *
-     * @return string
      */
-    public static function membershipModel()
+    public static function membershipModel(): string
     {
         return static::$membershipModel;
     }
 
     /**
      * Specify the membership model that should be used by Jetstream.
-     *
-     * @param  string  $model
-     * @return static
      */
-    public static function useMembershipModel(string $model)
+    public static function useMembershipModel(string $model): static
     {
         static::$membershipModel = $model;
 
@@ -346,21 +269,16 @@ class Jetstream
 
     /**
      * Get the name of the team invitation model used by the application.
-     *
-     * @return string
      */
-    public static function teamInvitationModel()
+    public static function teamInvitationModel(): string
     {
         return static::$teamInvitationModel;
     }
 
     /**
      * Specify the team invitation model that should be used by Jetstream.
-     *
-     * @param  string  $model
-     * @return static
      */
-    public static function useTeamInvitationModel(string $model)
+    public static function useTeamInvitationModel(string $model): static
     {
         static::$teamInvitationModel = $model;
 
@@ -369,87 +287,64 @@ class Jetstream
 
     /**
      * Register a class / callback that should be used to create teams.
-     *
-     * @param  string  $class
-     * @return void
      */
-    public static function createTeamsUsing(string $class)
+    public static function createTeamsUsing(string $class): void
     {
-        return app()->singleton(CreatesTeams::class, $class);
+        app()->singleton(CreatesTeams::class, $class);
     }
 
     /**
      * Register a class / callback that should be used to update team names.
-     *
-     * @param  string  $class
-     * @return void
      */
-    public static function updateTeamNamesUsing(string $class)
+    public static function updateTeamNamesUsing(string $class): void
     {
-        return app()->singleton(UpdatesTeamNames::class, $class);
+        app()->singleton(UpdatesTeamNames::class, $class);
     }
 
     /**
      * Register a class / callback that should be used to add team members.
-     *
-     * @param  string  $class
-     * @return void
      */
-    public static function addTeamMembersUsing(string $class)
+    public static function addTeamMembersUsing(string $class): void
     {
-        return app()->singleton(AddsTeamMembers::class, $class);
+        app()->singleton(AddsTeamMembers::class, $class);
     }
 
     /**
      * Register a class / callback that should be used to add team members.
-     *
-     * @param  string  $class
-     * @return void
      */
-    public static function inviteTeamMembersUsing(string $class)
+    public static function inviteTeamMembersUsing(string $class): void
     {
-        return app()->singleton(InvitesTeamMembers::class, $class);
+        app()->singleton(InvitesTeamMembers::class, $class);
     }
 
     /**
      * Register a class / callback that should be used to remove team members.
-     *
-     * @param  string  $class
-     * @return void
      */
-    public static function removeTeamMembersUsing(string $class)
+    public static function removeTeamMembersUsing(string $class): void
     {
-        return app()->singleton(RemovesTeamMembers::class, $class);
+        app()->singleton(RemovesTeamMembers::class, $class);
     }
 
     /**
      * Register a class / callback that should be used to delete teams.
-     *
-     * @param  string  $class
-     * @return void
      */
-    public static function deleteTeamsUsing(string $class)
+    public static function deleteTeamsUsing(string $class): void
     {
-        return app()->singleton(DeletesTeams::class, $class);
+        app()->singleton(DeletesTeams::class, $class);
     }
 
     /**
      * Register a class / callback that should be used to delete users.
-     *
-     * @param  string  $class
-     * @return void
      */
-    public static function deleteUsersUsing(string $class)
+    public static function deleteUsersUsing(string $class): void
     {
-        return app()->singleton(DeletesUsers::class, $class);
+        app()->singleton(DeletesUsers::class, $class);
     }
 
     /**
      * Manage Jetstream's Inertia settings.
-     *
-     * @return \Laravel\Jetstream\InertiaManager
      */
-    public static function inertia()
+    public static function inertia(): InertiaManager
     {
         if (is_null(static::$inertiaManager)) {
             static::$inertiaManager = new InertiaManager;
@@ -460,11 +355,8 @@ class Jetstream
 
     /**
      * Find the path to a localized Markdown resource.
-     *
-     * @param  string  $name
-     * @return string|null
      */
-    public static function localizedMarkdownPath($name)
+    public static function localizedMarkdownPath(string $name): string|null
     {
         $localName = preg_replace('#(\.md)$#i', '.'.app()->getLocale().'$1', $name);
 
@@ -478,10 +370,8 @@ class Jetstream
 
     /**
      * Configure Jetstream to not register its routes.
-     *
-     * @return static
      */
-    public static function ignoreRoutes()
+    public static function ignoreRoutes(): static
     {
         static::$registersRoutes = false;
 

--- a/src/JetstreamServiceProvider.php
+++ b/src/JetstreamServiceProvider.php
@@ -3,10 +3,10 @@
 namespace Laravel\Jetstream;
 
 use App\Http\Middleware\HandleInertiaRequests;
+use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\View\Compilers\BladeCompiler;
@@ -30,15 +30,13 @@ class JetstreamServiceProvider extends ServiceProvider
 {
     /**
      * Register any application services.
-     *
-     * @return void
      */
-    public function register()
+    public function register(): void
     {
         $this->mergeConfigFrom(__DIR__.'/../config/jetstream.php', 'jetstream');
 
         $this->app->afterResolving(BladeCompiler::class, function () {
-            if (config('jetstream.stack') === 'livewire' && class_exists(Livewire::class)) {
+            if (class_exists(Livewire::class) && config('jetstream.stack') === 'livewire') {
                 Livewire::component('navigation-menu', NavigationMenu::class);
                 Livewire::component('profile.update-profile-information-form', UpdateProfileInformationForm::class);
                 Livewire::component('profile.update-password-form', UpdatePasswordForm::class);
@@ -63,9 +61,9 @@ class JetstreamServiceProvider extends ServiceProvider
     /**
      * Bootstrap any application services.
      *
-     * @return void
+     * @throws BindingResolutionException
      */
-    public function boot()
+    public function boot(): void
     {
         Fortify::viewPrefix('auth.');
 
@@ -94,10 +92,8 @@ class JetstreamServiceProvider extends ServiceProvider
 
     /**
      * Configure publishing for the package.
-     *
-     * @return void
      */
-    protected function configurePublishing()
+    protected function configurePublishing(): void
     {
         if (! $this->app->runningInConsole()) {
             return;
@@ -131,10 +127,8 @@ class JetstreamServiceProvider extends ServiceProvider
 
     /**
      * Configure the routes offered by the application.
-     *
-     * @return void
      */
-    protected function configureRoutes()
+    protected function configureRoutes(): void
     {
         if (Jetstream::$registersRoutes) {
             Route::group([
@@ -149,10 +143,8 @@ class JetstreamServiceProvider extends ServiceProvider
 
     /**
      * Configure the commands offered by the application.
-     *
-     * @return void
      */
-    protected function configureCommands()
+    protected function configureCommands(): void
     {
         if (! $this->app->runningInConsole()) {
             return;
@@ -166,9 +158,9 @@ class JetstreamServiceProvider extends ServiceProvider
     /**
      * Boot any Inertia related services.
      *
-     * @return void
+     * @throws BindingResolutionException
      */
-    protected function bootInertia()
+    protected function bootInertia(): void
     {
         $kernel = $this->app->make(Kernel::class);
 

--- a/src/Mail/TeamInvitation.php
+++ b/src/Mail/TeamInvitation.php
@@ -14,16 +14,11 @@ class TeamInvitation extends Mailable
 
     /**
      * The team invitation instance.
-     *
-     * @var \Laravel\Jetstream\TeamInvitation
      */
-    public $invitation;
+    public TeamInvitationModel $invitation;
 
     /**
      * Create a new message instance.
-     *
-     * @param  \Laravel\Jetstream\TeamInvitation  $invitation
-     * @return void
      */
     public function __construct(TeamInvitationModel $invitation)
     {
@@ -32,10 +27,8 @@ class TeamInvitation extends Mailable
 
     /**
      * Build the message.
-     *
-     * @return $this
      */
-    public function build()
+    public function build(): static
     {
         return $this->markdown('emails.team-invitation', ['acceptUrl' => URL::signedRoute('team-invitations.accept', [
             'invitation' => $this->invitation,

--- a/src/RedirectsActions.php
+++ b/src/RedirectsActions.php
@@ -2,24 +2,23 @@
 
 namespace Laravel\Jetstream;
 
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Response;
+use Illuminate\Routing\Redirector;
 
 trait RedirectsActions
 {
     /**
      * Get the redirect response for the given action.
-     *
-     * @param  mixed  $action
-     * @return \Illuminate\Http\Response
      */
-    public function redirectPath($action)
+    public function redirectPath(mixed $action): Response|Redirector|RedirectResponse
     {
         if (method_exists($action, 'redirectTo')) {
             $response = $action->redirectTo();
         } else {
             $response = property_exists($action, 'redirectTo')
-                                ? $action->redirectTo
-                                : config('fortify.home');
+                ? $action->redirectTo
+                : config('fortify.home');
         }
 
         return $response instanceof Response ? $response : redirect($response);

--- a/src/Role.php
+++ b/src/Role.php
@@ -8,38 +8,27 @@ class Role implements JsonSerializable
 {
     /**
      * The key identifier for the role.
-     *
-     * @var string
      */
-    public $key;
+    public string $key;
 
     /**
      * The name of the role.
-     *
-     * @var string
      */
-    public $name;
+    public string $name;
 
     /**
      * The role's permissions.
-     *
-     * @var array
      */
-    public $permissions;
+    public array $permissions;
 
     /**
      * The role's description.
-     *
-     * @var string
      */
-    public $description;
+    public string $description;
 
     /**
      * Create a new role instance.
      *
-     * @param  string  $key
-     * @param  string  $name
-     * @param  array  $permissions
      * @return void
      */
     public function __construct(string $key, string $name, array $permissions)
@@ -51,11 +40,8 @@ class Role implements JsonSerializable
 
     /**
      * Describe the role.
-     *
-     * @param  string  $description
-     * @return $this
      */
-    public function description(string $description)
+    public function description(string $description): static
     {
         $this->description = $description;
 
@@ -64,11 +50,9 @@ class Role implements JsonSerializable
 
     /**
      * Get the JSON serializable representation of the object.
-     *
-     * @return array
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'key' => $this->key,

--- a/src/Rules/Role.php
+++ b/src/Rules/Role.php
@@ -9,22 +9,16 @@ class Role implements Rule
 {
     /**
      * Determine if the validation rule passes.
-     *
-     * @param  string  $attribute
-     * @param  mixed  $value
-     * @return bool
      */
-    public function passes($attribute, $value)
+    public function passes($attribute, $value): bool
     {
-        return in_array($value, array_keys(Jetstream::$roles));
+        return array_key_exists($value, Jetstream::$roles);
     }
 
     /**
      * Get the validation error message.
-     *
-     * @return string
      */
-    public function message()
+    public function message(): string
     {
         return __('The :attribute must be a valid role.');
     }

--- a/src/TeamInvitation.php
+++ b/src/TeamInvitation.php
@@ -3,13 +3,14 @@
 namespace Laravel\Jetstream;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class TeamInvitation extends Model
 {
     /**
      * The attributes that are mass assignable.
      *
-     * @var array
+     * @var array<int, string>
      */
     protected $fillable = [
         'email',
@@ -18,10 +19,8 @@ class TeamInvitation extends Model
 
     /**
      * Get the team that the invitation belongs to.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function team()
+    public function team(): BelongsTo
     {
         return $this->belongsTo(Jetstream::teamModel());
     }

--- a/stubs/config/jetstream.php
+++ b/stubs/config/jetstream.php
@@ -53,7 +53,7 @@ return [
     |
     | Some of Jetstream's features are optional. You may disable the features
     | by removing them from this array. You're free to only remove some of
-    | these features or you can even remove all of these if you need to.
+    | these features, or you can even remove all of these if you need to.
     |
     */
 
@@ -71,8 +71,8 @@ return [
     |--------------------------------------------------------------------------
     |
     | This configuration value determines the default disk that will be used
-    | when storing profile photos for your application's users. Typically
-    | this will be the "public" disk but you may adjust this if needed.
+    | when storing profile photos for your application's users. Typically,
+    | this will be the "public" disk, but you may adjust this if needed.
     |
     */
 


### PR DESCRIPTION
This PR implements the use of PHP Return Types and corrects wrong return types that were initially implemented. 

Here are the benefits of this PR:

** I want to mention first that this PR will not break any user experiences.
** After implementing this there was a dramatic performance increase in the compilation and response time (try it yourself).
** I think this is a good final adjustment to the backend for a while.

Using return types in PHP offers several benefits, including:

Type Safety: By specifying a return type, you can ensure that the function always returns a value of the expected type. This can help catch bugs and errors early and make it easier to reason about the behavior of your code.

Improved Readability: Return types make it clear what type of value a function returns, which can improve code readability and make it easier to understand the purpose of the function.

Better Documentation: Return types can be used to document the expected return value of a function, which can make it easier for other developers to understand how to use the function.

Easier Maintenance: By specifying return types, you can make it easier to update and modify code in the future, since you'll know what type of data the function is returning and what other parts of the code depend on that return value.

Performance Improvements: Return types can improve performance by reducing the amount of type juggling and type casting that PHP needs to do at runtime.

Error Prevention: Return types can help prevent errors by ensuring that the function returns a valid value of the expected type. This can help catch errors early and reduce the amount of debugging that needs to be done later on.