### PR TITLE
Get fresh user instance on two factor authentication tests

### DIFF
--- a/stubs/pest-tests/livewire/TwoFactorAuthenticationSettingsTest.php
+++ b/stubs/pest-tests/livewire/TwoFactorAuthenticationSettingsTest.php
@@ -6,7 +6,7 @@ use Laravel\Jetstream\Http\Livewire\TwoFactorAuthenticationForm;
 use Livewire\Livewire;
 
 test('two factor authentication can be enabled', function () {
-    $this->actingAs($user = User::factory()->create());
+    $this->actingAs($user = User::factory()->create()->fresh());
 
     $this->withSession(['auth.password_confirmed_at' => time()]);
 
@@ -22,7 +22,7 @@ test('two factor authentication can be enabled', function () {
 }, 'Two factor authentication is not enabled.');
 
 test('recovery codes can be regenerated', function () {
-    $this->actingAs($user = User::factory()->create());
+    $this->actingAs($user = User::factory()->create()->fresh());
 
     $this->withSession(['auth.password_confirmed_at' => time()]);
 
@@ -41,7 +41,7 @@ test('recovery codes can be regenerated', function () {
 }, 'Two factor authentication is not enabled.');
 
 test('two factor authentication can be disabled', function () {
-    $this->actingAs($user = User::factory()->create());
+    $this->actingAs($user = User::factory()->create()->fresh());
 
     $this->withSession(['auth.password_confirmed_at' => time()]);
 


### PR DESCRIPTION
In my installation, these tests fail because the user doesn't have the `two_factor_confirmed_at` attribute:
```
The attribute [two_factor_confirmed_at] either does not exist or was not retrieved for model [App\Models\User]. (View: /var/www/html/vendor/livewire/livewire/src/views/mount-component.blade.php)
```

I believe this is because the factory doesn't specify the attribute.

I considered updating the factory to include it (set to `null`), but then I thought it might be a little messy because there should be a check to see if the feature's enabled.

This solution, however, requires everyone to remember to get a fresh user instance, when needed, without it being clear as to why.

So...let me know if I should try a different approach...

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

If you change the behavior of the Inertia stack you're expected to update the Livewire stack as well and vice versa.
-->
