### PR TITLE
Fix issue with page reload/refresh on two-factor-challenge page

### DIFF
--- a/stubs/livewire/resources/views/auth/two-factor-challenge.blade.php
+++ b/stubs/livewire/resources/views/auth/two-factor-challenge.blade.php
@@ -1,7 +1,3 @@
-<style>
-    [x-cloak] { display: none; }
-</style>
-
 <x-guest-layout>
     <x-authentication-card>
         <x-slot name="logo">

--- a/stubs/livewire/resources/views/auth/two-factor-challenge.blade.php
+++ b/stubs/livewire/resources/views/auth/two-factor-challenge.blade.php
@@ -1,3 +1,7 @@
+<style>
+    [x-cloak] { display: none; }
+</style>
+
 <x-guest-layout>
     <x-authentication-card>
         <x-slot name="logo">
@@ -5,11 +9,11 @@
         </x-slot>
 
         <div x-data="{ recovery: false }">
-            <div class="mb-4 text-sm text-gray-600 dark:text-gray-400" x-show="! recovery">
+            <div class="mb-4 text-sm text-gray-600 dark:text-gray-400" x-cloak x-show="! recovery">
                 {{ __('Please confirm access to your account by entering the authentication code provided by your authenticator application.') }}
             </div>
 
-            <div class="mb-4 text-sm text-gray-600 dark:text-gray-400" x-show="recovery">
+            <div class="mb-4 text-sm text-gray-600 dark:text-gray-400" x-cloak x-show="recovery">
                 {{ __('Please confirm access to your account by entering one of your emergency recovery codes.') }}
             </div>
 
@@ -18,18 +22,19 @@
             <form method="POST" action="{{ route('two-factor.login') }}">
                 @csrf
 
-                <div class="mt-4" x-show="! recovery">
+                <div class="mt-4" x-cloak x-show="! recovery">
                     <x-label for="code" value="{{ __('Code') }}" />
                     <x-input id="code" class="block mt-1 w-full" type="text" inputmode="numeric" name="code" autofocus x-ref="code" autocomplete="one-time-code" />
                 </div>
 
-                <div class="mt-4" x-show="recovery">
+                <div class="mt-4" x-cloak x-show="recovery">
                     <x-label for="recovery_code" value="{{ __('Recovery Code') }}" />
                     <x-input id="recovery_code" class="block mt-1 w-full" type="text" name="recovery_code" x-ref="recovery_code" autocomplete="one-time-code" />
                 </div>
 
                 <div class="flex items-center justify-end mt-4">
                     <button type="button" class="text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 underline cursor-pointer"
+                                    x-cloak
                                     x-show="! recovery"
                                     x-on:click="
                                         recovery = true;
@@ -39,6 +44,7 @@
                     </button>
 
                     <button type="button" class="text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 underline cursor-pointer"
+                                    x-cloak
                                     x-show="recovery"
                                     x-on:click="
                                         recovery = false;

--- a/stubs/resources/css/app.css
+++ b/stubs/resources/css/app.css
@@ -1,3 +1,5 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+[x-cloak] { display: none; }


### PR DESCRIPTION
The following pull request fixes the issue as explained here: https://github.com/laravel/jetstream/issues/1289#issue-1652817995

Reloading/refreshing the page no longer causes the recovery code form input to appear for a short amount of time. The "blip" as Alpine calls it is no longer occuring, which was causing the issue in the first place. 

In Alpine's documentation:

"_Sometimes, when you're using AlpineJS for a part of your template, there is a "blip" where you might see your uninitialized template after the page loads, but before Alpine loads._"

"_`x-cloak` addresses this scenario by hiding the element it's attached to until Alpine is fully loaded on the page._"