### PR TITLE
Fix validation of the two factor challenge with an empty recovery code input

### DIFF
--- a/stubs/inertia/resources/js/Pages/Auth/Partials/TwoFactorChallengeForm.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/Partials/TwoFactorChallengeForm.vue
@@ -1,0 +1,63 @@
+<script setup>
+import { nextTick, ref } from 'vue';
+import { useForm } from '@inertiajs/vue3';
+import InputError from '@/Components/InputError.vue';
+import InputLabel from '@/Components/InputLabel.vue';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+import TextInput from '@/Components/TextInput.vue';
+
+const props = defineProps({
+    index: String,
+    label: String,
+})
+
+const emit = defineEmits(['toggle']);
+
+const form = useForm({
+    [props.index]: '',
+});
+
+const input = ref(null);
+
+nextTick(() => {
+    input.value.focus();
+    form[props.index] = '';
+});
+
+const submit = () => {
+    form.post(route('two-factor.login'));
+};
+
+const toggle = () => emit('toggle');
+</script>
+
+<template>
+    <div class="mb-4 text-sm text-gray-600 dark:text-gray-400">
+        <slot name="description" />
+    </div>
+
+    <form @submit.prevent="submit">
+        <div>
+            <InputLabel :for="index" :value="label" />
+            <TextInput
+                :id="index"
+                ref="input"
+                v-model="form[index]"
+                type="text"
+                class="mt-1 block w-full"
+                autocomplete="one-time-code"
+            />
+            <InputError class="mt-2" :message="form.errors[index]" />
+        </div>
+
+        <div class="flex items-center justify-end mt-4">
+            <button type="button" class="text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 underline cursor-pointer" @click.prevent="toggle">
+                <slot name="toggle" />
+            </button>
+
+            <PrimaryButton class="ml-4" :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
+                Log in
+            </PrimaryButton>
+        </div>
+    </form>
+</template>

--- a/stubs/inertia/resources/js/Pages/Auth/TwoFactorChallenge.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/TwoFactorChallenge.vue
@@ -1,39 +1,14 @@
 <script setup>
-import { nextTick, ref } from 'vue';
-import { Head, useForm } from '@inertiajs/vue3';
+import { ref } from 'vue';
+import { Head } from '@inertiajs/vue3';
 import AuthenticationCard from '@/Components/AuthenticationCard.vue';
 import AuthenticationCardLogo from '@/Components/AuthenticationCardLogo.vue';
-import InputError from '@/Components/InputError.vue';
-import InputLabel from '@/Components/InputLabel.vue';
-import PrimaryButton from '@/Components/PrimaryButton.vue';
-import TextInput from '@/Components/TextInput.vue';
+import TwoFactorChallengeForm from '@/Pages/Auth/Partials/TwoFactorChallengeForm.vue'
 
 const recovery = ref(false);
 
-const form = useForm({
-    code: '',
-    recovery_code: '',
-});
-
-const recoveryCodeInput = ref(null);
-const codeInput = ref(null);
-
 const toggleRecovery = async () => {
     recovery.value ^= true;
-
-    await nextTick();
-
-    if (recovery.value) {
-        recoveryCodeInput.value.focus();
-        form.code = '';
-    } else {
-        codeInput.value.focus();
-        form.recovery_code = '';
-    }
-};
-
-const submit = () => {
-    form.post(route('two-factor.login'));
 };
 </script>
 
@@ -42,63 +17,35 @@ const submit = () => {
 
     <AuthenticationCard>
         <template #logo>
-            <AuthenticationCardLogo />
+            <AuthenticationCardLogo @toggle="toggleRecovery" />
         </template>
 
-        <div class="mb-4 text-sm text-gray-600 dark:text-gray-400">
-            <template v-if="! recovery">
+        <TwoFactorChallengeForm
+            v-if="!recovery"
+            @toggle="toggleRecovery"
+            index="code"
+            label="Code"
+        >
+            <template #description>
                 Please confirm access to your account by entering the authentication code provided by your authenticator application.
             </template>
+            <template #toggle>
+                Use a recovery code
+            </template>
+        </TwoFactorChallengeForm>
 
-            <template v-else>
+        <TwoFactorChallengeForm
+            v-else
+            @toggle="toggleRecovery"
+            index="recovery_code"
+            label="Recovery Code"
+        >
+            <template #description>
                 Please confirm access to your account by entering one of your emergency recovery codes.
             </template>
-        </div>
-
-        <form @submit.prevent="submit">
-            <div v-if="! recovery">
-                <InputLabel for="code" value="Code" />
-                <TextInput
-                    id="code"
-                    ref="codeInput"
-                    v-model="form.code"
-                    type="text"
-                    inputmode="numeric"
-                    class="mt-1 block w-full"
-                    autofocus
-                    autocomplete="one-time-code"
-                />
-                <InputError class="mt-2" :message="form.errors.code" />
-            </div>
-
-            <div v-else>
-                <InputLabel for="recovery_code" value="Recovery Code" />
-                <TextInput
-                    id="recovery_code"
-                    ref="recoveryCodeInput"
-                    v-model="form.recovery_code"
-                    type="text"
-                    class="mt-1 block w-full"
-                    autocomplete="one-time-code"
-                />
-                <InputError class="mt-2" :message="form.errors.recovery_code" />
-            </div>
-
-            <div class="flex items-center justify-end mt-4">
-                <button type="button" class="text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 underline cursor-pointer" @click.prevent="toggleRecovery">
-                    <template v-if="! recovery">
-                        Use a recovery code
-                    </template>
-
-                    <template v-else>
-                        Use an authentication code
-                    </template>
-                </button>
-
-                <PrimaryButton class="ml-4" :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
-                    Log in
-                </PrimaryButton>
-            </div>
-        </form>
+            <template #toggle>
+                Use an authentication code
+            </template>
+        </TwoFactorChallengeForm>
     </AuthenticationCard>
 </template>


### PR DESCRIPTION
### Description

This PR together with the one I've submitted to [laravel/fortify](https://github.com/laravel/fortify/pull/459) is providing the fix for the following scenario:

---

While authenticating with 2FA using the code option with empty input, on submission we get the validation message:

![Screenshot 2023-04-15 at 12 10 44](https://user-images.githubusercontent.com/2211203/232210476-cd0b73b0-8978-4e89-aaf3-1f45fb1d9470.png)

however when doing the same using recovery code option - we do not see the error:

![Screenshot 2023-04-15 at 12 12 06](https://user-images.githubusercontent.com/2211203/232210528-fefa7b62-5168-440a-aaf8-f4af3059c180.png)

### Steps To Reproduce

Authenticate using username and password, followed by 2FA form - first try the `code` and then `recovery code` - both times submit form with empty input. 

Only `code` version will display validation message.