### PR TITLE
Ensure email is included in state

### DIFF
--- a/src/Http/Livewire/UpdateProfileInformationForm.php
+++ b/src/Http/Livewire/UpdateProfileInformationForm.php
@@ -39,7 +39,10 @@ class UpdateProfileInformationForm extends Component
      */
     public function mount()
     {
-        $this->state = Auth::user()->withoutRelations()->toArray();
+        $user = Auth::user();
+        $this->state = array_merge([
+            'email' => $user->email,
+        ], $user->withoutRelations()->toArray());
     }
 
     /**

--- a/src/Http/Livewire/UpdateProfileInformationForm.php
+++ b/src/Http/Livewire/UpdateProfileInformationForm.php
@@ -40,6 +40,7 @@ class UpdateProfileInformationForm extends Component
     public function mount()
     {
         $user = Auth::user();
+
         $this->state = array_merge([
             'email' => $user->email,
         ], $user->withoutRelations()->toArray());


### PR DESCRIPTION
If email is hidden for serialization (in the User model `hidden` array) the view will crash, as `toArray()` won't include the email.

Hiding email field in particular is useful to avoid accidentally exposing other users emails to the frontend / client.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

If you change the behavior of the Inertia stack you're expected to update the Livewire stack as well and vice versa.
-->
