### PR TITLE
Fix gate check when updating user permissions on a team

### DIFF
--- a/src/Http/Controllers/Inertia/TeamController.php
+++ b/src/Http/Controllers/Inertia/TeamController.php
@@ -39,6 +39,7 @@ class TeamController extends Controller
                 'canDeleteTeam' => Gate::check('delete', $team),
                 'canRemoveTeamMembers' => Gate::check('removeTeamMember', $team),
                 'canUpdateTeam' => Gate::check('update', $team),
+                'canUpdateTeamMembers' => Gate::check('updateTeamMember', $team),
             ],
         ]);
     }

--- a/stubs/inertia/resources/js/Pages/Teams/Partials/TeamMemberManager.vue
+++ b/stubs/inertia/resources/js/Pages/Teams/Partials/TeamMemberManager.vue
@@ -236,7 +236,7 @@ const displayableRole = (role) => {
                             <div class="flex items-center">
                                 <!-- Manage Team Member Role -->
                                 <button
-                                    v-if="userPermissions.canAddTeamMembers && availableRoles.length"
+                                    v-if="userPermissions.canUpdateTeamMembers && availableRoles.length"
                                     class="ml-2 text-sm text-gray-400 underline"
                                     @click="manageRole(user)"
                                 >

--- a/stubs/livewire/resources/views/teams/team-member-manager.blade.php
+++ b/stubs/livewire/resources/views/teams/team-member-manager.blade.php
@@ -139,7 +139,7 @@
 
                                 <div class="flex items-center">
                                     <!-- Manage Team Member Role -->
-                                    @if (Gate::check('addTeamMember', $team) && Laravel\Jetstream\Jetstream::hasRoles())
+                                    @if (Gate::check('updateTeamMember', $team) && Laravel\Jetstream\Jetstream::hasRoles())
                                         <button class="ml-2 text-sm text-gray-400 underline" wire:click="manageRole('{{ $user->id }}')">
                                             {{ Laravel\Jetstream\Jetstream::findRole($user->membership->role)->name }}
                                         </button>


### PR DESCRIPTION
I think I found a bug where managing a team member's role is being guarded by the `canAddTeamMembers` permissions instead of `canUpdateTeamMembers`.

This isn't super obvious right off the bat because they share the exact same logic, which is:

```
return $user->ownsTeam($team);
```

I spotted this in my own application when I changed the logic a bit so that both Administrators and Owners can invite new team members, but only Owners should be able to modify user permissions.