### PR TITLE
Fix ShareInertiaData middleware for Eloquent strict mode when 2FA is disabled

### DIFF
--- a/src/Http/Middleware/ShareInertiaData.php
+++ b/src/Http/Middleware/ShareInertiaData.php
@@ -54,7 +54,8 @@ class ShareInertiaData
                     return array_merge($user->toArray(), array_filter([
                         'all_teams' => $userHasTeamFeatures ? $user->allTeams()->values() : null,
                     ]), [
-                        'two_factor_enabled' => ! is_null($user->two_factor_secret),
+                        'two_factor_enabled' => Features::enabled(Features::twoFactorAuthentication())
+                            && ! is_null($user->two_factor_secret),
                     ]);
                 },
             ],


### PR DESCRIPTION
When we don't want to have 2FA Fortify feature `Features::twoFactorAuthentication()` enabled, we usually don't have any `two_factor_*` (namely `two_factor_secret`) columns on our User model / in our migration. In that case, we couldn't enable [Eloquent Strictness](https://laravel.com/docs/10.x/eloquent#configuring-eloquent-strictness), which is recommended for non-production environments. Enabled `Model::preventSilentlyDiscardingAttributes()` would throw the following `MissingAttributeException` exception:

```
The attribute [two_factor_secret] either does not exist or was not retrieved for model [App\Models\User].
```

This happens on [Http/Middleware/ShareInertiaData.php#L57](https://github.com/laravel/jetstream/blob/v3.2.2/src/Http/Middleware/ShareInertiaData.php#L57) when trying to access the non-existing attribute:

```php
'two_factor_enabled' => ! is_null($user->two_factor_secret),
```

This is a simple fix by adding an additional check if the 2FA feature is enabled.