### PR TITLE
Fix / Allow team owners to make tokens with permissions

### DIFF
--- a/src/HasTeams.php
+++ b/src/HasTeams.php
@@ -204,7 +204,7 @@ trait HasTeams
             $this->currentAccessToken() !== null) {
             return false;
         }
-        
+
         if ($this->ownsTeam($team)) {
             return true;
         }

--- a/src/HasTeams.php
+++ b/src/HasTeams.php
@@ -199,17 +199,17 @@ trait HasTeams
      */
     public function hasTeamPermission($team, string $permission)
     {
+        if (in_array(HasApiTokens::class, class_uses_recursive($this)) &&
+            ! $this->tokenCan($permission) &&
+            $this->currentAccessToken() !== null) {
+            return false;
+        }
+        
         if ($this->ownsTeam($team)) {
             return true;
         }
 
         if (! $this->belongsToTeam($team)) {
-            return false;
-        }
-
-        if (in_array(HasApiTokens::class, class_uses_recursive($this)) &&
-            ! $this->tokenCan($permission) &&
-            $this->currentAccessToken() !== null) {
             return false;
         }
 


### PR DESCRIPTION
Previously team ownership was checked first and true was returned, hence owners tokens always had access to everything regardless of permissions.

This allows the team owner to make API tokens with strict permissions. 

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

If you change the behavior of the Inertia stack you're expected to update the Livewire stack as well and vice versa.
-->
