### PR TITLE
fix: duplicated validation error

### DIFF
--- a/stubs/livewire/resources/views/profile/logout-other-browser-sessions-form.blade.php
+++ b/stubs/livewire/resources/views/profile/logout-other-browser-sessions-form.blade.php
@@ -77,8 +77,6 @@
                                 x-ref="password"
                                 wire:model.defer="password"
                                 wire:keydown.enter="logoutOtherBrowserSessions" />
-
-                    <x-input-error for="password" class="mt-2" />
                 </div>
             </x-slot>
 


### PR DESCRIPTION
#### Replicate

1. Create new laravel project (latest)
2. Add jetstream to the project (latest)
3. Install livewire (php artisan jetstream:install livewire)

#### Issue

There is a duplicated error in the "Logout Other Browser Session" modal when submitting a password. This PR resolves that issue.

>Before

![browser-modal](https://github.com/laravel/jetstream/assets/22732118/debfde08-a017-4504-9d8d-bac74da651e3)

> After

![image](https://github.com/laravel/jetstream/assets/22732118/d9ffa008-def7-4e04-94e2-f3afac49264c)
