### PR TITLE
Use appName directly from .env in <title>

### DIFF
--- a/stubs/inertia/resources/js/app.js
+++ b/stubs/inertia/resources/js/app.js
@@ -6,7 +6,7 @@ import { createInertiaApp } from '@inertiajs/vue3';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
 import { ZiggyVue } from '../../vendor/tightenco/ziggy/dist/vue.m';
 
-const appName = window.document.getElementsByTagName('title')[0]?.innerText || 'Laravel';
+const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 
 createInertiaApp({
     title: (title) => `${title} - ${appName}`,

--- a/stubs/inertia/resources/js/ssr.js
+++ b/stubs/inertia/resources/js/ssr.js
@@ -5,7 +5,7 @@ import createServer from '@inertiajs/vue3/server';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
 import { ZiggyVue } from '../../vendor/tightenco/ziggy/dist/vue.m';
 
-const appName = 'Laravel';
+const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 
 createServer((page) =>
     createInertiaApp({


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

If you change the behavior of the Inertia stack you're expected to update the Livewire stack as well and vice versa.
-->
Currently, appName in app.tsx is pulled via DOM from app.blade.php <title> tag. It works, but using it from .env seems like a better approach. Additionally, it serves as an example of how .env variables should be accessed in React/Vue.

The ssr template had 'Laravel' hardcoded as the app name, which is not great for SEO. Replaced that part with import.meta.env.VITE_APP_NAME as well.

This depends on https://github.com/laravel/laravel/pull/6204 where I added VITE_APP_NAME as an alias to APP_NAME

I don't think any changes in this PR could be considered breaking.

Similar issue fixed in Breeze: https://github.com/laravel/breeze/pull/292