### PR TITLE
[3.x] Remove unnecessary Ziggy parameter which causes ESLint errors

### DIFF
--- a/stubs/inertia/resources/js/app.js
+++ b/stubs/inertia/resources/js/app.js
@@ -14,7 +14,7 @@ createInertiaApp({
     setup({ el, App, props, plugin }) {
         return createApp({ render: () => h(App, props) })
             .use(plugin)
-            .use(ZiggyVue, Ziggy)
+            .use(ZiggyVue)
             .mount(el);
     },
     progress: {


### PR DESCRIPTION
Using the additional `Ziggy` parameter with `.use(ZiggyVue, Ziggy)` is unnecessary when using the `@routes` Blade directive. Leaving this in (accurately) triggers an ESLint error `ESLint: 'Ziggy' is not defined.(no-undef)` since `Ziggy` is undefined in this context.

Since this additional parameter isn't necessary as the `@routes` blade directive is already being used, it should be removed to avoid triggering errors when using ESLint.

Alternatively, we could add `const { Ziggy } = window` or change the parameter to `window.Ziggy`, but this is all unnecessary and removing it seems to be the simplest, cleanest solution.

See [Ziggy Docs]( https://github.com/tighten/ziggy#vue) for more information

> Note: If you use the @routes Blade directive in your views, Ziggy's configuration will already be available globally, so you don't need to import the Ziggy config object and pass it into use().

