### PR TITLE
Fix the banner not showing again after dismissed by the user if the next message contents are the same

### DIFF
--- a/stubs/inertia/resources/js/Components/Banner.vue
+++ b/stubs/inertia/resources/js/Components/Banner.vue
@@ -1,13 +1,15 @@
 <script setup>
-import { computed, ref, watch } from 'vue';
+import {ref, watchEffect} from 'vue';
 import { usePage } from '@inertiajs/vue3';
 
 const show = ref(true);
-const style = computed(() => usePage().props.jetstream.flash?.bannerStyle || 'success');
-const message = computed(() => usePage().props.jetstream.flash?.banner || '');
+const style = ref('success');
+const message = ref('');
 
-watch(message, async () => {
-  show.value = true;
+watchEffect(async () => {
+    style.value = usePage().props.jetstream.flash?.bannerStyle || 'success';
+    message.value = usePage().props.jetstream.flash?.banner || '';
+    show.value = true;
 });
 </script>
 


### PR DESCRIPTION
This alters already accepted PR https://github.com/laravel/jetstream/pull/1045 to trigger the banner even if the next message contents did not change.

Explanation:
`watch`: setting the same value for a primitive type (number, string, boolean...) will not be considered as a value change.
`watchEffect`: triggers the change even if you set the same value, showing the banner again.

How to reproduce:
1. Flash a banner with the message "Action successful."
2. The user acknowledges the banner and clicks on the x button.
3. Flash another banner with the same message "Action successful."
4. No banners will be shown again, unless the message contents changes, user manually reloads the page or does a non-Inertia navigation.