### PR TITLE
[3.x] Pest detection

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -649,7 +649,7 @@ EOF;
      */
     protected function getTestStubsPath()
     {
-        return $this->option('pest')
+        return $this->option('pest') || $this->isUsingPest()
             ? __DIR__.'/../../stubs/pest-tests'
             : __DIR__.'/../../stubs/tests';
     }
@@ -880,6 +880,17 @@ EOF;
         $input->setOption('pest', select(
             label: 'Which testing framework do you prefer?',
             options: ['PHPUnit', 'Pest'],
+            default: $this->isUsingPest() ? 'Pest' : 'PHPUnit',
         ) === 'Pest');
+    }
+
+    /**
+     * Determine whether the project is already using Pest.
+     *
+     * @return bool
+     */
+    protected function isUsingPest()
+    {
+        return file_exists(base_path('tests/Pest.php'));
     }
 }

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -106,8 +106,10 @@ class InstallCommand extends Command implements PromptsForMissingInput
         // Tests...
         $stubs = $this->getTestStubsPath();
 
-        if ($this->option('pest')) {
-            $this->removeComposerDevPackages(['phpunit/phpunit']);
+        if ($this->option('pest') || $this->isUsingPest()) {
+            if ($this->hasComposerPackage('phpunit/phpunit')) {
+                $this->removeComposerDevPackages(['phpunit/phpunit']);
+            }
 
             if (! $this->requireComposerDevPackages(['pestphp/pest:^2.0', 'pestphp/pest-plugin-laravel:^2.0'])) {
                 return 1;
@@ -730,6 +732,20 @@ EOF;
             ->run(function ($type, $output) {
                 $this->output->write($output);
             }) === 0;
+    }
+
+    /**
+     * Determine if the given Composer Package is installed.
+     *
+     * @param  string  $package
+     * @return bool
+     */
+    protected function hasComposerPackage($package)
+    {
+        $packages = json_decode(file_get_contents(base_path('composer.json')), true);
+
+        return array_key_exists($package, $packages['require'] ?? [])
+            || array_key_exists($package, $packages['require-dev'] ?? []);
     }
 
     /**


### PR DESCRIPTION
This PR updates the standalone Jetstream installer to default to Pest when it is already installed, either via the Laravel installer or installed manually.

When running `php artisan jetstream:install` with no arguments, the testing framework prompt will still be displayed, but defaulting to Pest when installed:

![image](https://github.com/laravel/jetstream/assets/4977161/e1b68117-22de-4779-a57c-856b6beb5678)

When passing arguments to the installer (e.g. `php artisan jetstream:install inertia`) the prompt does not appear. Currently, it will install PHPUnit tests unless the `--pest` flag was passed. With this change, it will automatically install Pest tests when appropriate.
