### PR TITLE
Make recovery code light when it on dark mode

### DIFF
--- a/stubs/inertia/resources/js/Pages/Profile/Partials/TwoFactorAuthenticationForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/Partials/TwoFactorAuthenticationForm.vue
@@ -178,7 +178,7 @@ const disableTwoFactorAuthentication = () => {
                         </p>
                     </div>
 
-                    <div class="grid gap-1 max-w-xl mt-4 px-4 py-4 font-mono text-sm bg-gray-100 dark:bg-gray-900 rounded-lg">
+                    <div class="grid gap-1 max-w-xl mt-4 px-4 py-4 font-mono text-sm bg-gray-100 dark:bg-gray-900 dark:text-gray-100 rounded-lg">
                         <div v-for="code in recoveryCodes" :key="code">
                             {{ code }}
                         </div>


### PR DESCRIPTION
Adding `dark:text-gray-100` on recovery codes.

### Before added.
![irsyadadl-screenshot-2023-08-11-00 23 44](https://github.com/laravel/jetstream/assets/44585532/cf3ccbd7-509b-4d66-bf60-05396351c9f5)

### After added.
![irsyadadl-screenshot-2023-08-11-00 25 31](https://github.com/laravel/jetstream/assets/44585532/c02779ec-417e-406c-ae39-32cf4f2a510e)

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

If you change the behavior of the Inertia stack you're expected to update the Livewire stack as well and vice versa.
-->
