### PR TITLE
Prevent calling Inertia before it's installed

### DIFF
--- a/src/JetstreamServiceProvider.php
+++ b/src/JetstreamServiceProvider.php
@@ -88,7 +88,7 @@ class JetstreamServiceProvider extends ServiceProvider
             ]);
         });
 
-        if (config('jetstream.stack') === 'inertia') {
+        if (config('jetstream.stack') === 'inertia' && class_exists(Inertia::class)) {
             $this->bootInertia();
         }
     }


### PR DESCRIPTION
When you pull in Jetstream into a fresh Laravel project manually and try accessing it in a browser before running the ```php artisan jetstream:install``` command, it will have the error that "Class 'Inertia\Inertia' not found" from the ShareInertiaData middleware. To prevent that, I added a check to ensure the class is present before calling the ```bootInertia``` method in the ServiceProvider.

<img width="903" alt="image" src="https://github.com/laravel/jetstream/assets/17649602/3371108e-910d-40f3-9c7a-89702b689c0b">
