### PR TITLE
Allow banner.blade.php to be a link

### DIFF
--- a/stubs/livewire/resources/views/components/banner.blade.php
+++ b/stubs/livewire/resources/views/components/banner.blade.php
@@ -1,4 +1,4 @@
-@props(['style' => session('flash.bannerStyle', 'success'), 'message' => session('flash.banner')])
+@props(['style' => session('flash.bannerStyle', 'success'), 'message' => session('flash.banner'), 'href' => null , 'target' => '_self'])
 
 <div x-data="{{ json_encode(['show' => true, 'style' => $style, 'message' => $message]) }}"
             :class="{ 'bg-indigo-500': style == 'success', 'bg-red-700': style == 'danger', 'bg-gray-500': style != 'success' && style != 'danger' }"
@@ -24,7 +24,13 @@
                     </svg>
                 </span>
 
-                <p class="ml-3 font-medium text-sm text-white truncate" x-text="message"></p>
+                @if($href)
+                    <a href="{{ $href }}" target="{{ $target }}">
+                        <p class="ml-3 font-medium text-sm text-white truncate" x-text="message"></p>
+                    </a>
+                @else
+                    <p class="ml-3 font-medium text-sm text-white truncate" x-text="message"></p>
+                @endif
             </div>
 
             <div class="shrink-0 sm:ml-3">


### PR DESCRIPTION
Example use case, we want to encourage email verification but didn't want to strictly enforce it

```blade
@if(auth()->user()->hasVerifiedEmail() === false)
    <x-banner style="info" message="We encourage you to verify your email for bonus points, click here!" href="{{ route('verification.notice') }}" target="_blank" />
@endif
```

There are many other potential use cases as well for allowing the banner to be a link

You can still click on the x button to close the banner like the past if you want