### PR TITLE
[4.x] Remove outdated session migration check

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -134,12 +134,10 @@ class InstallCommand extends Command implements PromptsForMissingInput
      */
     protected function configureSession()
     {
-        if (! class_exists('CreateSessionsTable')) {
-            try {
-                $this->call('session:table');
-            } catch (Exception $e) {
-                //
-            }
+        try {
+            $this->call('session:table');
+        } catch (Exception $e) {
+            //
         }
 
         $this->replaceInFile("'SESSION_DRIVER', 'file'", "'SESSION_DRIVER', 'database'", config_path('session.php'));


### PR DESCRIPTION
This PR removes the check for an existing session table migration, as it does not work with anonymous migrations.

Rather than try to implement new detection logic here, I've created https://github.com/laravel/framework/pull/48602 to handle this directly in the `session:table` command.

Fixes #1384