### PR TITLE
Fix: Livewire component premature registration

### DIFF
--- a/src/JetstreamServiceProvider.php
+++ b/src/JetstreamServiceProvider.php
@@ -35,28 +35,6 @@ class JetstreamServiceProvider extends ServiceProvider
     public function register()
     {
         $this->mergeConfigFrom(__DIR__.'/../config/jetstream.php', 'jetstream');
-
-        $this->callAfterResolving(BladeCompiler::class, function () {
-            if (config('jetstream.stack') === 'livewire' && class_exists(Livewire::class)) {
-                Livewire::component('navigation-menu', NavigationMenu::class);
-                Livewire::component('profile.update-profile-information-form', UpdateProfileInformationForm::class);
-                Livewire::component('profile.update-password-form', UpdatePasswordForm::class);
-                Livewire::component('profile.two-factor-authentication-form', TwoFactorAuthenticationForm::class);
-                Livewire::component('profile.logout-other-browser-sessions-form', LogoutOtherBrowserSessionsForm::class);
-                Livewire::component('profile.delete-user-form', DeleteUserForm::class);
-
-                if (Features::hasApiFeatures()) {
-                    Livewire::component('api.api-token-manager', ApiTokenManager::class);
-                }
-
-                if (Features::hasTeamFeatures()) {
-                    Livewire::component('teams.create-team-form', CreateTeamForm::class);
-                    Livewire::component('teams.update-team-name-form', UpdateTeamNameForm::class);
-                    Livewire::component('teams.team-member-manager', TeamMemberManager::class);
-                    Livewire::component('teams.delete-team-form', DeleteTeamForm::class);
-                }
-            }
-        });
     }
 
     /**
@@ -90,6 +68,26 @@ class JetstreamServiceProvider extends ServiceProvider
 
         if (config('jetstream.stack') === 'inertia' && class_exists(Inertia::class)) {
             $this->bootInertia();
+        }
+
+        if (config('jetstream.stack') === 'livewire' && class_exists(Livewire::class)) {
+            Livewire::component('navigation-menu', NavigationMenu::class);
+            Livewire::component('profile.update-profile-information-form', UpdateProfileInformationForm::class);
+            Livewire::component('profile.update-password-form', UpdatePasswordForm::class);
+            Livewire::component('profile.two-factor-authentication-form', TwoFactorAuthenticationForm::class);
+            Livewire::component('profile.logout-other-browser-sessions-form', LogoutOtherBrowserSessionsForm::class);
+            Livewire::component('profile.delete-user-form', DeleteUserForm::class);
+
+            if (Features::hasApiFeatures()) {
+                Livewire::component('api.api-token-manager', ApiTokenManager::class);
+            }
+
+            if (Features::hasTeamFeatures()) {
+                Livewire::component('teams.create-team-form', CreateTeamForm::class);
+                Livewire::component('teams.update-team-name-form', UpdateTeamNameForm::class);
+                Livewire::component('teams.team-member-manager', TeamMemberManager::class);
+                Livewire::component('teams.delete-team-form', DeleteTeamForm::class);
+            }
         }
     }
 


### PR DESCRIPTION
REF: https://github.com/livewire/livewire/pull/7076#issuecomment-1768027945
REF: https://github.com/livewire/livewire/discussions/7093

In the latest release of [Livewire v3.0.9](https://github.com/livewire/livewire/tree/v3.0.9), Laravel Service Container is utilized for Dependency Resolution, which after testing with a new installation of Jetstream found to have a premature component registration due to a race condition, resulting in `Unable to find component: [navigation-menu]` exceptions.

**Explaination:**
- Previously, mechanisms were created using standard PHP object creation `(new $mechanism)`, not involving Laravel's service container, hence no service container events were triggered. `LivewireServiceProvider::registerMechanisms()`
- With the recent change, these mechanisms are now instantiated via Laravel's IoC service container `app($mechanism)`, causing service container events to be triggered.
- 💡 **The core of the problem** arises when the `Livewire\Mechanisms\CompileLivewireTags` mechanism is instantiated. It extends `Illuminate\View\Compilers\ComponentTagCompiler` which has a constructor dependency of `Illuminate\View\Compilers\BladeCompiler` , and its creation via the service container triggers events. On the other hand, **the `JetstreamServiceProvider` prematurely listens to this event in the service provider `register()` method**, leading to a situation where Livewire components are being registered before all necessary mechanisms are set up, particularly the `Livewire\Mechanisms\ComponentRegistry` which comes next in order after `Livewire\Mechanisms\CompileLivewireTags`.


**Suggested fix:**
- Move the registration of Livewire components in `JetstreamServiceProvider` to the `boot()` method, which is where it should be. This ensures all mechanisms are in place before any component registration begins. It also makes the additional event handling for BladeCompiler resolution unnecessary. `$this->callAfterResolving(BladeCompiler::class, fn () => '');`