### PR TITLE
Typehint mutator profile_photo_url attribute function return

### DIFF
--- a/src/HasProfilePhoto.php
+++ b/src/HasProfilePhoto.php
@@ -59,7 +59,7 @@ trait HasProfilePhoto
      */
     public function profilePhotoUrl(): Attribute
     {
-        return Attribute::get(function () {
+        return Attribute::get(function (): string {
             return $this->profile_photo_path
                     ? Storage::disk($this->profilePhotoDisk())->url($this->profile_photo_path)
                     : $this->defaultProfilePhotoUrl();


### PR DESCRIPTION
We need to typehint mutator function return to let IDE Helper package know the type of the attribute.

https://github.com/barryvdh/laravel-ide-helper/issues/1315#issuecomment-1688154721

Then PHPStan will not throw error on undefined profile_photo_url property.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

If you change the behavior of the Inertia stack you're expected to update the Livewire stack as well and vice versa.
-->
