### PR TITLE
[4.x] Replace `jenssegers/agent` and use latest `mobiledetect/mobiledetectlib`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,7 @@
         "illuminate/console": "^10.17",
         "illuminate/support": "^10.17",
         "laravel/fortify": "^1.15",
-        "mobiledetect/mobiledetectlib": "^4.8",
-        "whichbrowser/parser": "^2.1"
+        "mobiledetect/mobiledetectlib": "^4.8"
     },
     "require-dev": {
         "inertiajs/inertia-laravel": "^0.6.5",

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,9 @@
         "ext-json": "*",
         "illuminate/console": "^10.17",
         "illuminate/support": "^10.17",
-        "jenssegers/agent": "^2.6",
-        "laravel/fortify": "^1.15"
+        "laravel/fortify": "^1.15",
+        "mobiledetect/mobiledetectlib": "^4.8",
+        "whichbrowser/parser": "^2.1"
     },
     "require-dev": {
         "inertiajs/inertia-laravel": "^0.6.5",

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -44,13 +44,11 @@ class Agent
         'IE' => 'MSIE|IEMobile|MSIEMobile|Trident/[.0-9]+',
         'Netscape' => 'Netscape',
         'Mozilla' => 'Mozilla',
-        'WeChat'  => 'MicroMessenger',
+        'WeChat' => 'MicroMessenger',
     ];
 
     /**
      * Construct a new agent.
-     *
-     * @param  string  $userAgent
      */
     public function __construct(
         protected string $userAgent
@@ -99,7 +97,6 @@ class Agent
     /**
      * Match a detection rule and return the matched key.
      *
-     * @param  array  $rules
      * @return string|null
      */
     protected function findDetectionRulesAgainstUserAgent(array $rules)
@@ -137,7 +134,7 @@ class Agent
                 } elseif (is_array($merged[$key])) {
                     $merged[$key][] = $value;
                 } else {
-                    $merged[$key] .= '|' . $value;
+                    $merged[$key] .= '|'.$value;
                 }
             }
         }

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Laravel\Jetstream;
+
+use Detection\MobileDetect;
+
+class Agent
+{
+    /**
+     * List of operating systems.
+     *
+     * @var array
+     */
+    protected static $operatingSystems = [
+        'Windows' => 'Windows',
+        'Windows NT' => 'Windows NT',
+        'OS X' => 'Mac OS X',
+        'Debian' => 'Debian',
+        'Ubuntu' => 'Ubuntu',
+        'Macintosh' => 'PPC',
+        'OpenBSD' => 'OpenBSD',
+        'Linux' => 'Linux',
+        'ChromeOS' => 'CrOS',
+    ];
+
+    /**
+     * List of browsers.
+     *
+     * @var array
+     */
+    protected static $browsers = [
+        'Opera Mini' => 'Opera Mini',
+        'Opera' => 'Opera|OPR',
+        'Edge' => 'Edge|Edg',
+        'Coc Coc' => 'coc_coc_browser',
+        'UCBrowser' => 'UCBrowser',
+        'Vivaldi' => 'Vivaldi',
+        'Chrome' => 'Chrome',
+        'Firefox' => 'Firefox',
+        'Safari' => 'Safari',
+        'IE' => 'MSIE|IEMobile|MSIEMobile|Trident/[.0-9]+',
+        'Netscape' => 'Netscape',
+        'Mozilla' => 'Mozilla',
+        'WeChat'  => 'MicroMessenger',
+    ];
+
+    /**
+     * Construct a new agent.
+     *
+     * @param  string  $userAgent
+     */
+    public function __construct(
+        protected string $userAgent
+    ) {
+        //
+    }
+
+    public static function getPlatforms()
+    {
+        return static::mergeRules(
+            MobileDetect::getOperatingSystems(),
+            static::$operatingSystems
+        );
+    }
+
+    /**
+     * Merge multiple rules into one array.
+     *
+     * @param  array  $all
+     * @return array
+     */
+    protected static function mergeRules(...$all)
+    {
+        $merged = [];
+
+        foreach ($all as $rules) {
+            foreach ($rules as $key => $value) {
+                if (empty($merged[$key])) {
+                    $merged[$key] = $value;
+                } elseif (is_array($merged[$key])) {
+                    $merged[$key][] = $value;
+                } else {
+                    $merged[$key] .= '|' . $value;
+                }
+            }
+        }
+
+        return $merged;
+    }
+
+    public static function getBrowsers()
+    {
+        return static::mergeRules(
+            static::$browsers,
+            MobileDetect::getBrowsers()
+        );
+    }
+
+    public function platform()
+    {
+        return $this->findDetectionRulesAgainstUserAgent(static::getPlatforms());
+    }
+
+    public function browser()
+    {
+        return $this->findDetectionRulesAgainstUserAgent(static::getBrowsers());
+    }
+
+    /**
+     * Determine if request from desktop.
+     *
+     * @return bool
+     */
+    public function isDesktop()
+    {
+        $mobileDetect = new MobileDetect();
+
+        $mobileDetect->setUserAgent($this->userAgent);
+
+        return $mobileDetect->isMobile() === false;
+    }
+
+    /**
+     * Match a detection rule and return the matched key.
+     *
+     * @param  array  $rules
+     * @return string|bool
+     */
+    protected function findDetectionRulesAgainstUserAgent(array $rules)
+    {
+        $mobileDetect = new MobileDetect();
+        $mobileDetect->setUserAgent($this->userAgent);
+
+        foreach ($rules as $key => $regex) {
+            if (empty($regex)) {
+                continue;
+            }
+
+            if ($mobileDetect->match($regex, $this->userAgent)) {
+                return $key;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -80,7 +80,7 @@ class Agent
                 } elseif (is_array($merged[$key])) {
                     $merged[$key][] = $value;
                 } else {
-                    $merged[$key] .= '|' . $value;
+                    $merged[$key] .= '|'.$value;
                 }
             }
         }

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -2,6 +2,9 @@
 
 namespace Laravel\Jetstream;
 
+use Closure;
+use Detection\Cache\CacheException;
+use Detection\Exception\MobileDetectException;
 use Detection\MobileDetect;
 
 /**
@@ -54,9 +57,11 @@ class Agent extends MobileDetect
      */
     public function platform()
     {
-        return $this->findDetectionRulesAgainstUserAgent(
-            $this->mergeRules(MobileDetect::getOperatingSystems(), static::$additionalOperatingSystems)
-        );
+        return $this->retrieveUsingCacheOrResolve('jetstream.platform', function () {
+            return $this->findDetectionRulesAgainstUserAgent(
+                $this->mergeRules(MobileDetect::getOperatingSystems(), static::$additionalOperatingSystems)
+            );
+        });
     }
 
     /**
@@ -66,9 +71,11 @@ class Agent extends MobileDetect
      */
     public function browser()
     {
-        return $this->findDetectionRulesAgainstUserAgent(
-            $this->mergeRules(static::$additionalBrowsers, MobileDetect::getBrowsers())
-        );
+        return $this->retrieveUsingCacheOrResolve('jetstream.browser', function () {
+            return $this->findDetectionRulesAgainstUserAgent(
+                $this->mergeRules(static::$additionalBrowsers, MobileDetect::getBrowsers())
+            );
+        });
     }
 
     /**
@@ -78,15 +85,17 @@ class Agent extends MobileDetect
      */
     public function isDesktop()
     {
-        // Check specifically for cloudfront headers if the useragent === 'Amazon CloudFront'
-        if (
-            $this->getUserAgent() === static::$cloudFrontUA
-            && $this->getHttpHeader('HTTP_CLOUDFRONT_IS_DESKTOP_VIEWER') === 'true'
-        ) {
-            return true;
-        }
+        return $this->retrieveUsingCacheOrResolve('jetstream.desktop', function () {
+            // Check specifically for cloudfront headers if the useragent === 'Amazon CloudFront'
+            if (
+                $this->getUserAgent() === static::$cloudFrontUA
+                && $this->getHttpHeader('HTTP_CLOUDFRONT_IS_DESKTOP_VIEWER') === 'true'
+            ) {
+                return true;
+            }
 
-        return ! $this->isMobile() && ! $this->isTablet();
+            return ! $this->isMobile() && ! $this->isTablet();
+        });
     }
 
     /**
@@ -109,6 +118,32 @@ class Agent extends MobileDetect
         }
 
         return null;
+    }
+
+    /**
+     * Retrieve from cache or resolve the value.
+     *
+     * @param  string  $key
+     * @param  \Closure():mixed  $callback
+     * @return mixed
+     *
+     * @throws \Detection\Exception\MobileDetectException
+     */
+    protected function retrieveUsingCacheOrResolve(string $key, Closure $callback)
+    {
+        try {
+            $cacheKey = $this->createCacheKey($key);
+
+            if (! is_null($cacheItem = $this->cache->get($cacheKey))) {
+                return $cacheItem->get();
+            }
+
+            return tap(call_user_func($callback), function ($result) use ($cacheKey) {
+                $this->cache->set($cacheKey, $result);
+            });
+        }  catch (CacheException $e) {
+            throw new MobileDetectException("Cache problem in for {$key}: {$e->getMessage()}");
+        }
     }
 
     /**

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -4,6 +4,9 @@ namespace Laravel\Jetstream;
 
 use Detection\MobileDetect;
 
+/**
+ * @copyright Originally created by Jens Segers: https://github.com/jenssegers/agent
+ */
 class Agent
 {
     /**
@@ -55,55 +58,28 @@ class Agent
         //
     }
 
-    public static function getPlatforms()
+    /**
+     * Get the platform name from User Agent.
+     *
+     * @return string|null
+     */
+    public function platform()
     {
-        return static::mergeRules(
-            MobileDetect::getOperatingSystems(),
-            static::$operatingSystems
+        return $this->findDetectionRulesAgainstUserAgent(
+            $this->mergeRules(MobileDetect::getOperatingSystems(), static::$operatingSystems)
         );
     }
 
     /**
-     * Merge multiple rules into one array.
+     * Get the browser name from User Agent.
      *
-     * @param  array  $all
-     * @return array
+     * @return string|null
      */
-    protected static function mergeRules(...$all)
-    {
-        $merged = [];
-
-        foreach ($all as $rules) {
-            foreach ($rules as $key => $value) {
-                if (empty($merged[$key])) {
-                    $merged[$key] = $value;
-                } elseif (is_array($merged[$key])) {
-                    $merged[$key][] = $value;
-                } else {
-                    $merged[$key] .= '|'.$value;
-                }
-            }
-        }
-
-        return $merged;
-    }
-
-    public static function getBrowsers()
-    {
-        return static::mergeRules(
-            static::$browsers,
-            MobileDetect::getBrowsers()
-        );
-    }
-
-    public function platform()
-    {
-        return $this->findDetectionRulesAgainstUserAgent(static::getPlatforms());
-    }
-
     public function browser()
     {
-        return $this->findDetectionRulesAgainstUserAgent(static::getBrowsers());
+        return $this->findDetectionRulesAgainstUserAgent(
+            $this->mergeRules(static::$browsers, MobileDetect::getBrowsers())
+        );
     }
 
     /**
@@ -124,7 +100,7 @@ class Agent
      * Match a detection rule and return the matched key.
      *
      * @param  array  $rules
-     * @return string|bool
+     * @return string|null
      */
     protected function findDetectionRulesAgainstUserAgent(array $rules)
     {
@@ -141,6 +117,31 @@ class Agent
             }
         }
 
-        return false;
+        return null;
+    }
+
+    /**
+     * Merge multiple rules into one array.
+     *
+     * @param  array  $all
+     * @return array
+     */
+    protected function mergeRules(...$all)
+    {
+        $merged = [];
+
+        foreach ($all as $rules) {
+            foreach ($rules as $key => $value) {
+                if (empty($merged[$key])) {
+                    $merged[$key] = $value;
+                } elseif (is_array($merged[$key])) {
+                    $merged[$key][] = $value;
+                } else {
+                    $merged[$key] .= '|' . $value;
+                }
+            }
+        }
+
+        return $merged;
     }
 }

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -79,11 +79,11 @@ class Agent extends MobileDetect
     public function isDesktop()
     {
         // Check specifically for cloudfront headers if the useragent === 'Amazon CloudFront'
-        if ($this->getUserAgent() === 'Amazon CloudFront') {
-            $cfHeaders = $this->getCfHeaders();
-            if(array_key_exists('HTTP_CLOUDFRONT_IS_DESKTOP_VIEWER', $cfHeaders)) {
-                return $cfHeaders['HTTP_CLOUDFRONT_IS_DESKTOP_VIEWER'] === 'true';
-            }
+        if (
+            $this->getUserAgent() === static::$cloudFrontUA
+            && $this->getHttpHeader('HTTP_CLOUDFRONT_IS_DESKTOP_VIEWER') === 'true'
+        ) {
+            return true;
         }
 
         return ! $this->isMobile() && ! $this->isTablet();

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -141,7 +141,7 @@ class Agent extends MobileDetect
             return tap(call_user_func($callback), function ($result) use ($cacheKey) {
                 $this->cache->set($cacheKey, $result);
             });
-        }  catch (CacheException $e) {
+        } catch (CacheException $e) {
             throw new MobileDetectException("Cache problem in for {$key}: {$e->getMessage()}");
         }
     }

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -89,7 +89,6 @@ class Agent extends MobileDetect
         return ! $this->isMobile() && ! $this->isTablet();
     }
 
-
     /**
      * Match a detection rule and return the matched key.
      *

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -51,7 +51,7 @@ class Agent extends MobileDetect
     ];
 
     /**
-     * Get the platform name from User Agent.
+     * Get the platform name from the User Agent.
      *
      * @return string|null
      */
@@ -65,7 +65,7 @@ class Agent extends MobileDetect
     }
 
     /**
-     * Get the browser name from User Agent.
+     * Get the browser name from the User Agent.
      *
      * @return string|null
      */
@@ -79,7 +79,7 @@ class Agent extends MobileDetect
     }
 
     /**
-     * Check if the device is a desktop computer.
+     * Determine if the device is a desktop computer.
      *
      * @return bool
      */
@@ -121,7 +121,7 @@ class Agent extends MobileDetect
     }
 
     /**
-     * Retrieve from cache or resolve the value.
+     * Retrieve from the given key from the cache or resolve the value.
      *
      * @param  string  $key
      * @param  \Closure():mixed  $callback

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -7,14 +7,14 @@ use Detection\MobileDetect;
 /**
  * @copyright Originally created by Jens Segers: https://github.com/jenssegers/agent
  */
-class Agent
+class Agent extends MobileDetect
 {
     /**
-     * List of operating systems.
+     * List of additional operating systems.
      *
-     * @var array
+     * @var array<string, string>
      */
-    protected static $operatingSystems = [
+    protected static $additionalOperatingSystems = [
         'Windows' => 'Windows',
         'Windows NT' => 'Windows NT',
         'OS X' => 'Mac OS X',
@@ -27,11 +27,11 @@ class Agent
     ];
 
     /**
-     * List of browsers.
+     * List of additional browsers.
      *
-     * @var array
+     * @var array<string, string>
      */
-    protected static $browsers = [
+    protected static $additionalBrowsers = [
         'Opera Mini' => 'Opera Mini',
         'Opera' => 'Opera|OPR',
         'Edge' => 'Edge|Edg',
@@ -48,15 +48,6 @@ class Agent
     ];
 
     /**
-     * Construct a new agent.
-     */
-    public function __construct(
-        protected string $userAgent
-    ) {
-        //
-    }
-
-    /**
      * Get the platform name from User Agent.
      *
      * @return string|null
@@ -64,7 +55,7 @@ class Agent
     public function platform()
     {
         return $this->findDetectionRulesAgainstUserAgent(
-            $this->mergeRules(MobileDetect::getOperatingSystems(), static::$operatingSystems)
+            $this->mergeRules(MobileDetect::getOperatingSystems(), static::$additionalOperatingSystems)
         );
     }
 
@@ -76,7 +67,7 @@ class Agent
     public function browser()
     {
         return $this->findDetectionRulesAgainstUserAgent(
-            $this->mergeRules(static::$browsers, MobileDetect::getBrowsers())
+            $this->mergeRules(static::$additionalBrowsers, MobileDetect::getBrowsers())
         );
     }
 
@@ -87,11 +78,7 @@ class Agent
      */
     public function isDesktop()
     {
-        $mobileDetect = new MobileDetect();
-
-        $mobileDetect->setUserAgent($this->userAgent);
-
-        return $mobileDetect->isMobile() === false;
+        return $this->isMobile() === false;
     }
 
     /**
@@ -101,16 +88,13 @@ class Agent
      */
     protected function findDetectionRulesAgainstUserAgent(array $rules)
     {
-        $mobileDetect = new MobileDetect();
-        $mobileDetect->setUserAgent($this->userAgent);
-
         foreach ($rules as $key => $regex) {
             if (empty($regex)) {
                 continue;
             }
 
-            if ($mobileDetect->match($regex, $this->userAgent)) {
-                return $key;
+            if ($this->match($regex, $this->userAgent)) {
+                return $key ?: reset($this->matchesArray);
             }
         }
 

--- a/src/Http/Controllers/Inertia/UserProfileController.php
+++ b/src/Http/Controllers/Inertia/UserProfileController.php
@@ -17,7 +17,6 @@ class UserProfileController extends Controller
     /**
      * Show the general profile settings screen.
      *
-     * @param  \Illuminate\Http\Request  $request
      * @return \Inertia\Response
      */
     public function show(Request $request)
@@ -33,7 +32,6 @@ class UserProfileController extends Controller
     /**
      * Get the current sessions.
      *
-     * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Support\Collection
      */
     public function sessions(Request $request)
@@ -44,9 +42,9 @@ class UserProfileController extends Controller
 
         return collect(
             DB::connection(config('session.connection'))->table(config('session.table', 'sessions'))
-                    ->where('user_id', $request->user()->getAuthIdentifier())
-                    ->orderBy('last_activity', 'desc')
-                    ->get()
+                ->where('user_id', $request->user()->getAuthIdentifier())
+                ->orderBy('last_activity', 'desc')
+                ->get()
         )->map(function ($session) use ($request) {
             $agent = $this->createAgent($session);
 
@@ -71,6 +69,6 @@ class UserProfileController extends Controller
      */
     protected function createAgent($session)
     {
-        return new Agent($session->user_agent);
+        return tap(new Agent(), fn ($agent) => $agent->setUserAgent($session->user_agent));
     }
 }

--- a/src/Http/Controllers/Inertia/UserProfileController.php
+++ b/src/Http/Controllers/Inertia/UserProfileController.php
@@ -17,6 +17,7 @@ class UserProfileController extends Controller
     /**
      * Show the general profile settings screen.
      *
+     * @param  \Illuminate\Http\Request  $request
      * @return \Inertia\Response
      */
     public function show(Request $request)
@@ -32,6 +33,7 @@ class UserProfileController extends Controller
     /**
      * Get the current sessions.
      *
+     * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Support\Collection
      */
     public function sessions(Request $request)

--- a/src/Http/Controllers/Inertia/UserProfileController.php
+++ b/src/Http/Controllers/Inertia/UserProfileController.php
@@ -6,8 +6,8 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
-use Jenssegers\Agent\Agent;
 use Laravel\Fortify\Features;
+use Laravel\Jetstream\Agent;
 use Laravel\Jetstream\Jetstream;
 
 class UserProfileController extends Controller
@@ -67,12 +67,10 @@ class UserProfileController extends Controller
      * Create a new agent instance from the given session.
      *
      * @param  mixed  $session
-     * @return \Jenssegers\Agent\Agent
+     * @return \Laravel\Jetstream\Agent
      */
     protected function createAgent($session)
     {
-        return tap(new Agent, function ($agent) use ($session) {
-            $agent->setUserAgent($session->user_agent);
-        });
+        return new Agent($session->user_agent);
     }
 }

--- a/src/Http/Controllers/Inertia/UserProfileController.php
+++ b/src/Http/Controllers/Inertia/UserProfileController.php
@@ -44,9 +44,9 @@ class UserProfileController extends Controller
 
         return collect(
             DB::connection(config('session.connection'))->table(config('session.table', 'sessions'))
-                ->where('user_id', $request->user()->getAuthIdentifier())
-                ->orderBy('last_activity', 'desc')
-                ->get()
+                    ->where('user_id', $request->user()->getAuthIdentifier())
+                    ->orderBy('last_activity', 'desc')
+                    ->get()
         )->map(function ($session) use ($request) {
             $agent = $this->createAgent($session);
 

--- a/src/Http/Livewire/LogoutOtherBrowserSessionsForm.php
+++ b/src/Http/Livewire/LogoutOtherBrowserSessionsForm.php
@@ -44,6 +44,7 @@ class LogoutOtherBrowserSessionsForm extends Component
     /**
      * Log out from other browser sessions.
      *
+     * @param  \Illuminate\Contracts\Auth\StatefulGuard  $guard
      * @return void
      */
     public function logoutOtherBrowserSessions(StatefulGuard $guard)

--- a/src/Http/Livewire/LogoutOtherBrowserSessionsForm.php
+++ b/src/Http/Livewire/LogoutOtherBrowserSessionsForm.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\ValidationException;
-use Jenssegers\Agent\Agent;
+use Laravel\Jetstream\Agent;
 use Livewire\Component;
 
 class LogoutOtherBrowserSessionsForm extends Component
@@ -121,13 +121,11 @@ class LogoutOtherBrowserSessionsForm extends Component
      * Create a new agent instance from the given session.
      *
      * @param  mixed  $session
-     * @return \Jenssegers\Agent\Agent
+     * @return \Laravel\Jetstream\Agent
      */
     protected function createAgent($session)
     {
-        return tap(new Agent, function ($agent) use ($session) {
-            $agent->setUserAgent($session->user_agent);
-        });
+        return new Agent($session->user_agent);
     }
 
     /**

--- a/src/Http/Livewire/LogoutOtherBrowserSessionsForm.php
+++ b/src/Http/Livewire/LogoutOtherBrowserSessionsForm.php
@@ -104,9 +104,9 @@ class LogoutOtherBrowserSessionsForm extends Component
 
         return collect(
             DB::connection(config('session.connection'))->table(config('session.table', 'sessions'))
-                ->where('user_id', Auth::user()->getAuthIdentifier())
-                ->orderBy('last_activity', 'desc')
-                ->get()
+                    ->where('user_id', Auth::user()->getAuthIdentifier())
+                    ->orderBy('last_activity', 'desc')
+                    ->get()
         )->map(function ($session) {
             return (object) [
                 'agent' => $this->createAgent($session),

--- a/src/Http/Livewire/LogoutOtherBrowserSessionsForm.php
+++ b/src/Http/Livewire/LogoutOtherBrowserSessionsForm.php
@@ -44,7 +44,6 @@ class LogoutOtherBrowserSessionsForm extends Component
     /**
      * Log out from other browser sessions.
      *
-     * @param  \Illuminate\Contracts\Auth\StatefulGuard  $guard
      * @return void
      */
     public function logoutOtherBrowserSessions(StatefulGuard $guard)
@@ -104,9 +103,9 @@ class LogoutOtherBrowserSessionsForm extends Component
 
         return collect(
             DB::connection(config('session.connection'))->table(config('session.table', 'sessions'))
-                    ->where('user_id', Auth::user()->getAuthIdentifier())
-                    ->orderBy('last_activity', 'desc')
-                    ->get()
+                ->where('user_id', Auth::user()->getAuthIdentifier())
+                ->orderBy('last_activity', 'desc')
+                ->get()
         )->map(function ($session) {
             return (object) [
                 'agent' => $this->createAgent($session),
@@ -125,7 +124,7 @@ class LogoutOtherBrowserSessionsForm extends Component
      */
     protected function createAgent($session)
     {
-        return new Agent($session->user_agent);
+        return tap(new Agent(), fn ($agent) => $agent->setUserAgent($session->user_agent));
     }
 
     /**

--- a/tests/AgentTest.php
+++ b/tests/AgentTest.php
@@ -1,0 +1,284 @@
+<?php
+
+namespace Laravel\Jetstream\Tests;
+
+use Jenssegers\Agent\Agent;
+use PHPUnit\Framework\TestCase;
+
+class AgentTest extends TestCase
+{
+    private $operatingSystems = [
+        'Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko' => 'Windows',
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/537.13+ (KHTML, like Gecko) Version/5.1.7 Safari/534.57.2' => 'OS X',
+        'Mozilla/5.0 (iPad; CPU OS 5_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko ) Version/5.1 Mobile/9B176 Safari/7534.48.3' => 'iOS',
+        'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:24.0) Gecko/20100101 Firefox/24.0' => 'Ubuntu',
+        'Mozilla/5.0 (BlackBerry; U; BlackBerry 9900; en) AppleWebKit/534.11+ (KHTML, like Gecko) Version/7.1.0.346 Mobile Safari/534.11+' => 'BlackBerryOS',
+        'Mozilla/5.0 (Linux; U; Android 2.2; en-us; Nexus One Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1' => 'AndroidOS',
+        'Mozilla/5.0 (X11; CrOS x86_64 6680.78.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.102 Safari/537.36' => 'ChromeOS',
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36' => 'Windows',
+    ];
+
+    private $browsers = [
+        'Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko' => 'IE',
+        'Mozilla/5.0 (iPad; CPU OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5355d Safari/8536.25' => 'Safari',
+        'Mozilla/5.0 (Windows; U; Win 9x 4.90; SG; rv:1.9.2.4) Gecko/20101104 Netscape/9.1.0285' => 'Netscape',
+        'Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:25.0) Gecko/20100101 Firefox/25.0' => 'Firefox',
+        'Mozilla/5.0 (Windows NT 6.2; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1667.0 Safari/537.36' => 'Chrome',
+        'Mozilla/5.0 (Windows; U; Windows NT 6.1; rv:2.2) Gecko/20110201' => 'Mozilla',
+        'Opera/9.80 (Windows NT 6.0) Presto/2.12.388 Version/12.14' => 'Opera',
+        'Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.115 Safari/537.36 OPR/27.0.1689.76' => 'Opera',
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12' => 'Edge',
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5376e Safari/8536.25' => 'Safari',
+        'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36 Vivaldi/1.2.490.43' => 'Vivaldi',
+        'Mozilla/5.0 (Linux; U; Android 4.0.4; en-US; LT28h Build/6.1.E.3.7) AppleWebKit/534.31 (KHTML, like Gecko) UCBrowser/9.2.2.323 U3/0.8.0 Mobile Safari/534.31' => 'UCBrowser',
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edge/15.15063' => 'Edge',
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.29 Safari/537.36 Edg/79.0.309.18' => 'Edge',
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) coc_coc_browser/86.0.180 Chrome/80.0.3987.180 Safari/537.36' => 'Coc Coc',
+    ];
+
+    private $robots = [
+        // 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)' => 'Googlebot',
+        'facebookexternalhit/1.1 (+http(s)://www.facebook.com/externalhit_uatext.php)' => 'Facebookexternalhit',
+        // 'Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)' => 'Bingbot',
+        'Twitterbot/1.0' => 'Twitterbot',
+        // 'Mozilla/5.0 (compatible; YandexBot/3.0; +http://yandex.com/bots)' => 'Yandex',
+    ];
+
+    private $mobileDevices = [
+        'Mozilla/5.0 (iPhone; U; ru; CPU iPhone OS 4_2_1 like Mac OS X; ru) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8C148a Safari/6533.18.5' => 'iPhone',
+        'Mozilla/5.0 (iPad; CPU OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5355d Safari/8536.25' => 'iPad',
+        'Mozilla/5.0 (Linux; U; Android 2.3.4; fr-fr; HTC Desire Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1' => 'HTC',
+        'Mozilla/5.0 (BlackBerry; U; BlackBerry 9900; en) AppleWebKit/534.11+ (KHTML, like Gecko) Version/7.1.0.346 Mobile Safari/534.11+' => 'BlackBerry',
+        'Mozilla/5.0 (Linux; U; Android 2.2; en-us; Nexus One Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1' => 'Nexus',
+        'Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; ASUS Transformer Pad TF300T Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30' => 'AsusTablet',
+    ];
+
+    private $desktopDevices = [
+        //'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11) AppleWebKit/601.1.56 (KHTML, like Gecko) Version/9.0 Safari/601.1.56' => 'Macintosh',
+    ];
+
+    private $browserVersions = [
+        'Mozilla/5.0 (compatible; MSIE 10.6; Windows NT 6.1; Trident/5.0; InfoPath.2; SLCC1; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; .NET CLR 2.0.50727) 3gpp-gba UNTRUSTED/1.0' => '10.6',
+        'Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko' => '11.0',
+        'Mozilla/5.0 (iPad; CPU OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5355d Safari/8536.25' => '6.0',
+        'Mozilla/5.0 (Windows; U; Win 9x 4.90; SG; rv:1.9.2.4) Gecko/20101104 Netscape/9.1.0285' => '9.1.0285',
+        'Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:25.0) Gecko/20100101 Firefox/25.0' => '25.0',
+        'Mozilla/5.0 (Windows NT 6.2; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1667.0 Safari/537.36' => '32.0.1667.0',
+        'Mozilla/5.0 (Windows; U; Windows NT 6.1; rv:2.2) Gecko/20110201' => '2.2',
+        'Opera/9.80 (Windows NT 6.0) Presto/2.12.388 Version/12.14' => '12.14',
+        'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; de) Opera 11.51' => '11.51',
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12' => '12',
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.29 Safari/537.36 Edg/79.0.309.18' => '79.0.309.18',
+        'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36 Vivaldi/1.2.490.43' => '1.2.490.43',
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) coc_coc_browser/86.0.180 Chrome/80.0.3987.180 Safari/537.36' => '86.0.180',
+    ];
+
+    private $operatingSystemVersions = [
+        'Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko' => '6.3',
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/537.13+ (KHTML, like Gecko) Version/5.1.7 Safari/534.57.2' => '10_6_8',
+        'Mozilla/5.0 (iPad; CPU OS 5_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko ) Version/5.1 Mobile/9B176 Safari/7534.48.3' => '5_1',
+        'Mozilla/5.0 (BlackBerry; U; BlackBerry 9900; en) AppleWebKit/534.11+ (KHTML, like Gecko) Version/7.1.0.346 Mobile Safari/534.11+' => '7.1.0.346',
+        'Mozilla/5.0 (Linux; U; Android 2.2; en-us; Nexus One Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1' => '2.2',
+        'Mozilla/5.0 (X11; CrOS x86_64 6680.78.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.102 Safari/537.36' => '6680.78.0',
+    ];
+
+    private $desktops = [
+        // 'Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko',
+        // 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:24.0) Gecko/20100101 Firefox/24.0',
+        // 'Mozilla/5.0 (Windows; U; Win 9x 4.90; SG; rv:1.9.2.4) Gecko/20101104 Netscape/9.1.0285',
+        // 'Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:25.0) Gecko/20100101 Firefox/25.0',
+        // 'Mozilla/5.0 (Windows NT 6.2; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1667.0 Safari/537.36',
+        // 'Mozilla/5.0 (Windows; U; Windows NT 6.1; rv:2.2) Gecko/20110201',
+        // 'Opera/9.80 (Windows NT 6.0) Presto/2.12.388 Version/12.14',
+        // 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/537.13+ (KHTML, like Gecko) Version/5.1.7 Safari/534.57.2',
+    ];
+
+    private $phones = [
+        'Mozilla/5.0 (iPhone; U; ru; CPU iPhone OS 4_2_1 like Mac OS X; ru) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8C148a Safari/6533.18.5',
+        'Mozilla/5.0 (Linux; U; Android 2.3.4; fr-fr; HTC Desire Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1',
+        'Mozilla/5.0 (BlackBerry; U; BlackBerry 9900; en) AppleWebKit/534.11+ (KHTML, like Gecko) Version/7.1.0.346 Mobile Safari/534.11+',
+        'Mozilla/5.0 (Linux; U; Android 2.2; en-us; Nexus One Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1',
+    ];
+
+    public function testLanguages()
+    {
+        $agent = new Agent();
+        $agent->setHttpHeaders([
+            'HTTP_ACCEPT_LANGUAGE' => 'nl-NL,nl;q=0.8,en-US;q=0.6,en;q=0.4',
+        ]);
+
+        $this->assertEquals(['nl-nl', 'nl', 'en-us', 'en'], $agent->languages());
+    }
+
+    public function testLanguagesSorted()
+    {
+        $agent = new Agent();
+        $agent->setHttpHeaders([
+            'HTTP_ACCEPT_LANGUAGE' => 'en;q=0.4,en-US,nl;q=0.6',
+        ]);
+
+        $this->assertEquals(['en-us', 'nl', 'en'], $agent->languages());
+    }
+
+    public function testOperatingSystems()
+    {
+        $agent = new Agent();
+
+        foreach ($this->operatingSystems as $ua => $platform) {
+            $agent->setUserAgent($ua);
+            $this->assertEquals($platform, $agent->platform(), $ua);
+            $this->assertTrue($agent->is($platform), $platform);
+
+            if (!strpos($platform, ' ')) {
+                $method = "is{$platform}";
+                $this->assertTrue($agent->{$method}(), $ua);
+            }
+        }
+    }
+
+    public function testBrowsers()
+    {
+        $agent = new Agent();
+
+        foreach ($this->browsers as $ua => $browser) {
+            $agent->setUserAgent($ua);
+            $this->assertEquals($browser, $agent->browser(), $ua);
+            $this->assertTrue($agent->is($browser), $browser);
+
+            if (!strpos($browser, ' ')) {
+                $method = "is{$browser}";
+                $this->assertTrue($agent->{$method}(), $ua);
+            }
+        }
+    }
+
+    public function testRobots()
+    {
+        $agent = new Agent();
+
+        foreach ($this->robots as $ua => $robot) {
+            $agent->setUserAgent($ua);
+            $this->assertTrue($agent->isRobot(), $ua);
+            $this->assertEquals($robot, $agent->robot());
+        }
+    }
+
+    public function testRobotShouldReturnFalse()
+    {
+        $agent = new Agent();
+
+        $this->assertFalse($agent->robot());
+    }
+
+    public function testCallShouldThrowBadMethodCallException()
+    {
+        $this->expectException('BadMethodCallException');
+
+        $agent = new Agent();
+        $agent->invalidMethod();
+    }
+
+    public function testMobileDevices()
+    {
+        $agent = new Agent();
+
+        foreach ($this->mobileDevices as $ua => $device) {
+            $agent->setUserAgent($ua);
+            $this->assertEquals($device, $agent->device(), $ua);
+            $this->assertTrue($agent->isMobile(), $ua);
+            $this->assertFalse($agent->isDesktop(), $ua);
+
+            if (!strpos($device, ' ')) {
+                $method = "is{$device}";
+                $this->assertTrue($agent->{$method}(), $ua, $method);
+            }
+        }
+    }
+
+    public function testDesktopDevices()
+    {
+        $agent = new Agent();
+
+        foreach ($this->desktopDevices as $ua => $device) {
+            $agent->setUserAgent($ua);
+            $this->assertEquals($device, $agent->device(), $ua);
+            $this->assertFalse($agent->isMobile(), $ua);
+            $this->assertTrue($agent->isDesktop(), $ua);
+
+            if (!strpos($device, ' ')) {
+                $method = "is{$device}";
+                $this->assertTrue($agent->{$method}(), $ua);
+            }
+        }
+    }
+
+    public function testVersions()
+    {
+        $agent = new Agent();
+
+        foreach ($this->browserVersions as $ua => $version) {
+            $agent->setUserAgent($ua);
+            $browser = $agent->browser();
+            $this->assertEquals($version, $agent->version($browser), $ua);
+        }
+
+        foreach ($this->operatingSystemVersions as $ua => $version) {
+            $agent->setUserAgent($ua);
+            $platform = $agent->platform();
+            $this->assertEquals($version, $agent->version($platform), $ua);
+        }
+
+        foreach ($this->browsers as $ua => $browser) {
+            $agent->setUserAgent('FAKE');
+            $this->assertFalse($agent->version($browser));
+        }
+    }
+
+    public function testIsMethods()
+    {
+        $agent = new Agent();
+
+        foreach ($this->desktops as $ua) {
+            $agent->setUserAgent($ua);
+            $this->assertTrue($agent->isDesktop(), $ua);
+            $this->assertFalse($agent->isMobile(), $ua);
+            $this->assertFalse($agent->isTablet(), $ua);
+            $this->assertFalse($agent->isPhone(), $ua);
+            $this->assertFalse($agent->isRobot(), $ua);
+        }
+
+        foreach ($this->phones as $ua) {
+            $agent->setUserAgent($ua);
+            $this->assertTrue($agent->isPhone(), $ua);
+            $this->assertTrue($agent->isMobile(), $ua);
+            $this->assertFalse($agent->isDesktop(), $ua);
+            $this->assertFalse($agent->isTablet(), $ua);
+            $this->assertFalse($agent->isRobot(), $ua);
+        }
+
+        foreach ($this->robots as $ua => $robot) {
+            $agent->setUserAgent($ua);
+            $this->assertTrue($agent->isRobot(), $ua);
+            $this->assertFalse($agent->isDesktop(), $ua);
+            $this->assertFalse($agent->isMobile(), $ua);
+            $this->assertFalse($agent->isTablet(), $ua);
+            $this->assertFalse($agent->isPhone(), $ua);
+        }
+
+        foreach ($this->mobileDevices as $ua => $device) {
+            $agent->setUserAgent($ua);
+            $this->assertTrue($agent->isMobile(), $ua);
+            $this->assertFalse($agent->isDesktop(), $ua);
+            $this->assertFalse($agent->isRobot(), $ua);
+        }
+
+        foreach ($this->desktopDevices as $ua => $device) {
+            $agent->setUserAgent($ua);
+            $this->assertTrue($agent->isDesktop(), $ua);
+            $this->assertFalse($agent->isMobile(), $ua);
+            $this->assertFalse($agent->isTablet(), $ua);
+            $this->assertFalse($agent->isPhone(), $ua);
+            $this->assertFalse($agent->isRobot(), $ua);
+        }
+    }
+}

--- a/tests/AgentTest.php
+++ b/tests/AgentTest.php
@@ -3,6 +3,7 @@
 namespace Laravel\Jetstream\Tests;
 
 use Laravel\Jetstream\Agent;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -10,9 +11,7 @@ use PHPUnit\Framework\TestCase;
  */
 class AgentTest extends TestCase
 {
-    /**
-     * @dataProvider operatingSystemsDataProvider
-     */
+    #[DataProvider('operatingSystemsDataProvider')]
     public function testOperatingSystems($ua, $platform)
     {
         $agent = new Agent();
@@ -33,9 +32,7 @@ class AgentTest extends TestCase
         yield ['Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36', 'Windows'];
     }
 
-    /**
-     * @dataProvider browsersDataProvider
-     */
+    #[DataProvider('browsersDataProvider')]
     public function testBrowsers($ua, $browser)
     {
         $agent = new Agent();
@@ -63,9 +60,7 @@ class AgentTest extends TestCase
         yield ['Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) coc_coc_browser/86.0.180 Chrome/80.0.3987.180 Safari/537.36', 'Coc Coc'];
     }
 
-    /**
-     * @dataProvider devicesDataProvider
-     */
+    #[DataProvider('devicesDataProvider')]
     public function testDesktopDevices($ua, $expected)
     {
         $agent = new Agent();

--- a/tests/AgentTest.php
+++ b/tests/AgentTest.php
@@ -15,7 +15,8 @@ class AgentTest extends TestCase
      */
     public function testOperatingSystems($ua, $platform)
     {
-        $agent = new Agent($ua);
+        $agent = new Agent();
+        $agent->setUserAgent($ua);
 
         $this->assertEquals($platform, $agent->platform(), $ua);
     }
@@ -37,7 +38,8 @@ class AgentTest extends TestCase
      */
     public function testBrowsers($ua, $browser)
     {
-        $agent = new Agent($ua);
+        $agent = new Agent();
+        $agent->setUserAgent($ua);
 
         $this->assertEquals($browser, $agent->browser());
     }
@@ -66,7 +68,8 @@ class AgentTest extends TestCase
      */
     public function testDesktopDevices($ua, $expected)
     {
-        $agent = new Agent($ua);
+        $agent = new Agent();
+        $agent->setUserAgent($ua);
 
         $this->assertSame($expected, $agent->isDesktop());
     }

--- a/tests/AgentTest.php
+++ b/tests/AgentTest.php
@@ -11,13 +11,18 @@ use PHPUnit\Framework\TestCase;
  */
 class AgentTest extends TestCase
 {
+    /**
+     * @param  string  $userAgent
+     * @param  string  $platform
+     * @return void
+     */
     #[DataProvider('operatingSystemsDataProvider')]
-    public function testOperatingSystems($ua, $platform)
+    public function testOperatingSystems($userAgent, $platform)
     {
         $agent = new Agent();
-        $agent->setUserAgent($ua);
+        $agent->setUserAgent($userAgent);
 
-        $this->assertEquals($platform, $agent->platform(), $ua);
+        $this->assertEquals($platform, $agent->platform());
     }
 
     public static function operatingSystemsDataProvider()
@@ -32,11 +37,16 @@ class AgentTest extends TestCase
         yield ['Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36', 'Windows'];
     }
 
+    /**
+     * @param  string  $userAgent
+     * @param  string  $browser
+     * @return void
+     */
     #[DataProvider('browsersDataProvider')]
-    public function testBrowsers($ua, $browser)
+    public function testBrowsers($userAgent, $browser)
     {
         $agent = new Agent();
-        $agent->setUserAgent($ua);
+        $agent->setUserAgent($userAgent);
 
         $this->assertEquals($browser, $agent->browser());
     }
@@ -60,11 +70,16 @@ class AgentTest extends TestCase
         yield ['Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) coc_coc_browser/86.0.180 Chrome/80.0.3987.180 Safari/537.36', 'Coc Coc'];
     }
 
+    /**
+     * @param  string  $userAgent
+     * @param  bool  $expected
+     * @return void
+     */
     #[DataProvider('devicesDataProvider')]
-    public function testDesktopDevices($ua, $expected)
+    public function testDesktopDevices($userAgent, $expected)
     {
         $agent = new Agent();
-        $agent->setUserAgent($ua);
+        $agent->setUserAgent($userAgent);
 
         $this->assertSame($expected, $agent->isDesktop());
     }

--- a/tests/AgentTest.php
+++ b/tests/AgentTest.php
@@ -2,283 +2,81 @@
 
 namespace Laravel\Jetstream\Tests;
 
-use Jenssegers\Agent\Agent;
+use Laravel\Jetstream\Agent;
 use PHPUnit\Framework\TestCase;
 
 class AgentTest extends TestCase
 {
-    private $operatingSystems = [
-        'Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko' => 'Windows',
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/537.13+ (KHTML, like Gecko) Version/5.1.7 Safari/534.57.2' => 'OS X',
-        'Mozilla/5.0 (iPad; CPU OS 5_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko ) Version/5.1 Mobile/9B176 Safari/7534.48.3' => 'iOS',
-        'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:24.0) Gecko/20100101 Firefox/24.0' => 'Ubuntu',
-        'Mozilla/5.0 (BlackBerry; U; BlackBerry 9900; en) AppleWebKit/534.11+ (KHTML, like Gecko) Version/7.1.0.346 Mobile Safari/534.11+' => 'BlackBerryOS',
-        'Mozilla/5.0 (Linux; U; Android 2.2; en-us; Nexus One Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1' => 'AndroidOS',
-        'Mozilla/5.0 (X11; CrOS x86_64 6680.78.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.102 Safari/537.36' => 'ChromeOS',
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36' => 'Windows',
-    ];
-
-    private $browsers = [
-        'Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko' => 'IE',
-        'Mozilla/5.0 (iPad; CPU OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5355d Safari/8536.25' => 'Safari',
-        'Mozilla/5.0 (Windows; U; Win 9x 4.90; SG; rv:1.9.2.4) Gecko/20101104 Netscape/9.1.0285' => 'Netscape',
-        'Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:25.0) Gecko/20100101 Firefox/25.0' => 'Firefox',
-        'Mozilla/5.0 (Windows NT 6.2; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1667.0 Safari/537.36' => 'Chrome',
-        'Mozilla/5.0 (Windows; U; Windows NT 6.1; rv:2.2) Gecko/20110201' => 'Mozilla',
-        'Opera/9.80 (Windows NT 6.0) Presto/2.12.388 Version/12.14' => 'Opera',
-        'Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.115 Safari/537.36 OPR/27.0.1689.76' => 'Opera',
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12' => 'Edge',
-        'Mozilla/5.0 (iPhone; CPU iPhone OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5376e Safari/8536.25' => 'Safari',
-        'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36 Vivaldi/1.2.490.43' => 'Vivaldi',
-        'Mozilla/5.0 (Linux; U; Android 4.0.4; en-US; LT28h Build/6.1.E.3.7) AppleWebKit/534.31 (KHTML, like Gecko) UCBrowser/9.2.2.323 U3/0.8.0 Mobile Safari/534.31' => 'UCBrowser',
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edge/15.15063' => 'Edge',
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.29 Safari/537.36 Edg/79.0.309.18' => 'Edge',
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) coc_coc_browser/86.0.180 Chrome/80.0.3987.180 Safari/537.36' => 'Coc Coc',
-    ];
-
-    private $robots = [
-        // 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)' => 'Googlebot',
-        'facebookexternalhit/1.1 (+http(s)://www.facebook.com/externalhit_uatext.php)' => 'Facebookexternalhit',
-        // 'Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)' => 'Bingbot',
-        'Twitterbot/1.0' => 'Twitterbot',
-        // 'Mozilla/5.0 (compatible; YandexBot/3.0; +http://yandex.com/bots)' => 'Yandex',
-    ];
-
-    private $mobileDevices = [
-        'Mozilla/5.0 (iPhone; U; ru; CPU iPhone OS 4_2_1 like Mac OS X; ru) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8C148a Safari/6533.18.5' => 'iPhone',
-        'Mozilla/5.0 (iPad; CPU OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5355d Safari/8536.25' => 'iPad',
-        'Mozilla/5.0 (Linux; U; Android 2.3.4; fr-fr; HTC Desire Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1' => 'HTC',
-        'Mozilla/5.0 (BlackBerry; U; BlackBerry 9900; en) AppleWebKit/534.11+ (KHTML, like Gecko) Version/7.1.0.346 Mobile Safari/534.11+' => 'BlackBerry',
-        'Mozilla/5.0 (Linux; U; Android 2.2; en-us; Nexus One Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1' => 'Nexus',
-        'Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; ASUS Transformer Pad TF300T Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30' => 'AsusTablet',
-    ];
-
-    private $desktopDevices = [
-        //'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11) AppleWebKit/601.1.56 (KHTML, like Gecko) Version/9.0 Safari/601.1.56' => 'Macintosh',
-    ];
-
-    private $browserVersions = [
-        'Mozilla/5.0 (compatible; MSIE 10.6; Windows NT 6.1; Trident/5.0; InfoPath.2; SLCC1; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; .NET CLR 2.0.50727) 3gpp-gba UNTRUSTED/1.0' => '10.6',
-        'Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko' => '11.0',
-        'Mozilla/5.0 (iPad; CPU OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5355d Safari/8536.25' => '6.0',
-        'Mozilla/5.0 (Windows; U; Win 9x 4.90; SG; rv:1.9.2.4) Gecko/20101104 Netscape/9.1.0285' => '9.1.0285',
-        'Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:25.0) Gecko/20100101 Firefox/25.0' => '25.0',
-        'Mozilla/5.0 (Windows NT 6.2; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1667.0 Safari/537.36' => '32.0.1667.0',
-        'Mozilla/5.0 (Windows; U; Windows NT 6.1; rv:2.2) Gecko/20110201' => '2.2',
-        'Opera/9.80 (Windows NT 6.0) Presto/2.12.388 Version/12.14' => '12.14',
-        'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; de) Opera 11.51' => '11.51',
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12' => '12',
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.29 Safari/537.36 Edg/79.0.309.18' => '79.0.309.18',
-        'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36 Vivaldi/1.2.490.43' => '1.2.490.43',
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) coc_coc_browser/86.0.180 Chrome/80.0.3987.180 Safari/537.36' => '86.0.180',
-    ];
-
-    private $operatingSystemVersions = [
-        'Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko' => '6.3',
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/537.13+ (KHTML, like Gecko) Version/5.1.7 Safari/534.57.2' => '10_6_8',
-        'Mozilla/5.0 (iPad; CPU OS 5_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko ) Version/5.1 Mobile/9B176 Safari/7534.48.3' => '5_1',
-        'Mozilla/5.0 (BlackBerry; U; BlackBerry 9900; en) AppleWebKit/534.11+ (KHTML, like Gecko) Version/7.1.0.346 Mobile Safari/534.11+' => '7.1.0.346',
-        'Mozilla/5.0 (Linux; U; Android 2.2; en-us; Nexus One Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1' => '2.2',
-        'Mozilla/5.0 (X11; CrOS x86_64 6680.78.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.102 Safari/537.36' => '6680.78.0',
-    ];
-
-    private $desktops = [
-        // 'Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko',
-        // 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:24.0) Gecko/20100101 Firefox/24.0',
-        // 'Mozilla/5.0 (Windows; U; Win 9x 4.90; SG; rv:1.9.2.4) Gecko/20101104 Netscape/9.1.0285',
-        // 'Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:25.0) Gecko/20100101 Firefox/25.0',
-        // 'Mozilla/5.0 (Windows NT 6.2; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1667.0 Safari/537.36',
-        // 'Mozilla/5.0 (Windows; U; Windows NT 6.1; rv:2.2) Gecko/20110201',
-        // 'Opera/9.80 (Windows NT 6.0) Presto/2.12.388 Version/12.14',
-        // 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/537.13+ (KHTML, like Gecko) Version/5.1.7 Safari/534.57.2',
-    ];
-
-    private $phones = [
-        'Mozilla/5.0 (iPhone; U; ru; CPU iPhone OS 4_2_1 like Mac OS X; ru) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8C148a Safari/6533.18.5',
-        'Mozilla/5.0 (Linux; U; Android 2.3.4; fr-fr; HTC Desire Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1',
-        'Mozilla/5.0 (BlackBerry; U; BlackBerry 9900; en) AppleWebKit/534.11+ (KHTML, like Gecko) Version/7.1.0.346 Mobile Safari/534.11+',
-        'Mozilla/5.0 (Linux; U; Android 2.2; en-us; Nexus One Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1',
-    ];
-
-    public function testLanguages()
+    /**
+     * @dataProvider operatingSystemsDataProvider
+     */
+    public function testOperatingSystems($ua, $platform)
     {
-        $agent = new Agent();
-        $agent->setHttpHeaders([
-            'HTTP_ACCEPT_LANGUAGE' => 'nl-NL,nl;q=0.8,en-US;q=0.6,en;q=0.4',
-        ]);
+        $agent = new Agent($ua);
 
-        $this->assertEquals(['nl-nl', 'nl', 'en-us', 'en'], $agent->languages());
+        $this->assertEquals($platform, $agent->platform(), $ua);
     }
 
-    public function testLanguagesSorted()
+    public static function operatingSystemsDataProvider()
     {
-        $agent = new Agent();
-        $agent->setHttpHeaders([
-            'HTTP_ACCEPT_LANGUAGE' => 'en;q=0.4,en-US,nl;q=0.6',
-        ]);
-
-        $this->assertEquals(['en-us', 'nl', 'en'], $agent->languages());
+        yield ['Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10586', 'Windows'];
+        yield ['Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/537.13+ (KHTML, like Gecko) Version/5.1.7 Safari/534.57.2', 'OS X'];
+        yield ['Mozilla/5.0 (iPad; CPU OS 5_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko ) Version/5.1 Mobile/9B176 Safari/7534.48.3', 'iOS'];
+        yield ['Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:24.0) Gecko/20100101 Firefox/24.0', 'Ubuntu'];
+        yield ['Mozilla/5.0 (BlackBerry; U; BlackBerry 9900; en) AppleWebKit/534.11+ (KHTML, like Gecko) Version/7.1.0.346 Mobile Safari/534.11+', 'BlackBerryOS'];
+        yield ['Mozilla/5.0 (Linux; U; Android 2.2; en-us; Nexus One Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1', 'AndroidOS'];
+        yield ['Mozilla/5.0 (X11; CrOS x86_64 6680.78.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.102 Safari/537.36', 'ChromeOS'];
+        yield ['Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36', 'Windows'];
     }
 
-    public function testOperatingSystems()
+    /**
+     * @dataProvider browsersDataProvider
+     */
+    public function testBrowsers($ua, $browser)
     {
-        $agent = new Agent();
+        $agent = new Agent($ua);
 
-        foreach ($this->operatingSystems as $ua => $platform) {
-            $agent->setUserAgent($ua);
-            $this->assertEquals($platform, $agent->platform(), $ua);
-            $this->assertTrue($agent->is($platform), $platform);
-
-            if (! strpos($platform, ' ')) {
-                $method = "is{$platform}";
-                $this->assertTrue($agent->{$method}(), $ua);
-            }
-        }
+        $this->assertEquals($browser, $agent->browser());
     }
 
-    public function testBrowsers()
+    public static function browsersDataProvider()
     {
-        $agent = new Agent();
-
-        foreach ($this->browsers as $ua => $browser) {
-            $agent->setUserAgent($ua);
-            $this->assertEquals($browser, $agent->browser(), $ua);
-            $this->assertTrue($agent->is($browser), $browser);
-
-            if (! strpos($browser, ' ')) {
-                $method = "is{$browser}";
-                $this->assertTrue($agent->{$method}(), $ua);
-            }
-        }
+        yield ['Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko', 'IE'];
+        yield ['Mozilla/5.0 (iPad; CPU OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5355d Safari/8536.25', 'Safari'];
+        yield ['Mozilla/5.0 (Windows; U; Win 9x 4.90; SG; rv:1.9.2.4) Gecko/20101104 Netscape/9.1.0285', 'Netscape'];
+        yield ['Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:25.0) Gecko/20100101 Firefox/25.0', 'Firefox'];
+        yield ['Mozilla/5.0 (Windows NT 6.2; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1667.0 Safari/537.36', 'Chrome'];
+        yield ['Mozilla/5.0 (Windows; U; Windows NT 6.1; rv:2.2) Gecko/20110201', 'Mozilla'];
+        yield ['Opera/9.80 (Windows NT 6.0) Presto/2.12.388 Version/12.14', 'Opera'];
+        yield ['Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.115 Safari/537.36 OPR/27.0.1689.76', 'Opera'];
+        yield ['Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12', 'Edge'];
+        yield ['Mozilla/5.0 (iPhone; CPU iPhone OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5376e Safari/8536.25', 'Safari'];
+        yield ['Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36 Vivaldi/1.2.490.43', 'Vivaldi'];
+        yield ['Mozilla/5.0 (Linux; U; Android 4.0.4; en-US; LT28h Build/6.1.E.3.7) AppleWebKit/534.31 (KHTML, like Gecko) UCBrowser/9.2.2.323 U3/0.8.0 Mobile Safari/534.31', 'UCBrowser'];
+        yield ['Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edge/15.15063', 'Edge'];
+        yield ['Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.29 Safari/537.36 Edg/79.0.309.18', 'Edge'];
+        yield ['Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) coc_coc_browser/86.0.180 Chrome/80.0.3987.180 Safari/537.36', 'Coc Coc'];
     }
 
-    public function testRobots()
+    /**
+     * @dataProvider devicesDataProvider
+     */
+    public function testDesktopDevices($ua, $expected)
     {
-        $agent = new Agent();
+        $agent = new Agent($ua);
 
-        foreach ($this->robots as $ua => $robot) {
-            $agent->setUserAgent($ua);
-            $this->assertTrue($agent->isRobot(), $ua);
-            $this->assertEquals($robot, $agent->robot());
-        }
+        $this->assertSame($expected, $agent->isDesktop());
     }
 
-    public function testRobotShouldReturnFalse()
+    public static function devicesDataProvider()
     {
-        $agent = new Agent();
-
-        $this->assertFalse($agent->robot());
-    }
-
-    public function testCallShouldThrowBadMethodCallException()
-    {
-        $this->expectException('BadMethodCallException');
-
-        $agent = new Agent();
-        $agent->invalidMethod();
-    }
-
-    public function testMobileDevices()
-    {
-        $agent = new Agent();
-
-        foreach ($this->mobileDevices as $ua => $device) {
-            $agent->setUserAgent($ua);
-            $this->assertEquals($device, $agent->device(), $ua);
-            $this->assertTrue($agent->isMobile(), $ua);
-            $this->assertFalse($agent->isDesktop(), $ua);
-
-            if (! strpos($device, ' ')) {
-                $method = "is{$device}";
-                $this->assertTrue($agent->{$method}(), $ua, $method);
-            }
-        }
-    }
-
-    public function testDesktopDevices()
-    {
-        $agent = new Agent();
-
-        foreach ($this->desktopDevices as $ua => $device) {
-            $agent->setUserAgent($ua);
-            $this->assertEquals($device, $agent->device(), $ua);
-            $this->assertFalse($agent->isMobile(), $ua);
-            $this->assertTrue($agent->isDesktop(), $ua);
-
-            if (! strpos($device, ' ')) {
-                $method = "is{$device}";
-                $this->assertTrue($agent->{$method}(), $ua);
-            }
-        }
-    }
-
-    public function testVersions()
-    {
-        $agent = new Agent();
-
-        foreach ($this->browserVersions as $ua => $version) {
-            $agent->setUserAgent($ua);
-            $browser = $agent->browser();
-            $this->assertEquals($version, $agent->version($browser), $ua);
-        }
-
-        foreach ($this->operatingSystemVersions as $ua => $version) {
-            $agent->setUserAgent($ua);
-            $platform = $agent->platform();
-            $this->assertEquals($version, $agent->version($platform), $ua);
-        }
-
-        foreach ($this->browsers as $ua => $browser) {
-            $agent->setUserAgent('FAKE');
-            $this->assertFalse($agent->version($browser));
-        }
-    }
-
-    public function testIsMethods()
-    {
-        $agent = new Agent();
-
-        foreach ($this->desktops as $ua) {
-            $agent->setUserAgent($ua);
-            $this->assertTrue($agent->isDesktop(), $ua);
-            $this->assertFalse($agent->isMobile(), $ua);
-            $this->assertFalse($agent->isTablet(), $ua);
-            $this->assertFalse($agent->isPhone(), $ua);
-            $this->assertFalse($agent->isRobot(), $ua);
-        }
-
-        foreach ($this->phones as $ua) {
-            $agent->setUserAgent($ua);
-            $this->assertTrue($agent->isPhone(), $ua);
-            $this->assertTrue($agent->isMobile(), $ua);
-            $this->assertFalse($agent->isDesktop(), $ua);
-            $this->assertFalse($agent->isTablet(), $ua);
-            $this->assertFalse($agent->isRobot(), $ua);
-        }
-
-        foreach ($this->robots as $ua => $robot) {
-            $agent->setUserAgent($ua);
-            $this->assertTrue($agent->isRobot(), $ua);
-            $this->assertFalse($agent->isDesktop(), $ua);
-            $this->assertFalse($agent->isMobile(), $ua);
-            $this->assertFalse($agent->isTablet(), $ua);
-            $this->assertFalse($agent->isPhone(), $ua);
-        }
-
-        foreach ($this->mobileDevices as $ua => $device) {
-            $agent->setUserAgent($ua);
-            $this->assertTrue($agent->isMobile(), $ua);
-            $this->assertFalse($agent->isDesktop(), $ua);
-            $this->assertFalse($agent->isRobot(), $ua);
-        }
-
-        foreach ($this->desktopDevices as $ua => $device) {
-            $agent->setUserAgent($ua);
-            $this->assertTrue($agent->isDesktop(), $ua);
-            $this->assertFalse($agent->isMobile(), $ua);
-            $this->assertFalse($agent->isTablet(), $ua);
-            $this->assertFalse($agent->isPhone(), $ua);
-            $this->assertFalse($agent->isRobot(), $ua);
-        }
+        // User Agent, Is Desktop?
+        yield ['Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11) AppleWebKit/601.1.56 (KHTML, like Gecko) Version/9.0 Safari/601.1.56', true];
+        yield ['Mozilla/5.0 (iPhone; U; ru; CPU iPhone OS 4_2_1 like Mac OS X; ru) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8C148a Safari/6533.18.5', false];
+        yield ['Mozilla/5.0 (iPad; CPU OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5355d Safari/8536.25', false];
+        yield ['Mozilla/5.0 (Linux; U; Android 2.3.4; fr-fr; HTC Desire Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1', false];
+        yield ['Mozilla/5.0 (BlackBerry; U; BlackBerry 9900; en) AppleWebKit/534.11+ (KHTML, like Gecko) Version/7.1.0.346 Mobile Safari/534.11+', false];
+        yield ['Mozilla/5.0 (Linux; U; Android 2.2; en-us; Nexus One Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1', false];
+        yield ['Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; ASUS Transformer Pad TF300T Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30', false];
     }
 }

--- a/tests/AgentTest.php
+++ b/tests/AgentTest.php
@@ -5,6 +5,9 @@ namespace Laravel\Jetstream\Tests;
 use Laravel\Jetstream\Agent;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @copyright Originally created by Jens Segers: https://github.com/jenssegers/agent
+ */
 class AgentTest extends TestCase
 {
     /**

--- a/tests/AgentTest.php
+++ b/tests/AgentTest.php
@@ -129,7 +129,7 @@ class AgentTest extends TestCase
             $this->assertEquals($platform, $agent->platform(), $ua);
             $this->assertTrue($agent->is($platform), $platform);
 
-            if (!strpos($platform, ' ')) {
+            if (! strpos($platform, ' ')) {
                 $method = "is{$platform}";
                 $this->assertTrue($agent->{$method}(), $ua);
             }
@@ -145,7 +145,7 @@ class AgentTest extends TestCase
             $this->assertEquals($browser, $agent->browser(), $ua);
             $this->assertTrue($agent->is($browser), $browser);
 
-            if (!strpos($browser, ' ')) {
+            if (! strpos($browser, ' ')) {
                 $method = "is{$browser}";
                 $this->assertTrue($agent->{$method}(), $ua);
             }
@@ -188,7 +188,7 @@ class AgentTest extends TestCase
             $this->assertTrue($agent->isMobile(), $ua);
             $this->assertFalse($agent->isDesktop(), $ua);
 
-            if (!strpos($device, ' ')) {
+            if (! strpos($device, ' ')) {
                 $method = "is{$device}";
                 $this->assertTrue($agent->{$method}(), $ua, $method);
             }
@@ -205,7 +205,7 @@ class AgentTest extends TestCase
             $this->assertFalse($agent->isMobile(), $ua);
             $this->assertTrue($agent->isDesktop(), $ua);
 
-            if (!strpos($device, ' ')) {
+            if (! strpos($device, ' ')) {
                 $method = "is{$device}";
                 $this->assertTrue($agent->{$method}(), $ua);
             }


### PR DESCRIPTION
* Port `Jenssegers\Agent\Agent` to `Laravel\Jetstream\Agent`
  - Without `isRobot()` detection