### PR TITLE
deleteTeam() return type

### DIFF
--- a/src/Http/Livewire/DeleteTeamForm.php
+++ b/src/Http/Livewire/DeleteTeamForm.php
@@ -42,7 +42,7 @@ class DeleteTeamForm extends Component
      *
      * @param  \Laravel\Jetstream\Actions\ValidateTeamDeletion  $validator
      * @param  \Laravel\Jetstream\Contracts\DeletesTeams  $deleter
-     * @return \Illuminate\Http\Response | \Illuminate\Http\RedirectResponse | \Livewire\Features\SupportRedirects\Redirector
+     * @return mixed
      */
     public function deleteTeam(ValidateTeamDeletion $validator, DeletesTeams $deleter)
     {

--- a/src/Http/Livewire/DeleteTeamForm.php
+++ b/src/Http/Livewire/DeleteTeamForm.php
@@ -42,7 +42,7 @@ class DeleteTeamForm extends Component
      *
      * @param  \Laravel\Jetstream\Actions\ValidateTeamDeletion  $validator
      * @param  \Laravel\Jetstream\Contracts\DeletesTeams  $deleter
-     * @return void
+     * @return \Illuminate\Http\Response | \Illuminate\Http\RedirectResponse | \Livewire\Features\SupportRedirects\Redirector
      */
     public function deleteTeam(ValidateTeamDeletion $validator, DeletesTeams $deleter)
     {


### PR DESCRIPTION
Fix invalid return type.
The deleteTeam() method currently has `void` set as return type. It redirects...

This changes the return type to `\Illuminate\Http\Response | \Illuminate\Http\RedirectResponse | \Livewire\Features\SupportRedirects\Redirector `

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

If you change the behavior of the Inertia stack you're expected to update the Livewire stack as well and vice versa.
-->
