### PR TITLE
Set password in session on update for inertia

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "ext-json": "*",
         "illuminate/console": "^10.17",
         "illuminate/support": "^10.17",
-        "laravel/fortify": "^1.15",
+        "laravel/fortify": "^1.19",
         "mobiledetect/mobiledetectlib": "^4.8"
     },
     "require-dev": {

--- a/src/JetstreamServiceProvider.php
+++ b/src/JetstreamServiceProvider.php
@@ -6,10 +6,13 @@ use App\Http\Middleware\HandleInertiaRequests;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\View\Compilers\BladeCompiler;
 use Inertia\Inertia;
+use Laravel\Fortify\Events\PasswordUpdatedViaController;
 use Laravel\Fortify\Fortify;
 use Laravel\Jetstream\Http\Livewire\ApiTokenManager;
 use Laravel\Jetstream\Http\Livewire\CreateTeamForm;
@@ -177,6 +180,12 @@ class JetstreamServiceProvider extends ServiceProvider
         if (class_exists(HandleInertiaRequests::class)) {
             $kernel->appendToMiddlewarePriority(HandleInertiaRequests::class);
         }
+
+        Event::listen(function (PasswordUpdatedViaController $event) {
+            if (request()->hasSession()) {
+                request()->session()->put(['password_hash_sanctum' => Auth::user()->getAuthPassword()]);
+            }
+        });
 
         Fortify::loginView(function () {
             return Inertia::render('Auth/Login', [


### PR DESCRIPTION
Like Livewire, Inertia needs to update the password hash in the session when it is updated by the Fortify service.