### PR TITLE
[4.x] Fix Browser Sessions not showing platform and browser

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -3,8 +3,6 @@
 namespace Laravel\Jetstream;
 
 use Closure;
-use Detection\Cache\CacheException;
-use Detection\Exception\MobileDetectException;
 use Detection\MobileDetect;
 
 /**
@@ -51,9 +49,9 @@ class Agent extends MobileDetect
     ];
 
     /**
-     * Key value store for resolved strings
+     * Key value store for resolved strings.
      *
-     * @var array<string: mixed>
+     * @var array<string, mixed>
      */
     protected $store = [];
 
@@ -133,24 +131,18 @@ class Agent extends MobileDetect
      * @param  string  $key
      * @param  \Closure():mixed  $callback
      * @return mixed
-     *
-     * @throws \Detection\Exception\MobileDetectException
      */
     protected function retrieveUsingCacheOrResolve(string $key, Closure $callback)
     {
-        try {
-            $cacheKey = $this->createCacheKey($key);
+        $cacheKey = $this->createCacheKey($key);
 
-            if (! is_null($cacheItem = $this->store[$cacheKey] ?? null)) {
-                return $cacheItem;
-            }
-
-            return tap(call_user_func($callback), function ($result) use ($cacheKey) {
-                $this->store[$cacheKey] = $result;
-            });
-        } catch (CacheException $e) {
-            throw new MobileDetectException("Cache problem in for {$key}: {$e->getMessage()}");
+        if (! is_null($cacheItem = $this->store[$cacheKey] ?? null)) {
+            return $cacheItem;
         }
+
+        return tap(call_user_func($callback), function ($result) use ($cacheKey) {
+            $this->store[$cacheKey] = $result;
+        });
     }
 
     /**

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -51,6 +51,13 @@ class Agent extends MobileDetect
     ];
 
     /**
+     * Key value store for resolved strings
+     *
+     * @var array<string: mixed>
+     */
+    protected $store = [];
+
+    /**
      * Get the platform name from the User Agent.
      *
      * @return string|null
@@ -134,12 +141,12 @@ class Agent extends MobileDetect
         try {
             $cacheKey = $this->createCacheKey($key);
 
-            if (! is_null($cacheItem = $this->cache->get($cacheKey))) {
-                return $cacheItem->get();
+            if (! is_null($cacheItem = $this->store[$cacheKey] ?? null)) {
+                return $cacheItem;
             }
 
             return tap(call_user_func($callback), function ($result) use ($cacheKey) {
-                $this->cache->set($cacheKey, $result);
+                $this->store[$cacheKey] = $result;
             });
         } catch (CacheException $e) {
             throw new MobileDetectException("Cache problem in for {$key}: {$e->getMessage()}");

--- a/tests/AgentTest.php
+++ b/tests/AgentTest.php
@@ -22,7 +22,10 @@ class AgentTest extends TestCase
         $agent = new Agent();
         $agent->setUserAgent($userAgent);
 
-        $this->assertEquals($platform, $agent->platform());
+        $this->assertSame($platform, $agent->platform());
+
+        // Test cached value return the same output.
+        $this->assertSame($platform, $agent->platform());
     }
 
     public static function operatingSystemsDataProvider()
@@ -48,7 +51,10 @@ class AgentTest extends TestCase
         $agent = new Agent();
         $agent->setUserAgent($userAgent);
 
-        $this->assertEquals($browser, $agent->browser());
+        $this->assertSame($browser, $agent->browser());
+
+        // Test cached value return the same output.
+        $this->assertSame($browser, $agent->browser());
     }
 
     public static function browsersDataProvider()


### PR DESCRIPTION
Browser Sessions are currently showing '1-1'  when they should be displaying 'Platform - Browser', the image below shows reality/expected behaviour.

![browser sessions](https://github.com/laravel/jetstream/assets/5549119/a07c33b3-3a89-4cf8-9010-0005d1f07de2)

#1399 used the cache implemented in `mobiledetect/mobiledetectlib` which [only supports `bool` values](https://github.com/serbanghita/Mobile-Detect/blob/90416e034adbf939c436c8bbb16877d776fc239b/src/Cache/CacheItem.php#L15-L18). As multiple calls to `agent->platform()` and `agent->browser()` are made in the component the cache is engaged and produces boolean values instead of the expected strings.

This pull request replaces the `mobiledetect` cache implementation with a simple key value store on the `Agent` class.

Current tests pass as the first call to `agent->platform()` and `agent->browser()` do not hit the cache. Hopefully I will have time tomorrow to update the tests too.

I am not sure if this is the ideal solution or if the `mobiledetect` cache should be reimplemented to support mixed values. I briefly considered using the Laravel cache, but considering this data is only stored for the request lifecycle it seemed a little over the top.

