### PR TITLE
Fixed email autocomplete field for inertia and livewire in UpdateProfileInformationForm component.

### DIFF
--- a/stubs/inertia/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
@@ -151,7 +151,7 @@ const clearPhotoFileInput = () => {
                     type="email"
                     class="mt-1 block w-full"
                     required
-                    autocomplete="username"
+                    autocomplete="email"
                 />
                 <InputError :message="form.errors.email" class="mt-2" />
 

--- a/stubs/livewire/resources/views/profile/update-profile-information-form.blade.php
+++ b/stubs/livewire/resources/views/profile/update-profile-information-form.blade.php
@@ -62,7 +62,7 @@
         <!-- Email -->
         <div class="col-span-6 sm:col-span-4">
             <x-label for="email" value="{{ __('Email') }}" />
-            <x-input id="email" type="email" class="mt-1 block w-full" wire:model="state.email" required autocomplete="username" />
+            <x-input id="email" type="email" class="mt-1 block w-full" wire:model="state.email" required autocomplete="email" />
             <x-input-error for="email" class="mt-2" />
 
             @if (Laravel\Fortify\Features::enabled(Laravel\Fortify\Features::emailVerification()) && ! $this->user->hasVerifiedEmail())


### PR DESCRIPTION
As the title states the autocomplete field has been changed to email instead of username for the email form of the UpdateProfileInformationForm.