### PR TITLE
[4.x] Remove Unreachable `return` in PHPUnit test stubs

### DIFF
--- a/stubs/tests/EmailVerificationTest.php
+++ b/stubs/tests/EmailVerificationTest.php
@@ -19,8 +19,6 @@ class EmailVerificationTest extends TestCase
     {
         if (! Features::enabled(Features::emailVerification())) {
             $this->markTestSkipped('Email verification not enabled.');
-
-            return;
         }
 
         $user = User::factory()->withPersonalTeam()->unverified()->create();
@@ -34,8 +32,6 @@ class EmailVerificationTest extends TestCase
     {
         if (! Features::enabled(Features::emailVerification())) {
             $this->markTestSkipped('Email verification not enabled.');
-
-            return;
         }
 
         Event::fake();
@@ -60,8 +56,6 @@ class EmailVerificationTest extends TestCase
     {
         if (! Features::enabled(Features::emailVerification())) {
             $this->markTestSkipped('Email verification not enabled.');
-
-            return;
         }
 
         $user = User::factory()->unverified()->create();

--- a/stubs/tests/PasswordResetTest.php
+++ b/stubs/tests/PasswordResetTest.php
@@ -17,8 +17,6 @@ class PasswordResetTest extends TestCase
     {
         if (! Features::enabled(Features::resetPasswords())) {
             $this->markTestSkipped('Password updates are not enabled.');
-
-            return;
         }
 
         $response = $this->get('/forgot-password');
@@ -30,8 +28,6 @@ class PasswordResetTest extends TestCase
     {
         if (! Features::enabled(Features::resetPasswords())) {
             $this->markTestSkipped('Password updates are not enabled.');
-
-            return;
         }
 
         Notification::fake();
@@ -49,8 +45,6 @@ class PasswordResetTest extends TestCase
     {
         if (! Features::enabled(Features::resetPasswords())) {
             $this->markTestSkipped('Password updates are not enabled.');
-
-            return;
         }
 
         Notification::fake();
@@ -74,8 +68,6 @@ class PasswordResetTest extends TestCase
     {
         if (! Features::enabled(Features::resetPasswords())) {
             $this->markTestSkipped('Password updates are not enabled.');
-
-            return;
         }
 
         Notification::fake();

--- a/stubs/tests/RegistrationTest.php
+++ b/stubs/tests/RegistrationTest.php
@@ -16,8 +16,6 @@ class RegistrationTest extends TestCase
     {
         if (! Features::enabled(Features::registration())) {
             $this->markTestSkipped('Registration support is not enabled.');
-
-            return;
         }
 
         $response = $this->get('/register');
@@ -29,8 +27,6 @@ class RegistrationTest extends TestCase
     {
         if (Features::enabled(Features::registration())) {
             $this->markTestSkipped('Registration support is enabled.');
-
-            return;
         }
 
         $response = $this->get('/register');
@@ -42,8 +38,6 @@ class RegistrationTest extends TestCase
     {
         if (! Features::enabled(Features::registration())) {
             $this->markTestSkipped('Registration support is not enabled.');
-
-            return;
         }
 
         $response = $this->post('/register', [

--- a/stubs/tests/inertia/ApiTokenPermissionsTest.php
+++ b/stubs/tests/inertia/ApiTokenPermissionsTest.php
@@ -16,8 +16,6 @@ class ApiTokenPermissionsTest extends TestCase
     {
         if (! Features::hasApiFeatures()) {
             $this->markTestSkipped('API support is not enabled.');
-
-            return;
         }
 
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());

--- a/stubs/tests/inertia/CreateApiTokenTest.php
+++ b/stubs/tests/inertia/CreateApiTokenTest.php
@@ -15,8 +15,6 @@ class CreateApiTokenTest extends TestCase
     {
         if (! Features::hasApiFeatures()) {
             $this->markTestSkipped('API support is not enabled.');
-
-            return;
         }
 
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());

--- a/stubs/tests/inertia/DeleteAccountTest.php
+++ b/stubs/tests/inertia/DeleteAccountTest.php
@@ -15,8 +15,6 @@ class DeleteAccountTest extends TestCase
     {
         if (! Features::hasAccountDeletionFeatures()) {
             $this->markTestSkipped('Account deletion is not enabled.');
-
-            return;
         }
 
         $this->actingAs($user = User::factory()->create());
@@ -32,8 +30,6 @@ class DeleteAccountTest extends TestCase
     {
         if (! Features::hasAccountDeletionFeatures()) {
             $this->markTestSkipped('Account deletion is not enabled.');
-
-            return;
         }
 
         $this->actingAs($user = User::factory()->create());

--- a/stubs/tests/inertia/DeleteApiTokenTest.php
+++ b/stubs/tests/inertia/DeleteApiTokenTest.php
@@ -16,8 +16,6 @@ class DeleteApiTokenTest extends TestCase
     {
         if (! Features::hasApiFeatures()) {
             $this->markTestSkipped('API support is not enabled.');
-
-            return;
         }
 
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());

--- a/stubs/tests/inertia/InviteTeamMemberTest.php
+++ b/stubs/tests/inertia/InviteTeamMemberTest.php
@@ -17,8 +17,6 @@ class InviteTeamMemberTest extends TestCase
     {
         if (! Features::sendsTeamInvitations()) {
             $this->markTestSkipped('Team invitations not enabled.');
-
-            return;
         }
 
         Mail::fake();
@@ -39,8 +37,6 @@ class InviteTeamMemberTest extends TestCase
     {
         if (! Features::sendsTeamInvitations()) {
             $this->markTestSkipped('Team invitations not enabled.');
-
-            return;
         }
 
         Mail::fake();

--- a/stubs/tests/inertia/TwoFactorAuthenticationSettingsTest.php
+++ b/stubs/tests/inertia/TwoFactorAuthenticationSettingsTest.php
@@ -15,8 +15,6 @@ class TwoFactorAuthenticationSettingsTest extends TestCase
     {
         if (! Features::canManageTwoFactorAuthentication()) {
             $this->markTestSkipped('Two factor authentication is not enabled.');
-
-            return;
         }
 
         $this->actingAs($user = User::factory()->create());
@@ -33,8 +31,6 @@ class TwoFactorAuthenticationSettingsTest extends TestCase
     {
         if (! Features::canManageTwoFactorAuthentication()) {
             $this->markTestSkipped('Two factor authentication is not enabled.');
-
-            return;
         }
 
         $this->actingAs($user = User::factory()->create());
@@ -56,8 +52,6 @@ class TwoFactorAuthenticationSettingsTest extends TestCase
     {
         if (! Features::canManageTwoFactorAuthentication()) {
             $this->markTestSkipped('Two factor authentication is not enabled.');
-
-            return;
         }
 
         $this->actingAs($user = User::factory()->create());

--- a/stubs/tests/livewire/ApiTokenPermissionsTest.php
+++ b/stubs/tests/livewire/ApiTokenPermissionsTest.php
@@ -18,8 +18,6 @@ class ApiTokenPermissionsTest extends TestCase
     {
         if (! Features::hasApiFeatures()) {
             $this->markTestSkipped('API support is not enabled.');
-
-            return;
         }
 
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());

--- a/stubs/tests/livewire/CreateApiTokenTest.php
+++ b/stubs/tests/livewire/CreateApiTokenTest.php
@@ -17,8 +17,6 @@ class CreateApiTokenTest extends TestCase
     {
         if (! Features::hasApiFeatures()) {
             $this->markTestSkipped('API support is not enabled.');
-
-            return;
         }
 
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());

--- a/stubs/tests/livewire/DeleteAccountTest.php
+++ b/stubs/tests/livewire/DeleteAccountTest.php
@@ -17,8 +17,6 @@ class DeleteAccountTest extends TestCase
     {
         if (! Features::hasAccountDeletionFeatures()) {
             $this->markTestSkipped('Account deletion is not enabled.');
-
-            return;
         }
 
         $this->actingAs($user = User::factory()->create());
@@ -34,8 +32,6 @@ class DeleteAccountTest extends TestCase
     {
         if (! Features::hasAccountDeletionFeatures()) {
             $this->markTestSkipped('Account deletion is not enabled.');
-
-            return;
         }
 
         $this->actingAs($user = User::factory()->create());

--- a/stubs/tests/livewire/DeleteApiTokenTest.php
+++ b/stubs/tests/livewire/DeleteApiTokenTest.php
@@ -18,8 +18,6 @@ class DeleteApiTokenTest extends TestCase
     {
         if (! Features::hasApiFeatures()) {
             $this->markTestSkipped('API support is not enabled.');
-
-            return;
         }
 
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());

--- a/stubs/tests/livewire/InviteTeamMemberTest.php
+++ b/stubs/tests/livewire/InviteTeamMemberTest.php
@@ -19,8 +19,6 @@ class InviteTeamMemberTest extends TestCase
     {
         if (! Features::sendsTeamInvitations()) {
             $this->markTestSkipped('Team invitations not enabled.');
-
-            return;
         }
 
         Mail::fake();
@@ -42,8 +40,6 @@ class InviteTeamMemberTest extends TestCase
     {
         if (! Features::sendsTeamInvitations()) {
             $this->markTestSkipped('Team invitations not enabled.');
-
-            return;
         }
 
         Mail::fake();

--- a/stubs/tests/livewire/TwoFactorAuthenticationSettingsTest.php
+++ b/stubs/tests/livewire/TwoFactorAuthenticationSettingsTest.php
@@ -36,8 +36,6 @@ class TwoFactorAuthenticationSettingsTest extends TestCase
     {
         if (! Features::canManageTwoFactorAuthentication()) {
             $this->markTestSkipped('Two factor authentication is not enabled.');
-
-            return;
         }
 
         $this->actingAs($user = User::factory()->create());
@@ -60,8 +58,6 @@ class TwoFactorAuthenticationSettingsTest extends TestCase
     {
         if (! Features::canManageTwoFactorAuthentication()) {
             $this->markTestSkipped('Two factor authentication is not enabled.');
-
-            return;
         }
 
         $this->actingAs($user = User::factory()->create());

--- a/stubs/tests/livewire/TwoFactorAuthenticationSettingsTest.php
+++ b/stubs/tests/livewire/TwoFactorAuthenticationSettingsTest.php
@@ -17,8 +17,6 @@ class TwoFactorAuthenticationSettingsTest extends TestCase
     {
         if (! Features::canManageTwoFactorAuthentication()) {
             $this->markTestSkipped('Two factor authentication is not enabled.');
-
-            return;
         }
 
         $this->actingAs($user = User::factory()->create());


### PR DESCRIPTION
`$this->markTestSkipped()` is used in many PHPUnit tests to skip testing disabled features, and throws an exception to immediately end the test. However, there is also an unreachable `return` statement after every call to `markTestSkipped`. This causes static analysis tools like PHPStan that are looking for dead code to trigger on the tests until someone cleans them up. Since they are functionally irrelevant, it'd be nice to clean up the stubs and drop the `return` statements.