### PR TITLE
[4.x] Fix PHPDoc for `UpdateUserProfileInformation::update`

### DIFF
--- a/stubs/app/Actions/Fortify/UpdateUserProfileInformation.php
+++ b/stubs/app/Actions/Fortify/UpdateUserProfileInformation.php
@@ -13,7 +13,7 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
     /**
      * Validate and update the given user's profile information.
      *
-     * @param  array<string, string>  $input
+     * @param  array<string, mixed>  $input
      */
     public function update(User $user, array $input): void
     {


### PR DESCRIPTION
Just a small PHPDoc fix. I ran into this using PHPStan with rule level 5 in a project that uses Jetstream.

The `$input` parameter is typed as an `array<string, string>`, but `$input['photo']` is an `UploadedFile` and not a `string`.