### PR TITLE
[4.x] Set default driver to password hash string in session for Inertia

### DIFF
--- a/src/JetstreamServiceProvider.php
+++ b/src/JetstreamServiceProvider.php
@@ -183,7 +183,8 @@ class JetstreamServiceProvider extends ServiceProvider
 
         Event::listen(function (PasswordUpdatedViaController $event) {
             if (request()->hasSession()) {
-                request()->session()->put(['password_hash_sanctum' => Auth::user()->getAuthPassword()]);
+                request()->session()->put(['password_hash_'.Auth::getDefaultDriver() => Auth::user()->getAuthPassword()]);
+
             }
         });
 

--- a/src/JetstreamServiceProvider.php
+++ b/src/JetstreamServiceProvider.php
@@ -184,7 +184,6 @@ class JetstreamServiceProvider extends ServiceProvider
         Event::listen(function (PasswordUpdatedViaController $event) {
             if (request()->hasSession()) {
                 request()->session()->put(['password_hash_'.Auth::getDefaultDriver() => Auth::user()->getAuthPassword()]);
-
             }
         });
 


### PR DESCRIPTION
Related to : #1426 issue

This PR replaces line 186 in `JetstreamServiceProvider.php` method `bootInertia()`

```
'password_hash_sanctum'
```

with 

```
'password_hash_'.Auth::user()->getDefaultDriver()`
```