### PR TITLE
[4.x] Change Inertia Modal.vue component to use a native <dialog> 

### DIFF
--- a/stubs/inertia/resources/js/Components/Modal.vue
+++ b/stubs/inertia/resources/js/Components/Modal.vue
@@ -24,9 +24,9 @@ watch(() => props.show, () => {
         document.body.style.overflow = 'hidden';
         dialog.value?.showModal();
     } else {
+        document.body.style.overflow = null;
         setTimeout(() => {
             dialog.value?.close();
-            document.body.style.overflow = null;
         }, 200);
     }
 });

--- a/stubs/inertia/resources/js/Components/Modal.vue
+++ b/stubs/inertia/resources/js/Components/Modal.vue
@@ -18,15 +18,18 @@ const props = defineProps({
 
 const emit = defineEmits(['close']);
 const dialog = ref();
+const showSlot = ref(props.show);
 
 watch(() => props.show, () => {
     if (props.show) {
         document.body.style.overflow = 'hidden';
+        showSlot.value = true;
         dialog.value?.showModal();
     } else {
         document.body.style.overflow = null;
         setTimeout(() => {
             dialog.value?.close();
+            showSlot.value = false;
         }, 200);
     }
 });
@@ -87,7 +90,7 @@ const maxWidthClass = computed(() => {
                 leave-to-class="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
             >
                 <div v-show="show" class="mb-6 bg-white dark:bg-gray-800 rounded-lg overflow-hidden shadow-xl transform transition-all sm:w-full sm:mx-auto" :class="maxWidthClass">
-                    <slot v-if="show"/>
+                    <slot v-if="showSlot"/>
                 </div>
             </transition>
         </div>

--- a/stubs/inertia/resources/js/Components/Modal.vue
+++ b/stubs/inertia/resources/js/Components/Modal.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, onMounted, onUnmounted, watch } from 'vue';
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
 
 const props = defineProps({
     show: {
@@ -17,12 +17,17 @@ const props = defineProps({
 });
 
 const emit = defineEmits(['close']);
+const dialog = ref();
 
 watch(() => props.show, () => {
     if (props.show) {
         document.body.style.overflow = 'hidden';
+        dialog.value?.showModal();
     } else {
-        document.body.style.overflow = null;
+        setTimeout(() => {
+            dialog.value?.close();
+            document.body.style.overflow = null;
+        }, 200);
     }
 });
 
@@ -57,35 +62,33 @@ const maxWidthClass = computed(() => {
 </script>
 
 <template>
-    <teleport to="body">
-        <transition leave-active-class="duration-200">
-            <div v-show="show" class="fixed inset-0 overflow-y-auto px-4 py-6 sm:px-0 z-50" scroll-region>
-                <transition
-                    enter-active-class="ease-out duration-300"
-                    enter-from-class="opacity-0"
-                    enter-to-class="opacity-100"
-                    leave-active-class="ease-in duration-200"
-                    leave-from-class="opacity-100"
-                    leave-to-class="opacity-0"
-                >
-                    <div v-show="show" class="fixed inset-0 transform transition-all" @click="close">
-                        <div class="absolute inset-0 bg-gray-500 dark:bg-gray-900 opacity-75" />
-                    </div>
-                </transition>
+    <dialog class="z-50 m-0 min-h-full min-w-full overflow-y-auto bg-transparent backdrop:bg-transparent" ref="dialog">
+        <div class="fixed inset-0 overflow-y-auto px-4 py-6 sm:px-0 z-50" scroll-region>
+            <transition
+                enter-active-class="ease-out duration-300"
+                enter-from-class="opacity-0"
+                enter-to-class="opacity-100"
+                leave-active-class="ease-in duration-200"
+                leave-from-class="opacity-100"
+                leave-to-class="opacity-0"
+            >
+                <div v-show="show" class="fixed inset-0 transform transition-all" @click="close">
+                    <div class="absolute inset-0 bg-gray-500 dark:bg-gray-900 opacity-75" />
+                </div>
+            </transition>
 
-                <transition
-                    enter-active-class="ease-out duration-300"
-                    enter-from-class="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
-                    enter-to-class="opacity-100 translate-y-0 sm:scale-100"
-                    leave-active-class="ease-in duration-200"
-                    leave-from-class="opacity-100 translate-y-0 sm:scale-100"
-                    leave-to-class="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
-                >
-                    <div v-show="show" class="mb-6 bg-white dark:bg-gray-800 rounded-lg overflow-hidden shadow-xl transform transition-all sm:w-full sm:mx-auto" :class="maxWidthClass">
-                        <slot v-if="show" />
-                    </div>
-                </transition>
-            </div>
-        </transition>
-    </teleport>
+            <transition
+                enter-active-class="ease-out duration-300"
+                enter-from-class="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+                enter-to-class="opacity-100 translate-y-0 sm:scale-100"
+                leave-active-class="ease-in duration-200"
+                leave-from-class="opacity-100 translate-y-0 sm:scale-100"
+                leave-to-class="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+            >
+                <div v-show="show" class="mb-6 bg-white dark:bg-gray-800 rounded-lg overflow-hidden shadow-xl transform transition-all sm:w-full sm:mx-auto" :class="maxWidthClass">
+                    <slot v-if="show"/>
+                </div>
+            </transition>
+        </div>
+    </dialog>
 </template>

--- a/stubs/inertia/resources/js/Components/Modal.vue
+++ b/stubs/inertia/resources/js/Components/Modal.vue
@@ -34,6 +34,7 @@ watch(() => props.show, () => {
 const close = () => {
     if (props.closeable) {
         emit('close');
+        e.preventDefault();
     }
 };
 

--- a/stubs/livewire/resources/views/components/modal.blade.php
+++ b/stubs/livewire/resources/views/components/modal.blade.php
@@ -12,43 +12,32 @@ $maxWidth = [
 ][$maxWidth ?? '2xl'];
 @endphp
 
-<dialog class="z-50 m-0 min-h-full min-w-full overflow-y-auto bg-transparent backdrop:bg-transparent"
-    id="{{ $id }}"
-    x-ref="dialog"
+<div
     x-data="{ show: @entangle($attributes->wire('model')) }"
     x-on:close.stop="show = false"
     x-on:keydown.escape.window="show = false"
-    x-init="$watch('show', show => {
-        const dialog = $refs.dialog;
-        if (show) {
-            dialog.showModal();
-        }
-        if (!show) {
-            setTimeout(() => {
-                dialog.close();
-            }, 200);
-        }
-    })"
+    x-show="show"
+    id="{{ $id }}"
+    class="jetstream-modal fixed inset-0 overflow-y-auto px-4 py-6 sm:px-0 z-50"
+    style="display: none;"
 >
-    <div class="jetstream-modal fixed inset-0 overflow-y-auto px-4 py-6 sm:px-0 z-50">
-        <div x-show="show" class="fixed inset-0 transform transition-all" x-on:click="show = false" x-transition:enter="ease-out duration-300"
-             x-transition:enter-start="opacity-0"
-             x-transition:enter-end="opacity-100"
-             x-transition:leave="ease-in duration-200"
-             x-transition:leave-start="opacity-100"
-             x-transition:leave-end="opacity-0">
-            <div class="absolute inset-0 bg-gray-500 dark:bg-gray-900 opacity-75"></div>
-        </div>
-
-        <div x-show="show" class="mb-6 bg-white dark:bg-gray-800 rounded-lg overflow-hidden shadow-xl transform transition-all sm:w-full {{ $maxWidth }} sm:mx-auto"
-             x-trap.inert.noscroll="show"
-             x-transition:enter="ease-out duration-300"
-             x-transition:enter-start="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
-             x-transition:enter-end="opacity-100 translate-y-0 sm:scale-100"
-             x-transition:leave="ease-in duration-200"
-             x-transition:leave-start="opacity-100 translate-y-0 sm:scale-100"
-             x-transition:leave-end="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95">
-            {{ $slot }}
-        </div>
+    <div x-show="show" class="fixed inset-0 transform transition-all" x-on:click="show = false" x-transition:enter="ease-out duration-300"
+                    x-transition:enter-start="opacity-0"
+                    x-transition:enter-end="opacity-100"
+                    x-transition:leave="ease-in duration-200"
+                    x-transition:leave-start="opacity-100"
+                    x-transition:leave-end="opacity-0">
+        <div class="absolute inset-0 bg-gray-500 dark:bg-gray-900 opacity-75"></div>
     </div>
-</dialog>
+
+    <div x-show="show" class="mb-6 bg-white dark:bg-gray-800 rounded-lg overflow-hidden shadow-xl transform transition-all sm:w-full {{ $maxWidth }} sm:mx-auto"
+                    x-trap.inert.noscroll="show"
+                    x-transition:enter="ease-out duration-300"
+                    x-transition:enter-start="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+                    x-transition:enter-end="opacity-100 translate-y-0 sm:scale-100"
+                    x-transition:leave="ease-in duration-200"
+                    x-transition:leave-start="opacity-100 translate-y-0 sm:scale-100"
+                    x-transition:leave-end="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95">
+        {{ $slot }}
+    </div>
+</div>

--- a/stubs/livewire/resources/views/components/modal.blade.php
+++ b/stubs/livewire/resources/views/components/modal.blade.php
@@ -12,32 +12,43 @@ $maxWidth = [
 ][$maxWidth ?? '2xl'];
 @endphp
 
-<div
+<dialog class="z-50 m-0 min-h-full min-w-full overflow-y-auto bg-transparent backdrop:bg-transparent"
+    id="{{ $id }}"
+    x-ref="dialog"
     x-data="{ show: @entangle($attributes->wire('model')) }"
     x-on:close.stop="show = false"
     x-on:keydown.escape.window="show = false"
-    x-show="show"
-    id="{{ $id }}"
-    class="jetstream-modal fixed inset-0 overflow-y-auto px-4 py-6 sm:px-0 z-50"
-    style="display: none;"
+    x-init="$watch('show', show => {
+        const dialog = $refs.dialog;
+        if (show) {
+            dialog.showModal();
+        }
+        if (!show) {
+            setTimeout(() => {
+                dialog.close();
+            }, 200);
+        }
+    })"
 >
-    <div x-show="show" class="fixed inset-0 transform transition-all" x-on:click="show = false" x-transition:enter="ease-out duration-300"
-                    x-transition:enter-start="opacity-0"
-                    x-transition:enter-end="opacity-100"
-                    x-transition:leave="ease-in duration-200"
-                    x-transition:leave-start="opacity-100"
-                    x-transition:leave-end="opacity-0">
-        <div class="absolute inset-0 bg-gray-500 dark:bg-gray-900 opacity-75"></div>
-    </div>
+    <div class="jetstream-modal fixed inset-0 overflow-y-auto px-4 py-6 sm:px-0 z-50">
+        <div x-show="show" class="fixed inset-0 transform transition-all" x-on:click="show = false" x-transition:enter="ease-out duration-300"
+             x-transition:enter-start="opacity-0"
+             x-transition:enter-end="opacity-100"
+             x-transition:leave="ease-in duration-200"
+             x-transition:leave-start="opacity-100"
+             x-transition:leave-end="opacity-0">
+            <div class="absolute inset-0 bg-gray-500 dark:bg-gray-900 opacity-75"></div>
+        </div>
 
-    <div x-show="show" class="mb-6 bg-white dark:bg-gray-800 rounded-lg overflow-hidden shadow-xl transform transition-all sm:w-full {{ $maxWidth }} sm:mx-auto"
-                    x-trap.inert.noscroll="show"
-                    x-transition:enter="ease-out duration-300"
-                    x-transition:enter-start="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
-                    x-transition:enter-end="opacity-100 translate-y-0 sm:scale-100"
-                    x-transition:leave="ease-in duration-200"
-                    x-transition:leave-start="opacity-100 translate-y-0 sm:scale-100"
-                    x-transition:leave-end="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95">
-        {{ $slot }}
+        <div x-show="show" class="mb-6 bg-white dark:bg-gray-800 rounded-lg overflow-hidden shadow-xl transform transition-all sm:w-full {{ $maxWidth }} sm:mx-auto"
+             x-trap.inert.noscroll="show"
+             x-transition:enter="ease-out duration-300"
+             x-transition:enter-start="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+             x-transition:enter-end="opacity-100 translate-y-0 sm:scale-100"
+             x-transition:leave="ease-in duration-200"
+             x-transition:leave-start="opacity-100 translate-y-0 sm:scale-100"
+             x-transition:leave-end="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95">
+            {{ $slot }}
+        </div>
     </div>
-</div>
+</dialog>


### PR DESCRIPTION
Currently, the Modal component uses a `<div>` element as the root with the Teleport feature. A modal like this does not properly trap tabs, allowing the user to tab to elements in the background which are supposed to be blocked by the modal.

Changing to use a `<dialog>` element improves accessibility by locking the tab order to the modal and prevents interaction with the background using the keyboard by taking advantage of native browser features.

This update should not affect any style or other features beyond the `<dialog>` behavior.