### PR TITLE
[4.x] Fix home route

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -66,6 +66,7 @@ class InstallCommand extends Command implements PromptsForMissingInput
 
         // "Home" Route...
         $this->replaceInFile('/home', '/dashboard', app_path('Providers/RouteServiceProvider.php'));
+        $this->replaceInFile('/home', '/dashboard', config_path('fortify.php'));
 
         if (file_exists(resource_path('views/welcome.blade.php'))) {
             $this->replaceInFile('/home', '/dashboard', resource_path('views/welcome.blade.php'));


### PR DESCRIPTION
In Fortify `1.20.0`, the default `home` config value changed from `RouteServiceProvider::HOME` to `/home` in preparation for Laravel 11 (https://github.com/laravel/fortify/pull/515/commits/2f84969caf226a667f064b997a06bcccfa4b5e36).

This has created an issue in fresh Jetstream installs that will now attempt to redirect to `/home` (which doesn't exist) instead of `/dashboard`.

Jetstream's `master` branch has already updated the installer to update `config/fortify.php` instead of `RouteServiceProvider.php`. This PR is just a temporary fix to ensure both are updated for the time being.