### PR TITLE
[4.x] Check for confirm in fortify

### DIFF
--- a/src/Http/Middleware/ShareInertiaData.php
+++ b/src/Http/Middleware/ShareInertiaData.php
@@ -83,6 +83,7 @@ class ShareInertiaData
                 }
             }
         }
+        
         return false;
     }
 }

--- a/src/Http/Middleware/ShareInertiaData.php
+++ b/src/Http/Middleware/ShareInertiaData.php
@@ -71,9 +71,9 @@ class ShareInertiaData
     protected function twoFactorEnabled($user)
     {
         if (Features::enabled(Features::twoFactorAuthentication())) {
-            if (!is_null($user->two_factor_secret)) {
+            if (! is_null($user->two_factor_secret)) {
                 if (Features::enabled(Features::twoFactorAuthentication(['confirm']))) {
-                    if (!is_null($user->two_factor_confirmed_at)) {
+                    if (! is_null($user->two_factor_confirmed_at)) {
                         return true;
                     } else {
                         return false;

--- a/src/Http/Middleware/ShareInertiaData.php
+++ b/src/Http/Middleware/ShareInertiaData.php
@@ -83,7 +83,7 @@ class ShareInertiaData
                 }
             }
         }
-        
+
         return false;
     }
 }

--- a/src/Http/Middleware/ShareInertiaData.php
+++ b/src/Http/Middleware/ShareInertiaData.php
@@ -54,8 +54,7 @@ class ShareInertiaData
                     return array_merge($user->toArray(), array_filter([
                         'all_teams' => $userHasTeamFeatures ? $user->allTeams()->values() : null,
                     ]), [
-                        'two_factor_enabled' => Features::enabled(Features::twoFactorAuthentication())
-                            && ! is_null($user->two_factor_secret),
+                        'two_factor_enabled' => $this->twoFactorEnabled($user),
                     ]);
                 },
             ],
@@ -67,5 +66,23 @@ class ShareInertiaData
         ]));
 
         return $next($request);
+    }
+
+    protected function twoFactorEnabled($user)
+    {
+        if (Features::enabled(Features::twoFactorAuthentication())) {
+            if (!is_null($user->two_factor_secret)) {
+                if (Features::enabled(Features::twoFactorAuthentication(['confirm']))) {
+                    if (!is_null($user->two_factor_confirmed_at)) {
+                        return true;
+                    } else {
+                        return false;
+                    }
+                } else {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
There is a bug in the current logic for the `two_factor_enabled` in the SharedInertiaData middleware. It returns true even if the confirmed option in `fortify.php` config is set to true leading in an error if you refresh the page in the confirmation page. 

This is not a problem in the default configuration of the 2FA in the jetstream profile page but if you want to move this form to a different page it causes a problem with the logic since the front end thinks the `two_factor_enabled` is true even if it's not confirmed and only shows you the recovery codes. 

The function could be shortened to:
```
if (
    Features::enabled(Features::twoFactorAuthentication()) &&
    !is_null($user->two_factor_secret) &&
    (
        !Features::enabled(Features::twoFactorAuthentication(['confirm'])) ||
        !is_null($user->two_factor_confirmed_at)
    )
) {
    return true;
} else {
    return false;
}
```
but i expanded it for readability 