### PR TITLE
[5.x] Re-runs database migrations on Jetstream

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -16,6 +16,7 @@ use Symfony\Component\Finder\Finder;
 use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
 
+use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\multiselect;
 use function Laravel\Prompts\select;
 
@@ -744,7 +745,7 @@ EOF;
      */
     protected function runDatabaseMigrations()
     {
-        if ($this->components->confirm('Do you wish to wipe the database, and re-run the database migrations?', true)) {
+        if (confirm('New migrations were added. Would you like to re-create your database?', true)) {
             $this->call('db:wipe');
 
             $this->call('migrate', ['--force' => true]);

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -126,15 +126,6 @@ class InstallCommand extends Command implements PromptsForMissingInput
         copy($stubs.'/PasswordConfirmationTest.php', base_path('tests/Feature/PasswordConfirmationTest.php'));
         copy($stubs.'/PasswordResetTest.php', base_path('tests/Feature/PasswordResetTest.php'));
         copy($stubs.'/RegistrationTest.php', base_path('tests/Feature/RegistrationTest.php'));
-
-        // Migrations
-        if ($this->components->confirm('Do you wish to re-run the database migrations?', true)) {
-            (new Process([$this->phpBinary(), 'artisan', 'migrate:refresh', '--force'], base_path()))
-                ->setTimeout(null)
-                ->run(function ($type, $output) {
-                    $this->output->write($output);
-                });
-        }
     }
 
     /**
@@ -274,6 +265,8 @@ class InstallCommand extends Command implements PromptsForMissingInput
         } else {
             $this->runCommands(['npm install', 'npm run build']);
         }
+
+        $this->runDatabaseMigrations();
 
         $this->line('');
         $this->components->info('Livewire scaffolding installed successfully.');
@@ -474,6 +467,8 @@ EOF;
         } else {
             $this->runCommands(['npm install', 'npm run build']);
         }
+
+        $this->runDatabaseMigrations();
 
         $this->line('');
         $this->components->info('Inertia scaffolding installed successfully.');
@@ -740,6 +735,19 @@ EOF;
             base_path('package.json'),
             json_encode($packages, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT).PHP_EOL
         );
+    }
+
+    /**
+     * Run the database migrations.
+     *
+     * @return void
+     */
+    protected function runDatabaseMigrations()
+    {
+        // Migrations
+        if ($this->components->confirm('Do you wish to re-run the database migrations?', true)) {
+            $this->call('migrate:refresh', ['--force' => true]);
+        }
     }
 
     /**

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -267,6 +267,7 @@ class InstallCommand extends Command implements PromptsForMissingInput
             $this->runCommands(['npm install', 'npm run build']);
         }
 
+        $this->line('');
         $this->runDatabaseMigrations();
 
         $this->components->info('Livewire scaffolding installed successfully.');
@@ -468,6 +469,7 @@ EOF;
             $this->runCommands(['npm install', 'npm run build']);
         }
 
+        $this->line('');
         $this->runDatabaseMigrations();
 
         $this->components->info('Inertia scaffolding installed successfully.');

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -126,6 +126,15 @@ class InstallCommand extends Command implements PromptsForMissingInput
         copy($stubs.'/PasswordConfirmationTest.php', base_path('tests/Feature/PasswordConfirmationTest.php'));
         copy($stubs.'/PasswordResetTest.php', base_path('tests/Feature/PasswordResetTest.php'));
         copy($stubs.'/RegistrationTest.php', base_path('tests/Feature/RegistrationTest.php'));
+
+        // Migrations
+        if ($this->components->confirm('Do you wish to re-run the database migrations?', true)) {
+            (new Process([$this->phpBinary(), 'artisan', 'migrate:refresh', '--force'], base_path()))
+                ->setTimeout(null)
+                ->run(function ($type, $output) {
+                    $this->output->write($output);
+                });
+        }
     }
 
     /**

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -266,6 +266,7 @@ class InstallCommand extends Command implements PromptsForMissingInput
             $this->runCommands(['npm install', 'npm run build']);
         }
 
+        $this->line('');
         $this->runDatabaseMigrations();
 
         $this->line('');
@@ -468,6 +469,7 @@ EOF;
             $this->runCommands(['npm install', 'npm run build']);
         }
 
+        $this->line('');
         $this->runDatabaseMigrations();
 
         $this->line('');

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -267,7 +267,6 @@ class InstallCommand extends Command implements PromptsForMissingInput
             $this->runCommands(['npm install', 'npm run build']);
         }
 
-        $this->line('');
         $this->runDatabaseMigrations();
 
         $this->components->info('Livewire scaffolding installed successfully.');
@@ -469,7 +468,6 @@ EOF;
             $this->runCommands(['npm install', 'npm run build']);
         }
 
-        $this->line('');
         $this->runDatabaseMigrations();
 
         $this->components->info('Inertia scaffolding installed successfully.');

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -269,7 +269,6 @@ class InstallCommand extends Command implements PromptsForMissingInput
         $this->line('');
         $this->runDatabaseMigrations();
 
-        $this->line('');
         $this->components->info('Livewire scaffolding installed successfully.');
 
         return true;
@@ -472,7 +471,6 @@ EOF;
         $this->line('');
         $this->runDatabaseMigrations();
 
-        $this->line('');
         $this->components->info('Inertia scaffolding installed successfully.');
 
         return true;

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -745,7 +745,7 @@ EOF;
      */
     protected function runDatabaseMigrations()
     {
-        if (confirm('New migrations were added. Would you like to re-run your database migrations?', true)) {
+        if (confirm('New database migrations were added. Would you like to re-run your migrations?', true)) {
             $this->call('migrate:fresh', ['--force' => true]);
         }
     }

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -745,7 +745,7 @@ EOF;
      */
     protected function runDatabaseMigrations()
     {
-        if (confirm('New migrations were added. Would you like to re-create your database?', true)) {
+        if (confirm('New migrations were added. Would you like to wipe and migrate your database?', true)) {
             $this->call('db:wipe');
 
             $this->call('migrate', ['--force' => true]);

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -744,9 +744,10 @@ EOF;
      */
     protected function runDatabaseMigrations()
     {
-        // Migrations
-        if ($this->components->confirm('Do you wish to re-run the database migrations?', true)) {
-            $this->call('migrate:refresh', ['--force' => true]);
+        if ($this->components->confirm('Do you wish to wipe the database, and re-run the database migrations?', true)) {
+            $this->call('db:wipe');
+
+            $this->call('migrate', ['--force' => true]);
         }
     }
 

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -745,10 +745,8 @@ EOF;
      */
     protected function runDatabaseMigrations()
     {
-        if (confirm('New migrations were added. Would you like to wipe and migrate your database?', true)) {
-            $this->call('db:wipe');
-
-            $this->call('migrate', ['--force' => true]);
+        if (confirm('New migrations were added. Would you like to re-run your database migrations?', true)) {
+            $this->call('migrate:fresh', ['--force' => true]);
         }
     }
 


### PR DESCRIPTION
This pull request wipes and re-runs database migrations on while installation Jetstream - because there is options, like --teams, where that users_table migration is replaced.