### PR TITLE
Update to Ziggy v2

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -345,7 +345,7 @@ EOF;
     protected function installInertiaStack()
     {
         // Install Inertia...
-        if (! $this->requireComposerPackages('inertiajs/inertia-laravel:^0.6.8', 'tightenco/ziggy:^1.0')) {
+        if (! $this->requireComposerPackages('inertiajs/inertia-laravel:^0.6.8', 'tightenco/ziggy:^2.0')) {
             return false;
         }
 

--- a/stubs/inertia/app/Http/Middleware/HandleInertiaRequests.php
+++ b/stubs/inertia/app/Http/Middleware/HandleInertiaRequests.php
@@ -4,7 +4,7 @@ namespace App\Http\Middleware;
 
 use Illuminate\Http\Request;
 use Inertia\Middleware;
-use Tightenco\Ziggy\Ziggy;
+use Tighten\Ziggy\Ziggy;
 
 class HandleInertiaRequests extends Middleware
 {

--- a/stubs/inertia/resources/js/app.js
+++ b/stubs/inertia/resources/js/app.js
@@ -4,7 +4,7 @@ import '../css/app.css';
 import { createApp, h } from 'vue';
 import { createInertiaApp } from '@inertiajs/vue3';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
-import { ZiggyVue } from '../../vendor/tightenco/ziggy/dist';
+import { ZiggyVue } from '../../vendor/tightenco/ziggy';
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 

--- a/stubs/inertia/resources/js/app.js
+++ b/stubs/inertia/resources/js/app.js
@@ -4,7 +4,7 @@ import '../css/app.css';
 import { createApp, h } from 'vue';
 import { createInertiaApp } from '@inertiajs/vue3';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
-import { ZiggyVue } from '../../vendor/tightenco/ziggy/dist/vue.m';
+import { ZiggyVue } from '../../vendor/tightenco/ziggy/dist';
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 

--- a/stubs/inertia/resources/js/ssr.js
+++ b/stubs/inertia/resources/js/ssr.js
@@ -3,7 +3,7 @@ import { renderToString } from '@vue/server-renderer';
 import { createInertiaApp } from '@inertiajs/vue3';
 import createServer from '@inertiajs/vue3/server';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
-import { ZiggyVue } from '../../vendor/tightenco/ziggy/dist/vue.m';
+import { ZiggyVue } from '../../vendor/tightenco/ziggy/dist';
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 

--- a/stubs/inertia/resources/js/ssr.js
+++ b/stubs/inertia/resources/js/ssr.js
@@ -3,7 +3,7 @@ import { renderToString } from '@vue/server-renderer';
 import { createInertiaApp } from '@inertiajs/vue3';
 import createServer from '@inertiajs/vue3/server';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
-import { ZiggyVue } from '../../vendor/tightenco/ziggy/dist';
+import { ZiggyVue } from '../../vendor/tightenco/ziggy';
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 


### PR DESCRIPTION
[Ziggy v2 has just been released](https://github.com/tighten/ziggy/releases/tag/v2.0.0); this PR updates Jetstream accordingly. Corresponding Breeze PR: https://github.com/laravel/breeze/pull/359.

Since this change only affects Jetstream's installation process and stubs, I'm pretty sure it's not a breaking change for Jetstream itself and is safe to include in the current major version. Upgrading to Ziggy v2 may take more work for existing apps originally scaffolded with Jetstream, but that's a separate concern and these changes shouldn't affect it.