### PR TITLE
[4.x] Remove unnecessary e.preventDefault on modal close 

### DIFF
--- a/stubs/inertia/resources/js/Components/Modal.vue
+++ b/stubs/inertia/resources/js/Components/Modal.vue
@@ -37,7 +37,6 @@ watch(() => props.show, () => {
 const close = () => {
     if (props.closeable) {
         emit('close');
-        e.preventDefault();
     }
 };
 


### PR DESCRIPTION
This removed `e.preventDefault()` on closing the modal in Modal.vue, which was not necessary and triggered an error message.

This resolves the error reported here: https://github.com/laravel/jetstream/pull/1431#discussion_r1504979937