### PR TITLE
[5.x] Fixes double migrate-prompt

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -152,7 +152,9 @@ class InstallCommand extends Command implements PromptsForMissingInput
             return false;
         }
 
-        $this->call('install:api');
+        $this->call('install:api', [
+            '--ignore-migrate-prompt' => true,
+        ]);
 
         // Update Configuration...
         $this->replaceInFile('inertia', 'livewire', config_path('jetstream.php'));
@@ -336,7 +338,9 @@ EOF;
             return false;
         }
 
-        $this->call('install:api');
+        $this->call('install:api', [
+            '--ignore-migrate-prompt' => true,
+        ]);
 
         // Install NPM packages...
         $this->updateNodePackages(function ($packages) {

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -153,7 +153,7 @@ class InstallCommand extends Command implements PromptsForMissingInput
         }
 
         $this->call('install:api', [
-            '--ignore-migrate-prompt' => true,
+            '--without-migration-prompt' => true,
         ]);
 
         // Update Configuration...
@@ -339,7 +339,7 @@ EOF;
         }
 
         $this->call('install:api', [
-            '--ignore-migrate-prompt' => true,
+            '--without-migration-prompt' => true,
         ]);
 
         // Install NPM packages...


### PR DESCRIPTION
Depends on https://github.com/laravel/framework/pull/50404, and this pull request ignores the `install:api` migration prompt because Jetstream already does that runs the migration command.