### PR TITLE
[5.x] Suggestion : Add `auth_session` variable in default config file

### DIFF
--- a/config/jetstream.php
+++ b/config/jetstream.php
@@ -1,10 +1,12 @@
 <?php
 
 use Laravel\Jetstream\Features;
+use Laravel\Jetstream\Http\Middleware\AuthenticateSession;
 
 return [
     'stack' => 'inertia',
     'middleware' => ['web'],
     'features' => [Features::accountDeletion()],
     'profile_photo_disk' => 'public',
+    'auth_session' => AuthenticateSession::class,
 ];


### PR DESCRIPTION
During the update to Laravel 11, I encountered a difficult-to-understand issue: `Target class [] does not exist.`

Beforehand, I had cleaned up my configuration files to align with the new, cleaner Laravel 11 structure. The only different element remaining in my configuration file was the `features` array [ in the config stub file ].

It appears that the `Target class [] does not exist` issue stemmed from the absence of the `jetstream.auth_session` variable, which is typically found in `web.php`:

```php
 Route::middleware([
    'auth:sanctum',
    config('jetstream.auth_session'),
    'verified',
])->group(function () {
    Route::get('/dashboard', function () {
        return Inertia::render('Dashboard');
    })->name('dashboard');
});
```


Adding this variable to my configuration file resolved the issue. I wondered if it might be a good idea to include it by default in the `vendor/laravel/jetstream/config/jetstream.php` file.