### PR TITLE
Skip update password tests

### DIFF
--- a/stubs/pest-tests/PasswordResetTest.php
+++ b/stubs/pest-tests/PasswordResetTest.php
@@ -37,7 +37,7 @@ test('reset password screen can be rendered', function () {
     ]);
 
     Notification::assertSentTo($user, ResetPassword::class, function (object $notification) {
-        $response = $this->get('/reset-password/' . $notification->token);
+        $response = $this->get('/reset-password/'.$notification->token);
 
         $response->assertStatus(200);
 

--- a/stubs/pest-tests/PasswordResetTest.php
+++ b/stubs/pest-tests/PasswordResetTest.php
@@ -11,7 +11,7 @@ test('reset password link screen can be rendered', function () {
     $response->assertStatus(200);
 })->skip(function () {
     return ! Features::enabled(Features::resetPasswords());
-}, 'Password updates are not enabled.');
+}, 'Password resets are not enabled.');
 
 test('reset password link can be requested', function () {
     Notification::fake();
@@ -25,7 +25,7 @@ test('reset password link can be requested', function () {
     Notification::assertSentTo($user, ResetPassword::class);
 })->skip(function () {
     return ! Features::enabled(Features::resetPasswords());
-}, 'Password updates are not enabled.');
+}, 'Password resets are not enabled.');
 
 test('reset password screen can be rendered', function () {
     Notification::fake();
@@ -37,7 +37,7 @@ test('reset password screen can be rendered', function () {
     ]);
 
     Notification::assertSentTo($user, ResetPassword::class, function (object $notification) {
-        $response = $this->get('/reset-password/'.$notification->token);
+        $response = $this->get('/reset-password/' . $notification->token);
 
         $response->assertStatus(200);
 
@@ -45,7 +45,7 @@ test('reset password screen can be rendered', function () {
     });
 })->skip(function () {
     return ! Features::enabled(Features::resetPasswords());
-}, 'Password updates are not enabled.');
+}, 'Password resets are not enabled.');
 
 test('password can be reset with valid token', function () {
     Notification::fake();
@@ -70,4 +70,4 @@ test('password can be reset with valid token', function () {
     });
 })->skip(function () {
     return ! Features::enabled(Features::resetPasswords());
-}, 'Password updates are not enabled.');
+}, 'Password resets are not enabled.');

--- a/stubs/pest-tests/inertia/UpdatePasswordTest.php
+++ b/stubs/pest-tests/inertia/UpdatePasswordTest.php
@@ -2,6 +2,7 @@
 
 use App\Models\User;
 use Illuminate\Support\Facades\Hash;
+use Laravel\Fortify\Features;
 
 test('password can be updated', function () {
     $this->actingAs($user = User::factory()->create());
@@ -13,7 +14,9 @@ test('password can be updated', function () {
     ]);
 
     expect(Hash::check('new-password', $user->fresh()->password))->toBeTrue();
-});
+})->skip(function () {
+    return ! Features::enabled(Features::resetPasswords());
+}, 'Password updates are not enabled.');
 
 test('current password must be correct', function () {
     $this->actingAs($user = User::factory()->create());
@@ -27,7 +30,9 @@ test('current password must be correct', function () {
     $response->assertSessionHasErrors();
 
     expect(Hash::check('password', $user->fresh()->password))->toBeTrue();
-});
+})->skip(function () {
+    return ! Features::enabled(Features::resetPasswords());
+}, 'Password updates are not enabled.');
 
 test('new passwords must match', function () {
     $this->actingAs($user = User::factory()->create());
@@ -41,4 +46,6 @@ test('new passwords must match', function () {
     $response->assertSessionHasErrors();
 
     expect(Hash::check('password', $user->fresh()->password))->toBeTrue();
-});
+})->skip(function () {
+    return ! Features::enabled(Features::resetPasswords());
+}, 'Password updates are not enabled.');

--- a/stubs/pest-tests/livewire/UpdatePasswordTest.php
+++ b/stubs/pest-tests/livewire/UpdatePasswordTest.php
@@ -2,6 +2,7 @@
 
 use App\Models\User;
 use Illuminate\Support\Facades\Hash;
+use Laravel\Fortify\Features;
 use Laravel\Jetstream\Http\Livewire\UpdatePasswordForm;
 use Livewire\Livewire;
 
@@ -17,7 +18,9 @@ test('password can be updated', function () {
         ->call('updatePassword');
 
     expect(Hash::check('new-password', $user->fresh()->password))->toBeTrue();
-});
+})->skip(function () {
+    return ! Features::enabled(Features::resetPasswords());
+}, 'Password updates are not enabled.');
 
 test('current password must be correct', function () {
     $this->actingAs($user = User::factory()->create());
@@ -32,7 +35,9 @@ test('current password must be correct', function () {
         ->assertHasErrors(['current_password']);
 
     expect(Hash::check('password', $user->fresh()->password))->toBeTrue();
-});
+})->skip(function () {
+    return ! Features::enabled(Features::resetPasswords());
+}, 'Password updates are not enabled.');
 
 test('new passwords must match', function () {
     $this->actingAs($user = User::factory()->create());
@@ -47,4 +52,6 @@ test('new passwords must match', function () {
         ->assertHasErrors(['password']);
 
     expect(Hash::check('password', $user->fresh()->password))->toBeTrue();
-});
+})->skip(function () {
+    return ! Features::enabled(Features::resetPasswords());
+}, 'Password updates are not enabled.');

--- a/stubs/tests/PasswordResetTest.php
+++ b/stubs/tests/PasswordResetTest.php
@@ -16,7 +16,7 @@ class PasswordResetTest extends TestCase
     public function test_reset_password_link_screen_can_be_rendered(): void
     {
         if (! Features::enabled(Features::resetPasswords())) {
-            $this->markTestSkipped('Password updates are not enabled.');
+            $this->markTestSkipped('Password resets are not enabled.');
         }
 
         $response = $this->get('/forgot-password');
@@ -27,7 +27,7 @@ class PasswordResetTest extends TestCase
     public function test_reset_password_link_can_be_requested(): void
     {
         if (! Features::enabled(Features::resetPasswords())) {
-            $this->markTestSkipped('Password updates are not enabled.');
+            $this->markTestSkipped('Password resets are not enabled.');
         }
 
         Notification::fake();
@@ -44,7 +44,7 @@ class PasswordResetTest extends TestCase
     public function test_reset_password_screen_can_be_rendered(): void
     {
         if (! Features::enabled(Features::resetPasswords())) {
-            $this->markTestSkipped('Password updates are not enabled.');
+            $this->markTestSkipped('Password resets are not enabled.');
         }
 
         Notification::fake();
@@ -67,7 +67,7 @@ class PasswordResetTest extends TestCase
     public function test_password_can_be_reset_with_valid_token(): void
     {
         if (! Features::enabled(Features::resetPasswords())) {
-            $this->markTestSkipped('Password updates are not enabled.');
+            $this->markTestSkipped('Password resets are not enabled.');
         }
 
         Notification::fake();

--- a/stubs/tests/inertia/UpdatePasswordTest.php
+++ b/stubs/tests/inertia/UpdatePasswordTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Hash;
+use Laravel\Fortify\Features;
 use Tests\TestCase;
 
 class UpdatePasswordTest extends TestCase
@@ -13,6 +14,10 @@ class UpdatePasswordTest extends TestCase
 
     public function test_password_can_be_updated(): void
     {
+        if (!Features::enabled(Features::updatePasswords())) {
+            $this->markTestSkipped('Password updates are not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->create());
 
         $response = $this->put('/user/password', [
@@ -26,6 +31,10 @@ class UpdatePasswordTest extends TestCase
 
     public function test_current_password_must_be_correct(): void
     {
+        if (!Features::enabled(Features::updatePasswords())) {
+            $this->markTestSkipped('Password updates are not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->create());
 
         $response = $this->put('/user/password', [
@@ -41,6 +50,10 @@ class UpdatePasswordTest extends TestCase
 
     public function test_new_passwords_must_match(): void
     {
+        if (!Features::enabled(Features::updatePasswords())) {
+            $this->markTestSkipped('Password updates are not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->create());
 
         $response = $this->put('/user/password', [

--- a/stubs/tests/inertia/UpdatePasswordTest.php
+++ b/stubs/tests/inertia/UpdatePasswordTest.php
@@ -14,7 +14,7 @@ class UpdatePasswordTest extends TestCase
 
     public function test_password_can_be_updated(): void
     {
-        if (!Features::enabled(Features::updatePasswords())) {
+        if (! Features::enabled(Features::updatePasswords())) {
             $this->markTestSkipped('Password updates are not enabled.');
         }
 
@@ -31,7 +31,7 @@ class UpdatePasswordTest extends TestCase
 
     public function test_current_password_must_be_correct(): void
     {
-        if (!Features::enabled(Features::updatePasswords())) {
+        if (! Features::enabled(Features::updatePasswords())) {
             $this->markTestSkipped('Password updates are not enabled.');
         }
 
@@ -50,7 +50,7 @@ class UpdatePasswordTest extends TestCase
 
     public function test_new_passwords_must_match(): void
     {
-        if (!Features::enabled(Features::updatePasswords())) {
+        if (! Features::enabled(Features::updatePasswords())) {
             $this->markTestSkipped('Password updates are not enabled.');
         }
 

--- a/stubs/tests/livewire/UpdatePasswordTest.php
+++ b/stubs/tests/livewire/UpdatePasswordTest.php
@@ -16,7 +16,7 @@ class UpdatePasswordTest extends TestCase
 
     public function test_password_can_be_updated(): void
     {
-        if (!Features::enabled(Features::updatePasswords())) {
+        if (! Features::enabled(Features::updatePasswords())) {
             $this->markTestSkipped('Password updates are not enabled.');
         }
 
@@ -35,7 +35,7 @@ class UpdatePasswordTest extends TestCase
 
     public function test_current_password_must_be_correct(): void
     {
-        if (!Features::enabled(Features::updatePasswords())) {
+        if (! Features::enabled(Features::updatePasswords())) {
             $this->markTestSkipped('Password updates are not enabled.');
         }
 
@@ -55,7 +55,7 @@ class UpdatePasswordTest extends TestCase
 
     public function test_new_passwords_must_match(): void
     {
-        if (!Features::enabled(Features::updatePasswords())) {
+        if (! Features::enabled(Features::updatePasswords())) {
             $this->markTestSkipped('Password updates are not enabled.');
         }
 

--- a/stubs/tests/livewire/UpdatePasswordTest.php
+++ b/stubs/tests/livewire/UpdatePasswordTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Hash;
+use Laravel\Fortify\Features;
 use Laravel\Jetstream\Http\Livewire\UpdatePasswordForm;
 use Livewire\Livewire;
 use Tests\TestCase;
@@ -15,6 +16,10 @@ class UpdatePasswordTest extends TestCase
 
     public function test_password_can_be_updated(): void
     {
+        if (!Features::enabled(Features::updatePasswords())) {
+            $this->markTestSkipped('Password updates are not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->create());
 
         Livewire::test(UpdatePasswordForm::class)
@@ -30,6 +35,10 @@ class UpdatePasswordTest extends TestCase
 
     public function test_current_password_must_be_correct(): void
     {
+        if (!Features::enabled(Features::updatePasswords())) {
+            $this->markTestSkipped('Password updates are not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->create());
 
         Livewire::test(UpdatePasswordForm::class)
@@ -46,6 +55,10 @@ class UpdatePasswordTest extends TestCase
 
     public function test_new_passwords_must_match(): void
     {
+        if (!Features::enabled(Features::updatePasswords())) {
+            $this->markTestSkipped('Password updates are not enabled.');
+        }
+
         $this->actingAs($user = User::factory()->create());
 
         Livewire::test(UpdatePasswordForm::class)


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

If you change the behavior of the Inertia stack you're expected to update the Livewire stack as well and vice versa.
-->

This skips the update password tests when the feature is turned off.