### PR TITLE
Support confirmPassword false for 2FA

### DIFF
--- a/src/Http/Livewire/TwoFactorAuthenticationForm.php
+++ b/src/Http/Livewire/TwoFactorAuthenticationForm.php
@@ -37,6 +37,13 @@ class TwoFactorAuthenticationForm extends Component
     public $showingRecoveryCodes = false;
 
     /**
+     * Wether or not to confirm actions with the current password.
+     *
+     * @var bool
+     */
+    public $confirmPassword = true;
+
+    /**
      * The OTP code for confirming two factor authentication.
      *
      * @var string|null
@@ -54,6 +61,11 @@ class TwoFactorAuthenticationForm extends Component
             is_null(Auth::user()->two_factor_confirmed_at)) {
             app(DisableTwoFactorAuthentication::class)(Auth::user());
         }
+
+        $this->confirmPassword = Features::optionEnabled(
+            Features::twoFactorAuthentication(),
+            'confirmPassword'
+        );
     }
 
     /**

--- a/stubs/livewire/resources/views/profile/two-factor-authentication-form.blade.php
+++ b/stubs/livewire/resources/views/profile/two-factor-authentication-form.blade.php
@@ -78,44 +78,80 @@
 
         <div class="mt-5">
             @if (! $this->enabled)
-                <x-confirms-password wire:then="enableTwoFactorAuthentication">
-                    <x-button type="button" wire:loading.attr="disabled">
-                        {{ __('Enable') }}
-                    </x-button>
-                </x-confirms-password>
-            @else
-                @if ($showingRecoveryCodes)
-                    <x-confirms-password wire:then="regenerateRecoveryCodes">
-                        <x-secondary-button class="me-3">
-                            {{ __('Regenerate Recovery Codes') }}
-                        </x-secondary-button>
-                    </x-confirms-password>
-                @elseif ($showingConfirmation)
-                    <x-confirms-password wire:then="confirmTwoFactorAuthentication">
-                        <x-button type="button" class="me-3" wire:loading.attr="disabled">
-                            {{ __('Confirm') }}
+                @if ($confirmPassword)
+                    <x-confirms-password wire:then="enableTwoFactorAuthentication">
+                        <x-button type="button" wire:loading.attr="disabled">
+                            {{ __('Enable') }}
                         </x-button>
                     </x-confirms-password>
                 @else
-                    <x-confirms-password wire:then="showRecoveryCodes">
-                        <x-secondary-button class="me-3">
+                    <x-button type="button" wire:click="enableTwoFactorAuthentication">
+                        {{ __('Enable') }}
+                    </x-button>
+                @endif
+            @else
+                @if ($showingRecoveryCodes)
+                    @if ($confirmPassword)
+                        <x-confirms-password wire:then="regenerateRecoveryCodes">
+                            <x-secondary-button class="me-3">
+                                {{ __('Regenerate Recovery Codes') }}
+                            </x-secondary-button>
+                        </x-confirms-password>
+                    @else
+                        <x-secondary-button wire:click="regenerateRecoveryCodes" class="me-3">
+                            {{ __('Regenerate Recovery Codes') }}
+                        </x-secondary-button>
+                    @endif
+                @elseif ($showingConfirmation)
+                    @if ($confirmPassword)
+                        <x-confirms-password wire:then="confirmTwoFactorAuthentication">
+                            <x-button type="button" class="me-3" wire:loading.attr="disabled">
+                                {{ __('Confirm') }}
+                            </x-button>
+                        </x-confirms-password>
+                    @else
+                        <x-button type="button" class="me-3" wire:click="confirmTwoFactorAuthentication">
+                            {{ __('Confirm') }}
+                        </x-button>
+                    @endif
+                @else
+                    @if ($confirmPassword)
+                        <x-confirms-password wire:then="showRecoveryCodes">
+                            <x-secondary-button class="me-3">
+                                {{ __('Show Recovery Codes') }}
+                            </x-secondary-button>
+                        </x-confirms-password>
+                    @else
+                        <x-secondary-button class="me-3" wire:click="showRecoveryCodes">
                             {{ __('Show Recovery Codes') }}
                         </x-secondary-button>
-                    </x-confirms-password>
+                    @endif
                 @endif
 
                 @if ($showingConfirmation)
-                    <x-confirms-password wire:then="disableTwoFactorAuthentication">
-                        <x-secondary-button wire:loading.attr="disabled">
+                    @if ($confirmPassword)
+                        <x-confirms-password wire:then="disableTwoFactorAuthentication">
+                            <x-secondary-button wire:loading.attr="disabled">
+                                {{ __('Cancel') }}
+                            </x-secondary-button>
+                        </x-confirms-password>
+                    @else
+                        <x-secondary-button wire:click="disableTwoFactorAuthentication">
                             {{ __('Cancel') }}
                         </x-secondary-button>
-                    </x-confirms-password>
+                    @endif
                 @else
-                    <x-confirms-password wire:then="disableTwoFactorAuthentication">
-                        <x-danger-button wire:loading.attr="disabled">
+                    @if ($confirmPassword)
+                        <x-confirms-password wire:then="disableTwoFactorAuthentication">
+                            <x-danger-button wire:loading.attr="disabled">
+                                {{ __('Disable') }}
+                            </x-danger-button>
+                        </x-confirms-password>
+                    @else
+                        <x-danger-button wire:click="disableTwoFactorAuthentication">
                             {{ __('Disable') }}
                         </x-danger-button>
-                    </x-confirms-password>
+                    @endif
                 @endif
 
             @endif


### PR DESCRIPTION
Fortify, as well as the Jetstreams 2FA component class has code that supports skipping the password confirmation, if set in the according configuration via a feature-flag.

The current implementation of the livewire view however, does not respect that config.

This admittedly naive approach fixes this. 

The feature is especially useful for applications that don't make use of passwords (for example because they are using business SSO but still want to enforce 2FA)

This adresses issue #1463