### PR TITLE
Fix incorrect annotations in Livewire components using "@return void"

### DIFF
--- a/src/Http/Livewire/CreateTeamForm.php
+++ b/src/Http/Livewire/CreateTeamForm.php
@@ -22,7 +22,7 @@ class CreateTeamForm extends Component
      * Create a new team.
      *
      * @param  \Laravel\Jetstream\Contracts\CreatesTeams  $creator
-     * @return void
+     * @return mixed
      */
     public function createTeam(CreatesTeams $creator)
     {

--- a/src/Http/Livewire/TeamMemberManager.php
+++ b/src/Http/Livewire/TeamMemberManager.php
@@ -183,7 +183,7 @@ class TeamMemberManager extends Component
      * Remove the currently authenticated user from the team.
      *
      * @param  \Laravel\Jetstream\Contracts\RemovesTeamMembers  $remover
-     * @return \Illuminate\Routing\Redirector|\Illuminate\Http\RedirectResponse
+     * @return \Illuminate\Http\RedirectResponse
      */
     public function leaveTeam(RemovesTeamMembers $remover)
     {

--- a/src/Http/Livewire/TeamMemberManager.php
+++ b/src/Http/Livewire/TeamMemberManager.php
@@ -183,7 +183,7 @@ class TeamMemberManager extends Component
      * Remove the currently authenticated user from the team.
      *
      * @param  \Laravel\Jetstream\Contracts\RemovesTeamMembers  $remover
-     * @return void
+     * @return \Illuminate\Routing\Redirector|\Illuminate\Http\RedirectResponse
      */
     public function leaveTeam(RemovesTeamMembers $remover)
     {

--- a/src/Http/Livewire/UpdateProfileInformationForm.php
+++ b/src/Http/Livewire/UpdateProfileInformationForm.php
@@ -50,7 +50,7 @@ class UpdateProfileInformationForm extends Component
      * Update the user's profile information.
      *
      * @param  \Laravel\Fortify\Contracts\UpdatesUserProfileInformation  $updater
-     * @return void
+     * @return \Illuminate\Routing\Redirector|\Illuminate\Http\RedirectResponse|void
      */
     public function updateProfileInformation(UpdatesUserProfileInformation $updater)
     {

--- a/src/Http/Livewire/UpdateProfileInformationForm.php
+++ b/src/Http/Livewire/UpdateProfileInformationForm.php
@@ -50,7 +50,7 @@ class UpdateProfileInformationForm extends Component
      * Update the user's profile information.
      *
      * @param  \Laravel\Fortify\Contracts\UpdatesUserProfileInformation  $updater
-     * @return \Illuminate\Routing\Redirector|\Illuminate\Http\RedirectResponse|void
+     * @return \Illuminate\Routing\Redirector|\Illuminate\Http\RedirectResponse|null
      */
     public function updateProfileInformation(UpdatesUserProfileInformation $updater)
     {

--- a/src/Http/Livewire/UpdateProfileInformationForm.php
+++ b/src/Http/Livewire/UpdateProfileInformationForm.php
@@ -50,7 +50,7 @@ class UpdateProfileInformationForm extends Component
      * Update the user's profile information.
      *
      * @param  \Laravel\Fortify\Contracts\UpdatesUserProfileInformation  $updater
-     * @return \Illuminate\Routing\Redirector|\Illuminate\Http\RedirectResponse|null
+     * @return \Illuminate\Http\RedirectResponse|null
      */
     public function updateProfileInformation(UpdatesUserProfileInformation $updater)
     {


### PR DESCRIPTION
Hi!

This is a _tiny_ update to correct some of the type annotations which are currently `@return void` when a return type is possible.

This obviously shouldn't impact any runtime behaviour, but it's causing PHPStan errors in one of my projects so it would be appreciated if we could correct the type annotations 🙂 

I tried to follow the return type conventions used in other places, but please feel free to suggest superior alternatives if you believe they exist.

Thanks for all you do 🙏 