### PR TITLE
fix: position of confirm 2fa button to right

### DIFF
--- a/stubs/livewire/resources/views/profile/two-factor-authentication-form.blade.php
+++ b/stubs/livewire/resources/views/profile/two-factor-authentication-form.blade.php
@@ -91,6 +91,11 @@
                         </x-secondary-button>
                     </x-confirms-password>
                 @elseif ($showingConfirmation)
+                    <x-confirms-password wire:then="disableTwoFactorAuthentication">
+                        <x-secondary-button wire:loading.attr="disabled">
+                            {{ __('Cancel') }}
+                        </x-secondary-button>
+                    </x-confirms-password>
                     <x-confirms-password wire:then="confirmTwoFactorAuthentication">
                         <x-button type="button" class="me-3" wire:loading.attr="disabled">
                             {{ __('Confirm') }}
@@ -104,13 +109,7 @@
                     </x-confirms-password>
                 @endif
 
-                @if ($showingConfirmation)
-                    <x-confirms-password wire:then="disableTwoFactorAuthentication">
-                        <x-secondary-button wire:loading.attr="disabled">
-                            {{ __('Cancel') }}
-                        </x-secondary-button>
-                    </x-confirms-password>
-                @else
+                @if (!$showingConfirmation)
                     <x-confirms-password wire:then="disableTwoFactorAuthentication">
                         <x-danger-button wire:loading.attr="disabled">
                             {{ __('Disable') }}


### PR DESCRIPTION
I changed the position of the confirmation button for enabling two-factor authentication. It was previously displayed to the left of the cancel button, which differs from the Jetstream standard (cancel on the left, confirm on the right). To achieve this, I only needed to change the position of the cancel button code and modify an if statement. I am not yet familiar with integration testing, otherwise I would have proceeded with this action.

I believe that this modification improves the user experience, which is why I have implemented it in a personal project of mine.

![button change](https://github.com/laravel/jetstream/assets/28867801/3fa0e3e6-881c-4679-8386-50475fdd9e82)
This is my application, please ignore the changes in theme (im using daysi ui).