### PR TITLE
[5.x] Install API optionally

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -154,9 +154,11 @@ class InstallCommand extends Command implements PromptsForMissingInput
             return false;
         }
 
-        $this->call('install:api', [
-            '--without-migration-prompt' => true,
-        ]);
+        if ($this->option('api')) {
+            $this->call('install:api', [
+                '--without-migration-prompt' => true,
+            ]);
+        }
 
         // Update Configuration...
         $this->replaceInFile('inertia', 'livewire', config_path('jetstream.php'));
@@ -340,9 +342,11 @@ EOF;
             return false;
         }
 
-        $this->call('install:api', [
-            '--without-migration-prompt' => true,
-        ]);
+        if ($this->option('api')) {
+            $this->call('install:api', [
+                '--without-migration-prompt' => true,
+            ]);
+        }
 
         // Install NPM packages...
         $this->updateNodePackages(function ($packages) {


### PR DESCRIPTION
Currently, install command doesn't respect `--api` option and always call `install:api`. This PR fixes that.