### PR TITLE
[5.x] Remove unused variables from test stubs

### DIFF
--- a/stubs/pest-tests/inertia/ApiTokenPermissionsTest.php
+++ b/stubs/pest-tests/inertia/ApiTokenPermissionsTest.php
@@ -17,7 +17,7 @@ test('api token permissions can be updated', function () {
         'abilities' => ['create', 'read'],
     ]);
 
-    $response = $this->put('/user/api-tokens/'.$token->id, [
+    $this->put('/user/api-tokens/'.$token->id, [
         'name' => $token->name,
         'permissions' => [
             'delete',

--- a/stubs/pest-tests/inertia/BrowserSessionsTest.php
+++ b/stubs/pest-tests/inertia/BrowserSessionsTest.php
@@ -3,7 +3,7 @@
 use App\Models\User;
 
 test('other browser sessions can be logged out', function () {
-    $this->actingAs($user = User::factory()->create());
+    $this->actingAs(User::factory()->create());
 
     $response = $this->delete('/user/other-browser-sessions', [
         'password' => 'password',

--- a/stubs/pest-tests/inertia/CreateApiTokenTest.php
+++ b/stubs/pest-tests/inertia/CreateApiTokenTest.php
@@ -10,7 +10,7 @@ test('api tokens can be created', function () {
         $this->actingAs($user = User::factory()->create());
     }
 
-    $response = $this->post('/user/api-tokens', [
+    $this->post('/user/api-tokens', [
         'name' => 'Test Token',
         'permissions' => [
             'read',

--- a/stubs/pest-tests/inertia/CreateTeamTest.php
+++ b/stubs/pest-tests/inertia/CreateTeamTest.php
@@ -5,7 +5,7 @@ use App\Models\User;
 test('teams can be created', function () {
     $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
-    $response = $this->post('/teams', [
+    $this->post('/teams', [
         'name' => 'Test Team',
     ]);
 

--- a/stubs/pest-tests/inertia/DeleteAccountTest.php
+++ b/stubs/pest-tests/inertia/DeleteAccountTest.php
@@ -6,7 +6,7 @@ use Laravel\Jetstream\Features;
 test('user accounts can be deleted', function () {
     $this->actingAs($user = User::factory()->create());
 
-    $response = $this->delete('/user', [
+    $this->delete('/user', [
         'password' => 'password',
     ]);
 
@@ -18,7 +18,7 @@ test('user accounts can be deleted', function () {
 test('correct password must be provided before account can be deleted', function () {
     $this->actingAs($user = User::factory()->create());
 
-    $response = $this->delete('/user', [
+    $this->delete('/user', [
         'password' => 'wrong-password',
     ]);
 

--- a/stubs/pest-tests/inertia/DeleteApiTokenTest.php
+++ b/stubs/pest-tests/inertia/DeleteApiTokenTest.php
@@ -17,7 +17,7 @@ test('api tokens can be deleted', function () {
         'abilities' => ['create', 'read'],
     ]);
 
-    $response = $this->delete('/user/api-tokens/'.$token->id);
+    $this->delete('/user/api-tokens/'.$token->id);
 
     expect($user->fresh()->tokens)->toHaveCount(0);
 })->skip(function () {

--- a/stubs/pest-tests/inertia/DeleteTeamTest.php
+++ b/stubs/pest-tests/inertia/DeleteTeamTest.php
@@ -14,7 +14,7 @@ test('teams can be deleted', function () {
         $otherUser = User::factory()->create(), ['role' => 'test-role']
     );
 
-    $response = $this->delete('/teams/'.$team->id);
+    $this->delete('/teams/'.$team->id);
 
     expect($team->fresh())->toBeNull();
     expect($otherUser->fresh()->teams)->toHaveCount(0);
@@ -23,7 +23,7 @@ test('teams can be deleted', function () {
 test('personal teams cant be deleted', function () {
     $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
-    $response = $this->delete('/teams/'.$user->currentTeam->id);
+    $this->delete('/teams/'.$user->currentTeam->id);
 
     expect($user->currentTeam->fresh())->not->toBeNull();
 });

--- a/stubs/pest-tests/inertia/InviteTeamMemberTest.php
+++ b/stubs/pest-tests/inertia/InviteTeamMemberTest.php
@@ -10,7 +10,7 @@ test('team members can be invited to team', function () {
 
     $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
-    $response = $this->post('/teams/'.$user->currentTeam->id.'/members', [
+    $this->post('/teams/'.$user->currentTeam->id.'/members', [
         'email' => 'test@example.com',
         'role' => 'admin',
     ]);
@@ -32,7 +32,7 @@ test('team member invitations can be cancelled', function () {
         'role' => 'admin',
     ]);
 
-    $response = $this->delete('/team-invitations/'.$invitation->id);
+    $this->delete('/team-invitations/'.$invitation->id);
 
     expect($user->currentTeam->fresh()->teamInvitations)->toHaveCount(0);
 })->skip(function () {

--- a/stubs/pest-tests/inertia/LeaveTeamTest.php
+++ b/stubs/pest-tests/inertia/LeaveTeamTest.php
@@ -11,7 +11,7 @@ test('users can leave teams', function () {
 
     $this->actingAs($otherUser);
 
-    $response = $this->delete('/teams/'.$user->currentTeam->id.'/members/'.$otherUser->id);
+    $this->delete('/teams/'.$user->currentTeam->id.'/members/'.$otherUser->id);
 
     expect($user->currentTeam->fresh()->users)->toHaveCount(0);
 });

--- a/stubs/pest-tests/inertia/ProfileInformationTest.php
+++ b/stubs/pest-tests/inertia/ProfileInformationTest.php
@@ -5,7 +5,7 @@ use App\Models\User;
 test('profile information can be updated', function () {
     $this->actingAs($user = User::factory()->create());
 
-    $response = $this->put('/user/profile-information', [
+    $this->put('/user/profile-information', [
         'name' => 'Test Name',
         'email' => 'test@example.com',
     ]);

--- a/stubs/pest-tests/inertia/RemoveTeamMemberTest.php
+++ b/stubs/pest-tests/inertia/RemoveTeamMemberTest.php
@@ -9,7 +9,7 @@ test('team members can be removed from teams', function () {
         $otherUser = User::factory()->create(), ['role' => 'admin']
     );
 
-    $response = $this->delete('/teams/'.$user->currentTeam->id.'/members/'.$otherUser->id);
+    $this->delete('/teams/'.$user->currentTeam->id.'/members/'.$otherUser->id);
 
     expect($user->currentTeam->fresh()->users)->toHaveCount(0);
 });

--- a/stubs/pest-tests/inertia/TwoFactorAuthenticationSettingsTest.php
+++ b/stubs/pest-tests/inertia/TwoFactorAuthenticationSettingsTest.php
@@ -8,7 +8,7 @@ test('two factor authentication can be enabled', function () {
 
     $this->withSession(['auth.password_confirmed_at' => time()]);
 
-    $response = $this->post('/user/two-factor-authentication');
+    $this->post('/user/two-factor-authentication');
 
     expect($user->fresh()->two_factor_secret)->not->toBeNull();
     expect($user->fresh()->recoveryCodes())->toHaveCount(8);

--- a/stubs/pest-tests/inertia/UpdatePasswordTest.php
+++ b/stubs/pest-tests/inertia/UpdatePasswordTest.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Hash;
 test('password can be updated', function () {
     $this->actingAs($user = User::factory()->create());
 
-    $response = $this->put('/user/password', [
+    $this->put('/user/password', [
         'current_password' => 'password',
         'password' => 'new-password',
         'password_confirmation' => 'new-password',

--- a/stubs/pest-tests/inertia/UpdateTeamMemberRoleTest.php
+++ b/stubs/pest-tests/inertia/UpdateTeamMemberRoleTest.php
@@ -9,7 +9,7 @@ test('team member roles can be updated', function () {
         $otherUser = User::factory()->create(), ['role' => 'admin']
     );
 
-    $response = $this->put('/teams/'.$user->currentTeam->id.'/members/'.$otherUser->id, [
+    $this->put('/teams/'.$user->currentTeam->id.'/members/'.$otherUser->id, [
         'role' => 'editor',
     ]);
 
@@ -27,7 +27,7 @@ test('only team owner can update team member roles', function () {
 
     $this->actingAs($otherUser);
 
-    $response = $this->put('/teams/'.$user->currentTeam->id.'/members/'.$otherUser->id, [
+    $this->put('/teams/'.$user->currentTeam->id.'/members/'.$otherUser->id, [
         'role' => 'editor',
     ]);
 

--- a/stubs/pest-tests/inertia/UpdateTeamNameTest.php
+++ b/stubs/pest-tests/inertia/UpdateTeamNameTest.php
@@ -5,7 +5,7 @@ use App\Models\User;
 test('team names can be updated', function () {
     $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
-    $response = $this->put('/teams/'.$user->currentTeam->id, [
+    $this->put('/teams/'.$user->currentTeam->id, [
         'name' => 'Test Team',
     ]);
 

--- a/stubs/pest-tests/livewire/BrowserSessionsTest.php
+++ b/stubs/pest-tests/livewire/BrowserSessionsTest.php
@@ -5,7 +5,7 @@ use Laravel\Jetstream\Http\Livewire\LogoutOtherBrowserSessionsForm;
 use Livewire\Livewire;
 
 test('other browser sessions can be logged out', function () {
-    $this->actingAs($user = User::factory()->create());
+    $this->actingAs(User::factory()->create());
 
     Livewire::test(LogoutOtherBrowserSessionsForm::class)
         ->set('password', 'password')

--- a/stubs/pest-tests/livewire/DeleteAccountTest.php
+++ b/stubs/pest-tests/livewire/DeleteAccountTest.php
@@ -8,7 +8,7 @@ use Livewire\Livewire;
 test('user accounts can be deleted', function () {
     $this->actingAs($user = User::factory()->create());
 
-    $component = Livewire::test(DeleteUserForm::class)
+    Livewire::test(DeleteUserForm::class)
         ->set('password', 'password')
         ->call('deleteUser');
 

--- a/stubs/pest-tests/livewire/DeleteTeamTest.php
+++ b/stubs/pest-tests/livewire/DeleteTeamTest.php
@@ -16,7 +16,7 @@ test('teams can be deleted', function () {
         $otherUser = User::factory()->create(), ['role' => 'test-role']
     );
 
-    $component = Livewire::test(DeleteTeamForm::class, ['team' => $team->fresh()])
+    Livewire::test(DeleteTeamForm::class, ['team' => $team->fresh()])
         ->call('deleteTeam');
 
     expect($team->fresh())->toBeNull();
@@ -26,7 +26,7 @@ test('teams can be deleted', function () {
 test('personal teams cant be deleted', function () {
     $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
-    $component = Livewire::test(DeleteTeamForm::class, ['team' => $user->currentTeam])
+    Livewire::test(DeleteTeamForm::class, ['team' => $user->currentTeam])
         ->call('deleteTeam')
         ->assertHasErrors(['team']);
 

--- a/stubs/pest-tests/livewire/InviteTeamMemberTest.php
+++ b/stubs/pest-tests/livewire/InviteTeamMemberTest.php
@@ -12,7 +12,7 @@ test('team members can be invited to team', function () {
 
     $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
-    $component = Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])
+    Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])
         ->set('addTeamMemberForm', [
             'email' => 'test@example.com',
             'role' => 'admin',

--- a/stubs/pest-tests/livewire/LeaveTeamTest.php
+++ b/stubs/pest-tests/livewire/LeaveTeamTest.php
@@ -13,7 +13,7 @@ test('users can leave teams', function () {
 
     $this->actingAs($otherUser);
 
-    $component = Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])
+    Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])
         ->call('leaveTeam');
 
     expect($user->currentTeam->fresh()->users)->toHaveCount(0);
@@ -22,7 +22,7 @@ test('users can leave teams', function () {
 test('team owners cant leave their own team', function () {
     $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
-    $component = Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])
+    Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])
         ->call('leaveTeam')
         ->assertHasErrors(['team']);
 

--- a/stubs/pest-tests/livewire/RemoveTeamMemberTest.php
+++ b/stubs/pest-tests/livewire/RemoveTeamMemberTest.php
@@ -11,7 +11,7 @@ test('team members can be removed from teams', function () {
         $otherUser = User::factory()->create(), ['role' => 'admin']
     );
 
-    $component = Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])
+    Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])
         ->set('teamMemberIdBeingRemoved', $otherUser->id)
         ->call('removeTeamMember');
 
@@ -27,7 +27,7 @@ test('only team owner can remove team members', function () {
 
     $this->actingAs($otherUser);
 
-    $component = Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])
+    Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])
         ->set('teamMemberIdBeingRemoved', $user->id)
         ->call('removeTeamMember')
         ->assertStatus(403);

--- a/stubs/pest-tests/livewire/UpdateTeamMemberRoleTest.php
+++ b/stubs/pest-tests/livewire/UpdateTeamMemberRoleTest.php
@@ -11,7 +11,7 @@ test('team member roles can be updated', function () {
         $otherUser = User::factory()->create(), ['role' => 'admin']
     );
 
-    $component = Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])
+    Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])
         ->set('managingRoleFor', $otherUser)
         ->set('currentRole', 'editor')
         ->call('updateRole');
@@ -30,7 +30,7 @@ test('only team owner can update team member roles', function () {
 
     $this->actingAs($otherUser);
 
-    $component = Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])
+    Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])
         ->set('managingRoleFor', $otherUser)
         ->set('currentRole', 'editor')
         ->call('updateRole')

--- a/stubs/tests/PasswordResetTest.php
+++ b/stubs/tests/PasswordResetTest.php
@@ -34,7 +34,7 @@ class PasswordResetTest extends TestCase
 
         $user = User::factory()->create();
 
-        $response = $this->post('/forgot-password', [
+        $this->post('/forgot-password', [
             'email' => $user->email,
         ]);
 
@@ -51,7 +51,7 @@ class PasswordResetTest extends TestCase
 
         $user = User::factory()->create();
 
-        $response = $this->post('/forgot-password', [
+        $this->post('/forgot-password', [
             'email' => $user->email,
         ]);
 
@@ -74,7 +74,7 @@ class PasswordResetTest extends TestCase
 
         $user = User::factory()->create();
 
-        $response = $this->post('/forgot-password', [
+        $this->post('/forgot-password', [
             'email' => $user->email,
         ]);
 

--- a/stubs/tests/inertia/ApiTokenPermissionsTest.php
+++ b/stubs/tests/inertia/ApiTokenPermissionsTest.php
@@ -26,7 +26,7 @@ class ApiTokenPermissionsTest extends TestCase
             'abilities' => ['create', 'read'],
         ]);
 
-        $response = $this->put('/user/api-tokens/'.$token->id, [
+        $this->put('/user/api-tokens/'.$token->id, [
             'name' => $token->name,
             'permissions' => [
                 'delete',

--- a/stubs/tests/inertia/BrowserSessionsTest.php
+++ b/stubs/tests/inertia/BrowserSessionsTest.php
@@ -12,7 +12,7 @@ class BrowserSessionsTest extends TestCase
 
     public function test_other_browser_sessions_can_be_logged_out(): void
     {
-        $this->actingAs($user = User::factory()->create());
+        $this->actingAs(User::factory()->create());
 
         $response = $this->delete('/user/other-browser-sessions', [
             'password' => 'password',

--- a/stubs/tests/inertia/CreateApiTokenTest.php
+++ b/stubs/tests/inertia/CreateApiTokenTest.php
@@ -19,7 +19,7 @@ class CreateApiTokenTest extends TestCase
 
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
-        $response = $this->post('/user/api-tokens', [
+        $this->post('/user/api-tokens', [
             'name' => 'Test Token',
             'permissions' => [
                 'read',

--- a/stubs/tests/inertia/CreateTeamTest.php
+++ b/stubs/tests/inertia/CreateTeamTest.php
@@ -14,7 +14,7 @@ class CreateTeamTest extends TestCase
     {
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
-        $response = $this->post('/teams', [
+        $this->post('/teams', [
             'name' => 'Test Team',
         ]);
 

--- a/stubs/tests/inertia/DeleteAccountTest.php
+++ b/stubs/tests/inertia/DeleteAccountTest.php
@@ -19,7 +19,7 @@ class DeleteAccountTest extends TestCase
 
         $this->actingAs($user = User::factory()->create());
 
-        $response = $this->delete('/user', [
+        $this->delete('/user', [
             'password' => 'password',
         ]);
 
@@ -34,7 +34,7 @@ class DeleteAccountTest extends TestCase
 
         $this->actingAs($user = User::factory()->create());
 
-        $response = $this->delete('/user', [
+        $this->delete('/user', [
             'password' => 'wrong-password',
         ]);
 

--- a/stubs/tests/inertia/DeleteApiTokenTest.php
+++ b/stubs/tests/inertia/DeleteApiTokenTest.php
@@ -26,7 +26,7 @@ class DeleteApiTokenTest extends TestCase
             'abilities' => ['create', 'read'],
         ]);
 
-        $response = $this->delete('/user/api-tokens/'.$token->id);
+        $this->delete('/user/api-tokens/'.$token->id);
 
         $this->assertCount(0, $user->fresh()->tokens);
     }

--- a/stubs/tests/inertia/DeleteTeamTest.php
+++ b/stubs/tests/inertia/DeleteTeamTest.php
@@ -23,7 +23,7 @@ class DeleteTeamTest extends TestCase
             $otherUser = User::factory()->create(), ['role' => 'test-role']
         );
 
-        $response = $this->delete('/teams/'.$team->id);
+        $this->delete('/teams/'.$team->id);
 
         $this->assertNull($team->fresh());
         $this->assertCount(0, $otherUser->fresh()->teams);
@@ -33,7 +33,7 @@ class DeleteTeamTest extends TestCase
     {
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
-        $response = $this->delete('/teams/'.$user->currentTeam->id);
+        $this->delete('/teams/'.$user->currentTeam->id);
 
         $this->assertNotNull($user->currentTeam->fresh());
     }

--- a/stubs/tests/inertia/InviteTeamMemberTest.php
+++ b/stubs/tests/inertia/InviteTeamMemberTest.php
@@ -23,7 +23,7 @@ class InviteTeamMemberTest extends TestCase
 
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
-        $response = $this->post('/teams/'.$user->currentTeam->id.'/members', [
+        $this->post('/teams/'.$user->currentTeam->id.'/members', [
             'email' => 'test@example.com',
             'role' => 'admin',
         ]);
@@ -48,7 +48,7 @@ class InviteTeamMemberTest extends TestCase
             'role' => 'admin',
         ]);
 
-        $response = $this->delete('/team-invitations/'.$invitation->id);
+        $this->delete('/team-invitations/'.$invitation->id);
 
         $this->assertCount(0, $user->currentTeam->fresh()->teamInvitations);
     }

--- a/stubs/tests/inertia/LeaveTeamTest.php
+++ b/stubs/tests/inertia/LeaveTeamTest.php
@@ -20,7 +20,7 @@ class LeaveTeamTest extends TestCase
 
         $this->actingAs($otherUser);
 
-        $response = $this->delete('/teams/'.$user->currentTeam->id.'/members/'.$otherUser->id);
+        $this->delete('/teams/'.$user->currentTeam->id.'/members/'.$otherUser->id);
 
         $this->assertCount(0, $user->currentTeam->fresh()->users);
     }

--- a/stubs/tests/inertia/ProfileInformationTest.php
+++ b/stubs/tests/inertia/ProfileInformationTest.php
@@ -14,7 +14,7 @@ class ProfileInformationTest extends TestCase
     {
         $this->actingAs($user = User::factory()->create());
 
-        $response = $this->put('/user/profile-information', [
+        $this->put('/user/profile-information', [
             'name' => 'Test Name',
             'email' => 'test@example.com',
         ]);

--- a/stubs/tests/inertia/RemoveTeamMemberTest.php
+++ b/stubs/tests/inertia/RemoveTeamMemberTest.php
@@ -18,7 +18,7 @@ class RemoveTeamMemberTest extends TestCase
             $otherUser = User::factory()->create(), ['role' => 'admin']
         );
 
-        $response = $this->delete('/teams/'.$user->currentTeam->id.'/members/'.$otherUser->id);
+        $this->delete('/teams/'.$user->currentTeam->id.'/members/'.$otherUser->id);
 
         $this->assertCount(0, $user->currentTeam->fresh()->users);
     }

--- a/stubs/tests/inertia/TwoFactorAuthenticationSettingsTest.php
+++ b/stubs/tests/inertia/TwoFactorAuthenticationSettingsTest.php
@@ -21,7 +21,7 @@ class TwoFactorAuthenticationSettingsTest extends TestCase
 
         $this->withSession(['auth.password_confirmed_at' => time()]);
 
-        $response = $this->post('/user/two-factor-authentication');
+        $this->post('/user/two-factor-authentication');
 
         $this->assertNotNull($user->fresh()->two_factor_secret);
         $this->assertCount(8, $user->fresh()->recoveryCodes());

--- a/stubs/tests/inertia/UpdatePasswordTest.php
+++ b/stubs/tests/inertia/UpdatePasswordTest.php
@@ -15,7 +15,7 @@ class UpdatePasswordTest extends TestCase
     {
         $this->actingAs($user = User::factory()->create());
 
-        $response = $this->put('/user/password', [
+        $this->put('/user/password', [
             'current_password' => 'password',
             'password' => 'new-password',
             'password_confirmation' => 'new-password',

--- a/stubs/tests/inertia/UpdateTeamMemberRoleTest.php
+++ b/stubs/tests/inertia/UpdateTeamMemberRoleTest.php
@@ -18,7 +18,7 @@ class UpdateTeamMemberRoleTest extends TestCase
             $otherUser = User::factory()->create(), ['role' => 'admin']
         );
 
-        $response = $this->put('/teams/'.$user->currentTeam->id.'/members/'.$otherUser->id, [
+        $this->put('/teams/'.$user->currentTeam->id.'/members/'.$otherUser->id, [
             'role' => 'editor',
         ]);
 
@@ -37,7 +37,7 @@ class UpdateTeamMemberRoleTest extends TestCase
 
         $this->actingAs($otherUser);
 
-        $response = $this->put('/teams/'.$user->currentTeam->id.'/members/'.$otherUser->id, [
+        $this->put('/teams/'.$user->currentTeam->id.'/members/'.$otherUser->id, [
             'role' => 'editor',
         ]);
 

--- a/stubs/tests/inertia/UpdateTeamNameTest.php
+++ b/stubs/tests/inertia/UpdateTeamNameTest.php
@@ -14,7 +14,7 @@ class UpdateTeamNameTest extends TestCase
     {
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
-        $response = $this->put('/teams/'.$user->currentTeam->id, [
+        $this->put('/teams/'.$user->currentTeam->id, [
             'name' => 'Test Team',
         ]);
 

--- a/stubs/tests/livewire/BrowserSessionsTest.php
+++ b/stubs/tests/livewire/BrowserSessionsTest.php
@@ -14,7 +14,7 @@ class BrowserSessionsTest extends TestCase
 
     public function test_other_browser_sessions_can_be_logged_out(): void
     {
-        $this->actingAs($user = User::factory()->create());
+        $this->actingAs(User::factory()->create());
 
         Livewire::test(LogoutOtherBrowserSessionsForm::class)
             ->set('password', 'password')

--- a/stubs/tests/livewire/DeleteTeamTest.php
+++ b/stubs/tests/livewire/DeleteTeamTest.php
@@ -25,7 +25,7 @@ class DeleteTeamTest extends TestCase
             $otherUser = User::factory()->create(), ['role' => 'test-role']
         );
 
-        $component = Livewire::test(DeleteTeamForm::class, ['team' => $team->fresh()])
+        Livewire::test(DeleteTeamForm::class, ['team' => $team->fresh()])
             ->call('deleteTeam');
 
         $this->assertNull($team->fresh());
@@ -36,7 +36,7 @@ class DeleteTeamTest extends TestCase
     {
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
-        $component = Livewire::test(DeleteTeamForm::class, ['team' => $user->currentTeam])
+        Livewire::test(DeleteTeamForm::class, ['team' => $user->currentTeam])
             ->call('deleteTeam')
             ->assertHasErrors(['team']);
 

--- a/stubs/tests/livewire/InviteTeamMemberTest.php
+++ b/stubs/tests/livewire/InviteTeamMemberTest.php
@@ -25,7 +25,7 @@ class InviteTeamMemberTest extends TestCase
 
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
-        $component = Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])
+        Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])
             ->set('addTeamMemberForm', [
                 'email' => 'test@example.com',
                 'role' => 'admin',

--- a/stubs/tests/livewire/LeaveTeamTest.php
+++ b/stubs/tests/livewire/LeaveTeamTest.php
@@ -22,7 +22,7 @@ class LeaveTeamTest extends TestCase
 
         $this->actingAs($otherUser);
 
-        $component = Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])
+        Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])
             ->call('leaveTeam');
 
         $this->assertCount(0, $user->currentTeam->fresh()->users);
@@ -32,7 +32,7 @@ class LeaveTeamTest extends TestCase
     {
         $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
-        $component = Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])
+        Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])
             ->call('leaveTeam')
             ->assertHasErrors(['team']);
 

--- a/stubs/tests/livewire/RemoveTeamMemberTest.php
+++ b/stubs/tests/livewire/RemoveTeamMemberTest.php
@@ -20,7 +20,7 @@ class RemoveTeamMemberTest extends TestCase
             $otherUser = User::factory()->create(), ['role' => 'admin']
         );
 
-        $component = Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])
+        Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])
             ->set('teamMemberIdBeingRemoved', $otherUser->id)
             ->call('removeTeamMember');
 
@@ -37,7 +37,7 @@ class RemoveTeamMemberTest extends TestCase
 
         $this->actingAs($otherUser);
 
-        $component = Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])
+        Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])
             ->set('teamMemberIdBeingRemoved', $user->id)
             ->call('removeTeamMember')
             ->assertStatus(403);

--- a/stubs/tests/livewire/UpdateTeamMemberRoleTest.php
+++ b/stubs/tests/livewire/UpdateTeamMemberRoleTest.php
@@ -20,7 +20,7 @@ class UpdateTeamMemberRoleTest extends TestCase
             $otherUser = User::factory()->create(), ['role' => 'admin']
         );
 
-        $component = Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])
+        Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])
             ->set('managingRoleFor', $otherUser)
             ->set('currentRole', 'editor')
             ->call('updateRole');
@@ -40,7 +40,7 @@ class UpdateTeamMemberRoleTest extends TestCase
 
         $this->actingAs($otherUser);
 
-        $component = Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])
+        Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])
             ->set('managingRoleFor', $otherUser)
             ->set('currentRole', 'editor')
             ->call('updateRole')


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

If you change the behavior of the Inertia stack you're expected to update the Livewire stack as well and vice versa.
-->

This pull request removes unused variables from the test stubs in order to prevent people's IDE:s and linters from screaming in a freshly generated Jetstream project.
