### PR TITLE
[4.x] Use native <dialog> cancel event, remove unneeded showSlot

### DIFF
--- a/stubs/inertia/resources/js/Components/Modal.vue
+++ b/stubs/inertia/resources/js/Components/Modal.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 
 const props = defineProps({
     show: {
@@ -16,20 +16,17 @@ const props = defineProps({
     },
 });
 
-const emit = defineEmits(['close']);
+const emit = defineEmits(['close', 'cancel']);
 const dialog = ref();
-const showSlot = ref(props.show);
 
 watch(() => props.show, () => {
     if (props.show) {
         document.body.style.overflow = 'hidden';
-        showSlot.value = true;
         dialog.value?.showModal();
     } else {
         document.body.style.overflow = null;
         setTimeout(() => {
             dialog.value?.close();
-            showSlot.value = false;
         }, 200);
     }
 });
@@ -41,18 +38,6 @@ const close = () => {
     }
 };
 
-const closeOnEscape = (e) => {
-    if (e.key === 'Escape' && props.show) {
-        close();
-    }
-};
-
-onMounted(() => document.addEventListener('keydown', closeOnEscape));
-
-onUnmounted(() => {
-    document.removeEventListener('keydown', closeOnEscape);
-    document.body.style.overflow = null;
-});
 
 const maxWidthClass = computed(() => {
     return {
@@ -63,10 +48,18 @@ const maxWidthClass = computed(() => {
         '2xl': 'sm:max-w-2xl',
     }[props.maxWidth];
 });
+
+function onCancel(){
+    close();
+    emit('cancel');
+}
+
 </script>
 
 <template>
-    <dialog class="z-50 m-0 min-h-full min-w-full overflow-y-auto bg-transparent backdrop:bg-transparent" ref="dialog">
+    <dialog
+        @cancel.prevent="onCancel"
+        class="z-50 m-0 min-h-full min-w-full overflow-y-auto bg-transparent backdrop:bg-transparent" ref="dialog">
         <div class="fixed inset-0 overflow-y-auto px-4 py-6 sm:px-0 z-50" scroll-region>
             <transition
                 enter-active-class="ease-out duration-300"
@@ -90,7 +83,7 @@ const maxWidthClass = computed(() => {
                 leave-to-class="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
             >
                 <div v-show="show" class="mb-6 bg-white dark:bg-gray-800 rounded-lg overflow-hidden shadow-xl transform transition-all sm:w-full sm:mx-auto" :class="maxWidthClass">
-                    <slot v-if="showSlot"/>
+                    <slot />
                 </div>
             </transition>
         </div>


### PR DESCRIPTION
This PR changes the <dialog> to use a native dialog @cancel event instead of manually adding and removing document-level event listeners when the dialog is shown and dismissed.

This also removes an unnecessary ref which wasn't really doing anything.