### PR TITLE
Add Disabled Class to Primary Button

### DIFF
--- a/stubs/inertia/resources/js/Components/PrimaryButton.vue
+++ b/stubs/inertia/resources/js/Components/PrimaryButton.vue
@@ -8,7 +8,7 @@ defineProps({
 </script>
 
 <template>
-    <button :type="type" class="inline-flex items-center px-4 py-2 bg-gray-800 dark:bg-gray-200 border border-transparent rounded-md font-semibold text-xs text-white dark:text-gray-800 uppercase tracking-widest hover:bg-gray-700 dark:hover:bg-white focus:bg-gray-700 dark:focus:bg-white active:bg-gray-900 dark:active:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition ease-in-out duration-150">
+    <button :type="type" class="inline-flex disabled:opacity-50 disabled:cursor-not-allowed items-center px-4 py-2 bg-gray-800 dark:bg-gray-200 border border-transparent rounded-md font-semibold text-xs text-white dark:text-gray-800 uppercase tracking-widest hover:bg-gray-700 dark:hover:bg-white focus:bg-gray-700 dark:focus:bg-white active:bg-gray-900 dark:active:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition ease-in-out duration-150">
         <slot />
     </button>
 </template>

--- a/stubs/inertia/resources/js/Components/PrimaryButton.vue
+++ b/stubs/inertia/resources/js/Components/PrimaryButton.vue
@@ -8,7 +8,7 @@ defineProps({
 </script>
 
 <template>
-    <button :type="type" class="inline-flex disabled:opacity-50 disabled:cursor-not-allowed items-center px-4 py-2 bg-gray-800 dark:bg-gray-200 border border-transparent rounded-md font-semibold text-xs text-white dark:text-gray-800 uppercase tracking-widest hover:bg-gray-700 dark:hover:bg-white focus:bg-gray-700 dark:focus:bg-white active:bg-gray-900 dark:active:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition ease-in-out duration-150">
+    <button :type="type" class="inline-flex items-center px-4 py-2 bg-gray-800 dark:bg-gray-200 border border-transparent rounded-md font-semibold text-xs text-white dark:text-gray-800 uppercase tracking-widest hover:bg-gray-700 dark:hover:bg-white focus:bg-gray-700 dark:focus:bg-white active:bg-gray-900 dark:active:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition ease-in-out duration-150 disabled:opacity-50 disabled:cursor-not-allowed">
         <slot />
     </button>
 </template>


### PR DESCRIPTION
I add this on all projects maybe the buttons should come with this by default?

Benefit to the user: Allows the developer to show a button is not enabled to the user.

![CleanShot 2024-05-04 at 18 51 59@2x](https://github.com/laravel/jetstream/assets/365385/8f8dd1ef-9fbb-40e9-9afc-f771287b90d0)

then when enabled:

![CleanShot 2024-05-04 at 18 52 15@2x](https://github.com/laravel/jetstream/assets/365385/afe48e7b-a1d3-4ca3-a2bb-70a761ae8b6d)

