### PR TITLE
fix: replace hard-coded team invitation model table in unique validation rule

### DIFF
--- a/stubs/app/Actions/Jetstream/InviteTeamMember.php
+++ b/stubs/app/Actions/Jetstream/InviteTeamMember.php
@@ -62,7 +62,7 @@ class InviteTeamMember implements InvitesTeamMembers
         return array_filter([
             'email' => [
                 'required', 'email',
-                Rule::unique('team_invitations')->where(function (Builder $query) use ($team) {
+                Rule::unique(Jetstream::teamInvitationModel())->where(function (Builder $query) use ($team) {
                     $query->where('team_id', $team->id);
                 }),
             ],


### PR DESCRIPTION
Hard-coded team invitation model table in unique validation rule in `InviteTeamMember` action breaks application if user has overridden team invitation model using available `Jetstream::useTeamInvitationModel()` method.

This PR updates the validation rule to use `Jetstream::teamInvitationModel()` instead, so currently set invitation model table is used.
