### PR TITLE
Change update password message to use passphrase term instead

### DIFF
--- a/stubs/inertia/resources/js/Pages/Profile/Partials/UpdatePasswordForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/Partials/UpdatePasswordForm.vue
@@ -44,7 +44,7 @@ const updatePassword = () => {
         </template>
 
         <template #description>
-            Ensure your account is using a long, random password to stay secure.
+            Ensure your account is using a long, random passphrase to stay secure.
         </template>
 
         <template #form>

--- a/stubs/livewire/resources/views/profile/update-password-form.blade.php
+++ b/stubs/livewire/resources/views/profile/update-password-form.blade.php
@@ -4,7 +4,7 @@
     </x-slot>
 
     <x-slot name="description">
-        {{ __('Ensure your account is using a long, random password to stay secure.') }}
+        {{ __('Ensure your account is using a long, random passphrase to stay secure.') }}
     </x-slot>
 
     <x-slot name="form">


### PR DESCRIPTION
Since it's generally recommended to use passphrases instead of passwords, this updates the "Ensure your account is using a long, random password to stay secure." to tell the user to use a "random passphrase" instead. This change is not breaking as it does not change any code logic. It makes things easier for developers and end users by nudging them to use a more secure password type.