### PR TITLE
[5.x] Remove `_method` in `UpdateProfileInformationForm.vue`

### DIFF
--- a/stubs/inertia/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
@@ -14,7 +14,6 @@ const props = defineProps({
 });
 
 const form = useForm({
-    _method: 'PUT',
     name: props.user.name,
     email: props.user.email,
     photo: null,
@@ -29,7 +28,7 @@ const updateProfileInformation = () => {
         form.photo = photoInput.value.files[0];
     }
 
-    form.post(route('user-profile-information.update'), {
+    form.put(route('user-profile-information.update'), {
         errorBag: 'updateProfileInformation',
         preserveScroll: true,
         onSuccess: () => clearPhotoFileInput(),


### PR DESCRIPTION
Makes it a bit simpler. I assume the `_method` property was used when there were no other ways to submit the form.

Also, this is the only place with `_method` in Jetstream and Breeze.