### PR TITLE
[5.x] Allow Inertia pages paths modification

### DIFF
--- a/src/Contracts/ApiIndexViewResponse.php
+++ b/src/Contracts/ApiIndexViewResponse.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Laravel\Jetstream\Contracts;
+
+use Illuminate\Contracts\Support\Responsable;
+
+interface ApiIndexViewResponse extends Responsable
+{
+    //
+}

--- a/src/Contracts/ProfileShowViewResponse.php
+++ b/src/Contracts/ProfileShowViewResponse.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Laravel\Jetstream\Contracts;
+
+use Illuminate\Contracts\Support\Responsable;
+
+interface ProfileShowViewResponse extends Responsable
+{
+    //
+}

--- a/src/Contracts/TeamsCreateViewResponse.php
+++ b/src/Contracts/TeamsCreateViewResponse.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Laravel\Jetstream\Contracts;
+
+use Illuminate\Contracts\Support\Responsable;
+
+interface TeamsCreateViewResponse extends Responsable
+{
+    //
+}

--- a/src/Contracts/TeamsShowViewResponse.php
+++ b/src/Contracts/TeamsShowViewResponse.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Laravel\Jetstream\Contracts;
+
+use Illuminate\Contracts\Support\Responsable;
+
+interface TeamsShowViewResponse extends Responsable
+{
+    //
+}

--- a/src/Http/Controllers/Inertia/ApiTokenController.php
+++ b/src/Http/Controllers/Inertia/ApiTokenController.php
@@ -4,6 +4,7 @@ namespace Laravel\Jetstream\Http\Controllers\Inertia;
 
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Laravel\Jetstream\Contracts\ApiIndexViewResponse;
 use Laravel\Jetstream\Jetstream;
 
 class ApiTokenController extends Controller
@@ -12,19 +13,11 @@ class ApiTokenController extends Controller
      * Show the user API token screen.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return \Inertia\Response
+     * @return \Laravel\Jetstream\Contracts\ApiIndexViewResponse
      */
-    public function index(Request $request)
+    public function index(Request $request): ApiIndexViewResponse
     {
-        return Jetstream::inertia()->render($request, 'API/Index', [
-            'tokens' => $request->user()->tokens->map(function ($token) {
-                return $token->toArray() + [
-                    'last_used_ago' => optional($token->last_used_at)->diffForHumans(),
-                ];
-            }),
-            'availablePermissions' => Jetstream::$permissions,
-            'defaultPermissions' => Jetstream::$defaultPermissions,
-        ]);
+        return app(ApiIndexViewResponse::class);
     }
 
     /**

--- a/src/Http/Controllers/Inertia/TeamController.php
+++ b/src/Http/Controllers/Inertia/TeamController.php
@@ -8,6 +8,8 @@ use Illuminate\Support\Facades\Gate;
 use Laravel\Jetstream\Actions\ValidateTeamDeletion;
 use Laravel\Jetstream\Contracts\CreatesTeams;
 use Laravel\Jetstream\Contracts\DeletesTeams;
+use Laravel\Jetstream\Contracts\TeamsCreateViewResponse;
+use Laravel\Jetstream\Contracts\TeamsShowViewResponse;
 use Laravel\Jetstream\Contracts\UpdatesTeamNames;
 use Laravel\Jetstream\Jetstream;
 use Laravel\Jetstream\RedirectsActions;
@@ -21,40 +23,28 @@ class TeamController extends Controller
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  int  $teamId
-     * @return \Inertia\Response
+     * @return \Laravel\Jetstream\Contracts\TeamsShowViewResponse
      */
-    public function show(Request $request, $teamId)
+    public function show(Request $request, $teamId): TeamsShowViewResponse
     {
         $team = Jetstream::newTeamModel()->findOrFail($teamId);
 
         Gate::authorize('view', $team);
 
-        return Jetstream::inertia()->render($request, 'Teams/Show', [
-            'team' => $team->load('owner', 'users', 'teamInvitations'),
-            'availableRoles' => array_values(Jetstream::$roles),
-            'availablePermissions' => Jetstream::$permissions,
-            'defaultPermissions' => Jetstream::$defaultPermissions,
-            'permissions' => [
-                'canAddTeamMembers' => Gate::check('addTeamMember', $team),
-                'canDeleteTeam' => Gate::check('delete', $team),
-                'canRemoveTeamMembers' => Gate::check('removeTeamMember', $team),
-                'canUpdateTeam' => Gate::check('update', $team),
-                'canUpdateTeamMembers' => Gate::check('updateTeamMember', $team),
-            ],
-        ]);
+        return app(TeamsShowViewResponse::class);
     }
 
     /**
      * Show the team creation screen.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return \Inertia\Response
+     * @return \Laravel\Jetstream\Contracts\TeamsCreateViewResponse
      */
-    public function create(Request $request)
+    public function create(Request $request): TeamsCreateViewResponse
     {
         Gate::authorize('create', Jetstream::newTeamModel());
 
-        return Jetstream::inertia()->render($request, 'Teams/Create');
+        return app(TeamsCreateViewResponse::class);
     }
 
     /**

--- a/src/Http/Controllers/Inertia/UserProfileController.php
+++ b/src/Http/Controllers/Inertia/UserProfileController.php
@@ -44,7 +44,7 @@ class UserProfileController extends Controller
                     ->orderBy('last_activity', 'desc')
                     ->get()
         )->map(function ($session) use ($request) {
-            $agent = $this->createAgent($session);
+            $agent = self::createAgent($session);
 
             return (object) [
                 'agent' => [
@@ -65,7 +65,7 @@ class UserProfileController extends Controller
      * @param  mixed  $session
      * @return \Laravel\Jetstream\Agent
      */
-    protected function createAgent($session)
+    protected static function createAgent($session)
     {
         return tap(new Agent(), fn ($agent) => $agent->setUserAgent($session->user_agent));
     }

--- a/src/Http/Controllers/Inertia/UserProfileController.php
+++ b/src/Http/Controllers/Inertia/UserProfileController.php
@@ -6,9 +6,8 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
-use Laravel\Fortify\Features;
 use Laravel\Jetstream\Agent;
-use Laravel\Jetstream\Jetstream;
+use Laravel\Jetstream\Contracts\ProfileShowViewResponse;
 
 class UserProfileController extends Controller
 {
@@ -18,16 +17,13 @@ class UserProfileController extends Controller
      * Show the general profile settings screen.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return \Inertia\Response
+     * @return \Laravel\Jetstream\Contracts\ProfileShowViewResponse
      */
-    public function show(Request $request)
+    public function show(Request $request): ProfileShowViewResponse
     {
         $this->validateTwoFactorAuthenticationState($request);
 
-        return Jetstream::inertia()->render($request, 'Profile/Show', [
-            'confirmsTwoFactorAuthentication' => Features::optionEnabled(Features::twoFactorAuthentication(), 'confirm'),
-            'sessions' => $this->sessions($request)->all(),
-        ]);
+        return app(ProfileShowViewResponse::class);
     }
 
     /**
@@ -36,7 +32,7 @@ class UserProfileController extends Controller
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Support\Collection
      */
-    public function sessions(Request $request)
+    public static function sessions(Request $request)
     {
         if (config('session.driver') !== 'database') {
             return collect();

--- a/src/Http/Responses/SimpleViewResponse.php
+++ b/src/Http/Responses/SimpleViewResponse.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Laravel\Jetstream\Http\Responses;
+
+use Illuminate\Contracts\Support\Responsable;
+use Laravel\Jetstream\Contracts\ApiIndexViewResponse;
+use Laravel\Jetstream\Contracts\ProfileShowViewResponse;
+use Laravel\Jetstream\Contracts\TeamsCreateViewResponse;
+use Laravel\Jetstream\Contracts\TeamsShowViewResponse;
+
+class SimpleViewResponse implements
+    ApiIndexViewResponse,
+    ProfileShowViewResponse,
+    TeamsCreateViewResponse,
+    TeamsShowViewResponse
+{
+    /**
+     * The name of the view or the callable used to generate the view.
+     *
+     * @var callable|string
+     */
+    protected $view;
+
+    /**
+     * Create a new response instance.
+     *
+     * @param  callable|string  $view
+     * @return void
+     */
+    public function __construct($view)
+    {
+        $this->view = $view;
+    }
+
+    /**
+     * Create an HTTP response that represents the object.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function toResponse($request)
+    {
+        if (! is_callable($this->view) || is_string($this->view)) {
+            return view($this->view, ['request' => $request]);
+        }
+
+        $response = call_user_func($this->view, $request);
+
+        if ($response instanceof Responsable) {
+            return $response->toResponse($request);
+        }
+
+        return $response;
+    }
+}

--- a/src/Jetstream.php
+++ b/src/Jetstream.php
@@ -493,7 +493,7 @@ class Jetstream
         return new static;
     }
 
-       /**
+    /**
      * Specify which view should be used as the API index view.
      *
      * @param  callable|string  $view
@@ -532,7 +532,7 @@ class Jetstream
         });
     }
 
-        /**
+    /**
      * Specify which view should be used as the teams show view.
      *
      * @param  callable|string  $view

--- a/src/Jetstream.php
+++ b/src/Jetstream.php
@@ -5,12 +5,17 @@ namespace Laravel\Jetstream;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Laravel\Jetstream\Contracts\AddsTeamMembers;
+use Laravel\Jetstream\Contracts\ApiIndexViewResponse;
 use Laravel\Jetstream\Contracts\CreatesTeams;
 use Laravel\Jetstream\Contracts\DeletesTeams;
 use Laravel\Jetstream\Contracts\DeletesUsers;
 use Laravel\Jetstream\Contracts\InvitesTeamMembers;
+use Laravel\Jetstream\Contracts\ProfileShowViewResponse;
 use Laravel\Jetstream\Contracts\RemovesTeamMembers;
+use Laravel\Jetstream\Contracts\TeamsCreateViewResponse;
+use Laravel\Jetstream\Contracts\TeamsShowViewResponse;
 use Laravel\Jetstream\Contracts\UpdatesTeamNames;
+use Laravel\Jetstream\Http\Responses\SimpleViewResponse;
 
 class Jetstream
 {
@@ -486,5 +491,57 @@ class Jetstream
         static::$registersRoutes = false;
 
         return new static;
+    }
+
+       /**
+     * Specify which view should be used as the API index view.
+     *
+     * @param  callable|string  $view
+     * @return void
+     */
+    public static function apiIndexView($view)
+    {
+        app()->singleton(ApiIndexViewResponse::class, function () use ($view) {
+            return new SimpleViewResponse($view);
+        });
+    }
+
+    /**
+     * Specify which view should be used as the profile show view.
+     *
+     * @param  callable|string  $view
+     * @return void
+     */
+    public static function profileShowView($view)
+    {
+        app()->singleton(ProfileShowViewResponse::class, function () use ($view) {
+            return new SimpleViewResponse($view);
+        });
+    }
+
+    /**
+     * Specify which view should be used as the teams create view.
+     *
+     * @param  callable|string  $view
+     * @return void
+     */
+    public static function teamsCreateView($view)
+    {
+        app()->singleton(TeamsCreateViewResponse::class, function () use ($view) {
+            return new SimpleViewResponse($view);
+        });
+    }
+
+        /**
+     * Specify which view should be used as the teams show view.
+     *
+     * @param  callable|string  $view
+     * @return void
+     */
+    public static function teamsShowView($view)
+    {
+        app()->singleton(TeamsShowViewResponse::class, function () use ($view) {
+            return new SimpleViewResponse($view);
+        });
     }
 }

--- a/src/JetstreamServiceProvider.php
+++ b/src/JetstreamServiceProvider.php
@@ -8,12 +8,15 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\View\Compilers\BladeCompiler;
 use Inertia\Inertia;
 use Laravel\Fortify\Events\PasswordUpdatedViaController;
+use Laravel\Fortify\Features as FortifyFeatures;
 use Laravel\Fortify\Fortify;
+use Laravel\Jetstream\Http\Controllers\Inertia\UserProfileController;
 use Laravel\Jetstream\Http\Livewire\ApiTokenManager;
 use Laravel\Jetstream\Http\Livewire\CreateTeamForm;
 use Laravel\Jetstream\Http\Livewire\DeleteTeamForm;
@@ -231,6 +234,47 @@ class JetstreamServiceProvider extends ServiceProvider
 
         Fortify::confirmPasswordView(function () {
             return Inertia::render('Auth/ConfirmPassword');
+        });
+
+        Jetstream::apiIndexView(function (Request $request) {
+            return Jetstream::inertia()->render($request, 'API/Index', [
+                'tokens' => $request->user()->tokens->map(function ($token) {
+                    return $token->toArray() + [
+                        'last_used_ago' => optional($token->last_used_at)->diffForHumans(),
+                    ];
+                }),
+                'availablePermissions' => Jetstream::$permissions,
+                'defaultPermissions' => Jetstream::$defaultPermissions,
+            ]);
+        });
+
+        Jetstream::profileShowView(function (Request $request) {
+            return Jetstream::inertia()->render($request, 'Profile/Show', [
+                'confirmsTwoFactorAuthentication' => Features::optionEnabled(FortifyFeatures::twoFactorAuthentication(), 'confirm'),
+                'sessions' => UserProfileController::sessions($request)->all(),
+            ]);
+        });
+
+        Jetstream::teamsCreateView(function (Request $request) {
+            return Jetstream::inertia()->render($request, 'Teams/Create');
+        });
+
+        Jetstream::teamsShowView(function (Request $request, $teamId) {
+            $team = Jetstream::newTeamModel()->findOrFail($teamId);
+
+            return Jetstream::inertia()->render($request, 'Teams/Show', [
+                'team' => $team->load('owner', 'users', 'teamInvitations'),
+                'availableRoles' => array_values(Jetstream::$roles),
+                'availablePermissions' => Jetstream::$permissions,
+                'defaultPermissions' => Jetstream::$defaultPermissions,
+                'permissions' => [
+                    'canAddTeamMembers' => Gate::check('addTeamMember', $team),
+                    'canDeleteTeam' => Gate::check('delete', $team),
+                    'canRemoveTeamMembers' => Gate::check('removeTeamMember', $team),
+                    'canUpdateTeam' => Gate::check('update', $team),
+                    'canUpdateTeamMembers' => Gate::check('updateTeamMember', $team),
+                ],
+            ]);
         });
     }
 }

--- a/tests/JetstreamServiceProviderTest.php
+++ b/tests/JetstreamServiceProviderTest.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace Laravel\Jetstream\Tests;
+
+use App\Actions\Jetstream\CreateTeam;
+use Illuminate\Contracts\Support\Responsable;
+use Illuminate\Http\JsonResponse;
+use Laravel\Jetstream\Jetstream;
+use Laravel\Jetstream\Tests\Fixtures\User;
+
+class JetstreamServiceProviderTest extends OrchestraTestCase
+{
+    protected function defineEnvironment($app)
+    {
+        parent::defineEnvironment($app);
+
+        $app['config']->set('jetstream.features', ['api', 'teams']);
+    }
+
+    public function test_api_views_can_be_customized()
+    {
+        Jetstream::apiIndexView(function () {
+            return 'foo';
+        });
+
+        $user = User::forceCreate([
+            'name' => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
+            'password' => 'secret',
+            'email_verified_at' => now()
+        ]);
+
+        $response = $this->actingAs($user)->get('/user/api-tokens');
+
+        $response->assertOk();
+
+        $this->assertSame('foo', $response->content());
+    }
+
+    public function test_customized_api_views_can_return_their_own_responsable()
+    {
+        Jetstream::apiIndexView(function () {
+            return new class implements Responsable
+            {
+                public function toResponse($request)
+                {
+                    return new JsonResponse(['foo' => 'bar']);
+                }
+            };
+        });
+
+        $user = User::forceCreate([
+            'name' => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
+            'password' => 'secret',
+            'email_verified_at' => now()
+        ]);
+
+        $response = $this->actingAs($user)->get('/user/api-tokens');
+
+        $response->assertOk();
+
+        $response->assertExactJson(['foo' => 'bar']);
+    }
+
+    public function test_profile_views_can_be_customized()
+    {
+        Jetstream::profileShowView(function () {
+            return 'foo';
+        });
+
+        $user = User::forceCreate([
+            'name' => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
+            'password' => 'secret',
+            'email_verified_at' => now()
+        ]);
+
+        $response = $this->actingAs($user)->get('/user/profile');
+
+        $response->assertOk();
+
+        $this->assertSame('foo', $response->content());
+    }
+
+    public function test_customized_profile_views_can_return_their_own_responsable()
+    {
+        Jetstream::profileShowView(function () {
+            return new class implements Responsable
+            {
+                public function toResponse($request)
+                {
+                    return new JsonResponse(['foo' => 'bar']);
+                }
+            };
+        });
+
+        $user = User::forceCreate([
+            'name' => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
+            'password' => 'secret',
+            'email_verified_at' => now()
+        ]);
+
+        $response = $this->actingAs($user)->get('/user/profile');
+
+        $response->assertOk();
+
+        $response->assertExactJson(['foo' => 'bar']);
+    }
+
+    public function test_teams_views_can_be_customized()
+    {
+        Jetstream::teamsCreateView(function () {
+            return 'foo';
+        });
+
+        Jetstream::teamsShowView(function () {
+            return 'foo';
+        });
+
+        $user = User::forceCreate([
+            'name' => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
+            'password' => 'secret',
+            'email_verified_at' => now()
+        ]);
+
+        $response = $this->actingAs($user)->get('/teams/create');
+
+        $response->assertOk();
+
+        $this->assertSame('foo', $response->content());
+
+        $team = ( new CreateTeam() )->create($user, ['name' => 'Test Team']);
+
+        $response = $this->actingAs($user)->get('/teams/'.$team->id);
+
+        $response->assertOk();
+
+        $this->assertSame('foo', $response->content());
+    }
+
+    public function test_customized_teams_views_can_return_their_own_responsable()
+    {
+        Jetstream::teamsCreateView(function () {
+            return new class implements Responsable
+            {
+                public function toResponse($request)
+                {
+                    return new JsonResponse(['foo' => 'bar']);
+                }
+            };
+        });
+
+        Jetstream::teamsShowView(function () {
+            return new class implements Responsable
+            {
+                public function toResponse($request)
+                {
+                    return new JsonResponse(['foo' => 'bar']);
+                }
+            };
+        });
+
+        $user = User::forceCreate([
+            'name' => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
+            'password' => 'secret',
+            'email_verified_at' => now()
+        ]);
+
+        $response = $this->actingAs($user)->get('/teams/create');
+
+        $response->assertOk();
+
+        $response->assertExactJson(['foo' => 'bar']);
+
+        $team = ( new CreateTeam() )->create($user, ['name' => 'Test Team']);
+
+        $response = $this->actingAs($user)->get('/teams/'.$team->id);
+
+        $response->assertOk();
+
+        $response->assertExactJson(['foo' => 'bar']);
+    }
+}

--- a/tests/JetstreamServiceProviderTest.php
+++ b/tests/JetstreamServiceProviderTest.php
@@ -27,7 +27,7 @@ class JetstreamServiceProviderTest extends OrchestraTestCase
             'name' => 'Taylor Otwell',
             'email' => 'taylor@laravel.com',
             'password' => 'secret',
-            'email_verified_at' => now()
+            'email_verified_at' => now(),
         ]);
 
         $response = $this->actingAs($user)->get('/user/api-tokens');
@@ -53,7 +53,7 @@ class JetstreamServiceProviderTest extends OrchestraTestCase
             'name' => 'Taylor Otwell',
             'email' => 'taylor@laravel.com',
             'password' => 'secret',
-            'email_verified_at' => now()
+            'email_verified_at' => now(),
         ]);
 
         $response = $this->actingAs($user)->get('/user/api-tokens');
@@ -73,7 +73,7 @@ class JetstreamServiceProviderTest extends OrchestraTestCase
             'name' => 'Taylor Otwell',
             'email' => 'taylor@laravel.com',
             'password' => 'secret',
-            'email_verified_at' => now()
+            'email_verified_at' => now(),
         ]);
 
         $response = $this->actingAs($user)->get('/user/profile');
@@ -99,7 +99,7 @@ class JetstreamServiceProviderTest extends OrchestraTestCase
             'name' => 'Taylor Otwell',
             'email' => 'taylor@laravel.com',
             'password' => 'secret',
-            'email_verified_at' => now()
+            'email_verified_at' => now(),
         ]);
 
         $response = $this->actingAs($user)->get('/user/profile');
@@ -123,7 +123,7 @@ class JetstreamServiceProviderTest extends OrchestraTestCase
             'name' => 'Taylor Otwell',
             'email' => 'taylor@laravel.com',
             'password' => 'secret',
-            'email_verified_at' => now()
+            'email_verified_at' => now(),
         ]);
 
         $response = $this->actingAs($user)->get('/teams/create');
@@ -132,7 +132,7 @@ class JetstreamServiceProviderTest extends OrchestraTestCase
 
         $this->assertSame('foo', $response->content());
 
-        $team = ( new CreateTeam() )->create($user, ['name' => 'Test Team']);
+        $team = (new CreateTeam())->create($user, ['name' => 'Test Team']);
 
         $response = $this->actingAs($user)->get('/teams/'.$team->id);
 
@@ -167,7 +167,7 @@ class JetstreamServiceProviderTest extends OrchestraTestCase
             'name' => 'Taylor Otwell',
             'email' => 'taylor@laravel.com',
             'password' => 'secret',
-            'email_verified_at' => now()
+            'email_verified_at' => now(),
         ]);
 
         $response = $this->actingAs($user)->get('/teams/create');
@@ -176,7 +176,7 @@ class JetstreamServiceProviderTest extends OrchestraTestCase
 
         $response->assertExactJson(['foo' => 'bar']);
 
-        $team = ( new CreateTeam() )->create($user, ['name' => 'Test Team']);
+        $team = (new CreateTeam())->create($user, ['name' => 'Test Team']);
 
         $response = $this->actingAs($user)->get('/teams/'.$team->id);
 


### PR DESCRIPTION
Based on the issue #1491. @driesvints suggested to create a PR about this.

Currently it is not possible to modify the paths of Inertia pages like : 

api :  `API/Index`
profile : `Profile/Show`
teams : `Teams/Create` and `Teams/Show`

Based on the logic used in Fortify, I proposed to apply methods on the `Jetstream` class to enable the modification of the rendering behavior for these views.

Fortify logic : 

```
Fortify::loginView(function () {
    return Inertia::render('Auth/Login', [
        'canResetPassword' => Route::has('password.request'),
        'status' => session('status'),
    ]);
});
```

New methods from `Jetstream` class : 

```
Jetstream::apiIndexView( ... )
Jetstream::profileShowView( ... )
Jetstream::teamsCreateView( ... )
Jetstream::teamsShowView( ... )
```

A `JetstreamServiceProviderTest` file has been created based on `FortifyServiceProviderTest`.