### PR TITLE
Fixed an issue causing missing column two_factor_confirmed_at when migrations executed during installation.

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -755,7 +755,11 @@ EOF;
     protected function runDatabaseMigrations()
     {
         if (confirm('New database migrations were added. Would you like to re-run your migrations?', true)) {
-            $this->call('migrate:fresh', ['--force' => true]);
+            (new Process([$this->phpBinary(), 'artisan', 'migrate:fresh', '--force'], base_path()))
+                ->setTimeout(null)
+                ->run(function ($type, $output) {
+                    $this->output->write($output);
+                });
         }
     }
 


### PR DESCRIPTION
Fixed #1483. I was not able to find a real reason for this issue but executing migration in another process works as expected so until we have a real solution, this should work.