### PR TITLE
Update and Add Type Descriptions in PHPDoc Comments

### DIFF
--- a/stubs/app/Actions/Jetstream/AddTeamMember.php
+++ b/stubs/app/Actions/Jetstream/AddTeamMember.php
@@ -53,7 +53,7 @@ class AddTeamMember implements AddsTeamMembers
     /**
      * Get the validation rules for adding a team member.
      *
-     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     * @return array<string, null|array<\Illuminate\Contracts\Validation\Rule|string>>
      */
     protected function rules(): array
     {

--- a/stubs/app/Actions/Jetstream/InviteTeamMember.php
+++ b/stubs/app/Actions/Jetstream/InviteTeamMember.php
@@ -55,7 +55,7 @@ class InviteTeamMember implements InvitesTeamMembers
     /**
      * Get the validation rules for inviting a team member.
      *
-     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     * @return array<string, null|array<\Illuminate\Contracts\Validation\Rule|string>>
      */
     protected function rules(Team $team): array
     {

--- a/stubs/app/Models/TeamInvitation.php
+++ b/stubs/app/Models/TeamInvitation.php
@@ -20,6 +20,8 @@ class TeamInvitation extends JetstreamTeamInvitation
 
     /**
      * Get the team that the invitation belongs to.
+     *
+     * @return BelongsTo<Team, TeamInvitation>
      */
     public function team(): BelongsTo
     {


### PR DESCRIPTION
# Overview

There were some incorrect type descriptions and missing type descriptions in the PHPDoc comments within the `stubs`.

## Benefit to End Users

When using static analysis tools such as PHPStan, there is no need to modify the generated files.

## Reasons It Does Not Break Any Existing Features

PHPDoc has no effect on the execution of the code itself, so these changes will not impact existing functionality.

## Detection with PHPStan

Detection results at level 9

```bash
 ------ --------------------------------------------------------------------------------------------------------------------- 
  Line   app/Actions/Jetstream/AddTeamMember.php                                                                              
 ------ --------------------------------------------------------------------------------------------------------------------- 
  59     Method App\Actions\Jetstream\AddTeamMember::rules() return type has no value type specified in iterable type array.  
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                            
 ------ --------------------------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------------------------------- 
  Line   app/Actions/Jetstream/InviteTeamMember.php                                                                                     
 ------ -------------------------------------------------------------------------------------------------------------------------------                                                                                  
  60     Method App\Actions\Jetstream\InviteTeamMember::rules() return type has no value type specified in iterable type array.         
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                      
 ------ ------------------------------------------------------------------------------------------------------------------------------- 

------ ----------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   app/Models/TeamInvitation.php                                                                                                                  
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------- 
  24     Method App\Models\TeamInvitation::team() return type with generic class Illuminate\Database\Eloquent\Relations\BelongsTo does not specify its  
         types: TRelatedModel, TChildModel                                                                                                              
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------- 

```