### PR TITLE
Removed duplicate [x-cloak] styling

### DIFF
--- a/stubs/resources/css/app.css
+++ b/stubs/resources/css/app.css
@@ -1,7 +1,3 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-[x-cloak] {
-    display: none;
-}


### PR DESCRIPTION
Livewire v3 automatically injects styles for `x-cloak` (an attribute provided by Alpine.js) when using the `@livewireStyles` Blade directive.

Since Jetstream does not offer an Alpine.js-only setup, I guess we can safely remove it in _resources/css/app.css_.