### PR TITLE
Fixes unhandled match case error

### DIFF
--- a/stubs/livewire/resources/views/components/dropdown.blade.php
+++ b/stubs/livewire/resources/views/components/dropdown.blade.php
@@ -9,7 +9,6 @@ $alignmentClasses = match ($align) {
 };
 
 $width = match ($width) {
-    '48' => 'w-48',
     '60' => 'w-60',
     default => 'w-48',
 };

--- a/stubs/livewire/resources/views/components/dropdown.blade.php
+++ b/stubs/livewire/resources/views/components/dropdown.blade.php
@@ -10,6 +10,8 @@ $alignmentClasses = match ($align) {
 
 $width = match ($width) {
     '48' => 'w-48',
+    '60' => 'w-60',
+    default => 'w-48',
 };
 @endphp
 


### PR DESCRIPTION
This PR fixes a bug introduced in #1509 that throws an `UnhandledMatchError` on fresh install (livewire with teams). 

The Teams dropdown uses `width="60"` which results in error as there's no case to match

```blade
                <!-- Teams Dropdown -->
                @if (Laravel\Jetstream\Jetstream::hasTeamFeatures())
                    <div class="ms-3 relative">
                        <x-dropdown align="right" width="60">
```

![Screenshot from 2024-07-10 01-22-15](https://github.com/laravel/jetstream/assets/47095624/4c23251f-8171-4e0a-ac25-88100c9e6e08)

fixes #1514