### PR TITLE
Update dropdown.blade.php with w-60

### DIFF
--- a/stubs/livewire/resources/views/components/dropdown.blade.php
+++ b/stubs/livewire/resources/views/components/dropdown.blade.php
@@ -10,6 +10,7 @@ $alignmentClasses = match ($align) {
 
 $width = match ($width) {
     '48' => 'w-48',
+    '60' => 'w-60',
 };
 @endphp
 


### PR DESCRIPTION
Fix Issue: https://github.com/laravel/jetstream/issues/1514

**Description**

In dropdown.blade.php we have following widths supported:
https://github.com/laravel/jetstream/blob/5.x/stubs/livewire/resources/views/components/dropdown.blade.php#L11
```
$width = match ($width) {
    '48' => 'w-48',
};
```
In navigation-menu.blade.php, we use:

https://github.com/laravel/jetstream/blob/5.x/stubs/livewire/resources/views/navigation-menu.blade.php#L25
```
 <x-dropdown align="right" width="60">
```
I am guessing we need to '60' => 'w-60', to dropdown.
