### PR TITLE
Fix `CancelTeamInvitation` in the view stub

### DIFF
--- a/stubs/livewire/resources/views/teams/team-member-manager.blade.php
+++ b/stubs/livewire/resources/views/teams/team-member-manager.blade.php
@@ -100,7 +100,7 @@
                                     @if (Gate::check('removeTeamMember', $team))
                                         <!-- Cancel Team Invitation -->
                                         <button class="cursor-pointer ms-6 text-sm text-red-500 focus:outline-none"
-                                                            wire:click="cancelTeamInvitation({{ $invitation->id }})">
+                                                            wire:click="cancelTeamInvitation('{{ $invitation->id }}')">
                                             {{ __('Cancel') }}
                                         </button>
                                     @endif


### PR DESCRIPTION
I found that if using `ULIDs` for teams and team invitations, the `wire:click` for canceling a team invitation fails due to the id not being an integer. 

This is easily fixed by putting single quotes around the property

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

If you change the behavior of the Inertia stack you're expected to update the Livewire stack as well and vice versa.
-->
