### PR TITLE
[5.x] Support Laravel Passport

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     },
     "require-dev": {
         "inertiajs/inertia-laravel": "^1.0",
+        "laravel/passport": "13.x-dev",
         "laravel/sanctum": "^4.0",
         "livewire/livewire": "^3.3",
         "mockery/mockery": "^1.0",

--- a/routes/inertia.php
+++ b/routes/inertia.php
@@ -51,9 +51,9 @@ Route::group(['middleware' => config('jetstream.middleware', ['web'])], function
             // API...
             if (Jetstream::hasApiFeatures()) {
                 if (Jetstream::hasOAuthFeatures()) {
-                    Route::get('/user/api-tokens', [SanctumApiTokenController::class, 'index'])->name('api-tokens.index');
-                    Route::post('/user/api-tokens', [SanctumApiTokenController::class, 'store'])->name('api-tokens.store');
-                    Route::delete('/user/api-tokens/{token}', [SanctumApiTokenController::class, 'destroy'])->name('api-tokens.destroy');
+                    Route::get('/user/api-tokens', [PassportApiTokenController::class, 'index'])->name('api-tokens.index');
+                    Route::post('/user/api-tokens', [PassportApiTokenController::class, 'store'])->name('api-tokens.store');
+                    Route::delete('/user/api-tokens/{token}', [PassportApiTokenController::class, 'destroy'])->name('api-tokens.destroy');
                 } else {
                     Route::get('/user/api-tokens', [SanctumApiTokenController::class, 'index'])->name('api-tokens.index');
                     Route::post('/user/api-tokens', [SanctumApiTokenController::class, 'store'])->name('api-tokens.store');
@@ -68,6 +68,8 @@ Route::group(['middleware' => config('jetstream.middleware', ['web'])], function
                 Route::post('/user/oauth-apps', [OAuthAppController::class, 'store'])->name('oauth-apps.store');
                 Route::put('/user/oauth-apps/{app}', [OAuthAppController::class, 'update'])->name('oauth-apps.update');
                 Route::delete('/user/oauth-apps/{app}', [OAuthAppController::class, 'destroy'])->name('oauth-apps.destroy');
+
+                Route::get('/user/oauth-connections', [OAuthConnectionController::class, 'index'])->name('oauth-connections.index');
                 Route::delete('/user/oauth-connections/{app}', [OAuthConnectionController::class, 'destroy'])->name('oauth-connections.destroy');
             }
 

--- a/routes/inertia.php
+++ b/routes/inertia.php
@@ -2,9 +2,12 @@
 
 use Illuminate\Support\Facades\Route;
 use Laravel\Jetstream\Http\Controllers\CurrentTeamController;
-use Laravel\Jetstream\Http\Controllers\Inertia\ApiTokenController;
+use Laravel\Jetstream\Http\Controllers\Inertia\ApiTokenController as SanctumApiTokenController;
 use Laravel\Jetstream\Http\Controllers\Inertia\CurrentUserController;
+use Laravel\Jetstream\Http\Controllers\Inertia\OAuthAppController;
+use Laravel\Jetstream\Http\Controllers\Inertia\OAuthConnectionController;
 use Laravel\Jetstream\Http\Controllers\Inertia\OtherBrowserSessionsController;
+use Laravel\Jetstream\Http\Controllers\Inertia\PassportApiTokenController;
 use Laravel\Jetstream\Http\Controllers\Inertia\PrivacyPolicyController;
 use Laravel\Jetstream\Http\Controllers\Inertia\ProfilePhotoController;
 use Laravel\Jetstream\Http\Controllers\Inertia\TeamController;
@@ -47,10 +50,25 @@ Route::group(['middleware' => config('jetstream.middleware', ['web'])], function
         Route::group(['middleware' => 'verified'], function () {
             // API...
             if (Jetstream::hasApiFeatures()) {
-                Route::get('/user/api-tokens', [ApiTokenController::class, 'index'])->name('api-tokens.index');
-                Route::post('/user/api-tokens', [ApiTokenController::class, 'store'])->name('api-tokens.store');
-                Route::put('/user/api-tokens/{token}', [ApiTokenController::class, 'update'])->name('api-tokens.update');
-                Route::delete('/user/api-tokens/{token}', [ApiTokenController::class, 'destroy'])->name('api-tokens.destroy');
+                if (Jetstream::hasOAuthFeatures()) {
+                    Route::get('/user/api-tokens', [SanctumApiTokenController::class, 'index'])->name('api-tokens.index');
+                    Route::post('/user/api-tokens', [SanctumApiTokenController::class, 'store'])->name('api-tokens.store');
+                    Route::delete('/user/api-tokens/{token}', [SanctumApiTokenController::class, 'destroy'])->name('api-tokens.destroy');
+                } else {
+                    Route::get('/user/api-tokens', [SanctumApiTokenController::class, 'index'])->name('api-tokens.index');
+                    Route::post('/user/api-tokens', [SanctumApiTokenController::class, 'store'])->name('api-tokens.store');
+                    Route::put('/user/api-tokens/{token}', [SanctumApiTokenController::class, 'update'])->name('api-tokens.update');
+                    Route::delete('/user/api-tokens/{token}', [SanctumApiTokenController::class, 'destroy'])->name('api-tokens.destroy');
+                }
+            }
+
+            // OAuth...
+            if (Jetstream::hasOAuthFeatures()) {
+                Route::get('/user/oauth-apps', [OAuthAppController::class, 'index'])->name('oauth-apps.index');
+                Route::post('/user/oauth-apps', [OAuthAppController::class, 'store'])->name('oauth-apps.store');
+                Route::put('/user/oauth-apps/{app}', [OAuthAppController::class, 'update'])->name('oauth-apps.update');
+                Route::delete('/user/oauth-apps/{app}', [OAuthAppController::class, 'destroy'])->name('oauth-apps.destroy');
+                Route::delete('/user/oauth-connections/{app}', [OAuthConnectionController::class, 'destroy'])->name('oauth-connections.destroy');
             }
 
             // Teams...

--- a/routes/inertia.php
+++ b/routes/inertia.php
@@ -69,7 +69,6 @@ Route::group(['middleware' => config('jetstream.middleware', ['web'])], function
                 Route::put('/user/oauth-apps/{app}', [OAuthAppController::class, 'update'])->name('oauth-apps.update');
                 Route::delete('/user/oauth-apps/{app}', [OAuthAppController::class, 'destroy'])->name('oauth-apps.destroy');
 
-                Route::get('/user/oauth-connections', [OAuthConnectionController::class, 'index'])->name('oauth-connections.index');
                 Route::delete('/user/oauth-connections/{app}', [OAuthConnectionController::class, 'destroy'])->name('oauth-connections.destroy');
             }
 

--- a/routes/livewire.php
+++ b/routes/livewire.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Route;
 use Laravel\Jetstream\Http\Controllers\CurrentTeamController;
 use Laravel\Jetstream\Http\Controllers\Livewire\ApiTokenController;
+use Laravel\Jetstream\Http\Controllers\Livewire\OAuthAppController;
 use Laravel\Jetstream\Http\Controllers\Livewire\PrivacyPolicyController;
 use Laravel\Jetstream\Http\Controllers\Livewire\TeamController;
 use Laravel\Jetstream\Http\Controllers\Livewire\TermsOfServiceController;
@@ -32,6 +33,11 @@ Route::group(['middleware' => config('jetstream.middleware', ['web'])], function
             // API...
             if (Jetstream::hasApiFeatures()) {
                 Route::get('/user/api-tokens', [ApiTokenController::class, 'index'])->name('api-tokens.index');
+            }
+
+            // OAuth...
+            if (Jetstream::hasOAuthFeatures()) {
+                Route::get('/user/oauth-apps', [OAuthAppController::class, 'index'])->name('oauth-apps.index');
             }
 
             // Teams...

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -197,6 +197,10 @@ class InstallCommand extends Command implements PromptsForMissingInput
         (new Filesystem)->ensureDirectoryExists(resource_path('views/layouts'));
         (new Filesystem)->ensureDirectoryExists(resource_path('views/profile'));
 
+        if ($this->option('oauth')) {
+            (new Filesystem)->ensureDirectoryExists(app_path('Actions/Passport'));
+        }
+
         (new Filesystem)->deleteDirectory(resource_path('sass'));
 
         // Terms Of Service / Privacy Policy...
@@ -221,6 +225,11 @@ class InstallCommand extends Command implements PromptsForMissingInput
         copy(__DIR__.'/../../stubs/app/Actions/Fortify/CreateNewUser.php', app_path('Actions/Fortify/CreateNewUser.php'));
         copy(__DIR__.'/../../stubs/app/Actions/Fortify/UpdateUserProfileInformation.php', app_path('Actions/Fortify/UpdateUserProfileInformation.php'));
         copy(__DIR__.'/../../stubs/app/Actions/Jetstream/DeleteUser.php', app_path('Actions/Jetstream/DeleteUser.php'));
+
+        if ($this->option('oauth')) {
+            copy(__DIR__.'/../../stubs/app/Actions/Passport/CreateClient.php', app_path('Actions/Passport/CreateClient.php'));
+            copy(__DIR__.'/../../stubs/app/Actions/Passport/UpdateClient.php', app_path('Actions/Passport/UpdateClient.php'));
+        }
 
         // Components...
         (new Filesystem)->copyDirectory(__DIR__.'/../../stubs/livewire/resources/views/components', resource_path('views/components'));
@@ -398,6 +407,10 @@ EOF;
         (new Filesystem)->ensureDirectoryExists(resource_path('views'));
         (new Filesystem)->ensureDirectoryExists(resource_path('markdown'));
 
+        if ($this->option('oauth')) {
+            (new Filesystem)->ensureDirectoryExists(app_path('Actions/Passport'));
+        }
+
         (new Filesystem)->deleteDirectory(resource_path('sass'));
 
         // Terms Of Service / Privacy Policy...
@@ -435,6 +448,11 @@ EOF;
         copy(__DIR__.'/../../stubs/app/Actions/Fortify/CreateNewUser.php', app_path('Actions/Fortify/CreateNewUser.php'));
         copy(__DIR__.'/../../stubs/app/Actions/Fortify/UpdateUserProfileInformation.php', app_path('Actions/Fortify/UpdateUserProfileInformation.php'));
         copy(__DIR__.'/../../stubs/app/Actions/Jetstream/DeleteUser.php', app_path('Actions/Jetstream/DeleteUser.php'));
+
+        if ($this->option('oauth')) {
+            copy(__DIR__.'/../../stubs/app/Actions/Passport/CreateClient.php', app_path('Actions/Passport/CreateClient.php'));
+            copy(__DIR__.'/../../stubs/app/Actions/Passport/UpdateClient.php', app_path('Actions/Passport/UpdateClient.php'));
+        }
 
         // Blade Views...
         copy(__DIR__.'/../../stubs/inertia/resources/views/app.blade.php', resource_path('views/app.blade.php'));

--- a/src/Contracts/CreatesOAuthClients.php
+++ b/src/Contracts/CreatesOAuthClients.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Laravel\Jetstream\Contracts;
+
+/**
+ * @method \Laravel\Passport\Client create(\Illuminate\Foundation\Auth\User $user, array $input)
+ */
+interface CreatesOAuthClients
+{
+    //
+}

--- a/src/Contracts/UpdatesOAuthClients.php
+++ b/src/Contracts/UpdatesOAuthClients.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Laravel\Jetstream\Contracts;
+
+/**
+ * @method void update(\Illuminate\Foundation\Auth\User $user, \Laravel\Passport\Client $client, array $input)
+ */
+interface UpdatesOAuthClients
+{
+    //
+}

--- a/src/Features.php
+++ b/src/Features.php
@@ -49,6 +49,16 @@ class Features
     }
 
     /**
+     * Determine if the application is using any OAuth features.
+     *
+     * @return bool
+     */
+    public static function hasOAuthFeatures()
+    {
+        return static::enabled(static::oauth());
+    }
+
+    /**
      * Determine if the application is using any team features.
      *
      * @return bool
@@ -106,6 +116,16 @@ class Features
     public static function api()
     {
         return 'api';
+    }
+
+    /**
+     * Enable the OAuth feature.
+     *
+     * @return string
+     */
+    public static function oauth()
+    {
+        return 'oauth';
     }
 
     /**

--- a/src/HasTeams.php
+++ b/src/HasTeams.php
@@ -3,7 +3,8 @@
 namespace Laravel\Jetstream;
 
 use Illuminate\Support\Str;
-use Laravel\Sanctum\HasApiTokens;
+use Laravel\Sanctum\HasApiTokens as SanctumHasApiTokens;
+use Laravel\Passport\HasApiTokens as PassportHasApiTokens;
 
 trait HasTeams
 {
@@ -207,7 +208,8 @@ trait HasTeams
             return false;
         }
 
-        if (in_array(HasApiTokens::class, class_uses_recursive($this)) &&
+        if ((in_array(SanctumHasApiTokens::class, $traits = class_uses_recursive($this)) ||
+            in_array(PassportHasApiTokens::class, $traits)) &&
             ! $this->tokenCan($permission) &&
             $this->currentAccessToken() !== null) {
             return false;

--- a/src/HasTeams.php
+++ b/src/HasTeams.php
@@ -3,8 +3,8 @@
 namespace Laravel\Jetstream;
 
 use Illuminate\Support\Str;
-use Laravel\Sanctum\HasApiTokens as SanctumHasApiTokens;
 use Laravel\Passport\HasApiTokens as PassportHasApiTokens;
+use Laravel\Sanctum\HasApiTokens as SanctumHasApiTokens;
 
 trait HasTeams
 {

--- a/src/Http/Controllers/Inertia/OAuthAppController.php
+++ b/src/Http/Controllers/Inertia/OAuthAppController.php
@@ -31,9 +31,10 @@ class OAuthAppController extends Controller
                 ->groupBy('client_id')
                 ->map(fn ($tokens) => [
                     'client' => $tokens->first()->client,
-                    'scopes' => $tokens->pluck('scopes')->flatten()->unique()->all(),
+                    'scopes' => $tokens->pluck('scopes')->flatten()->unique()->values()->all(),
                     'tokens_count' => $tokens->count(),
-                ]),
+                ])
+                ->values(),
             'apps' => $request->user()->clients()
                 ->where('revoked', false)
                 ->get()

--- a/src/Http/Controllers/Inertia/OAuthAppController.php
+++ b/src/Http/Controllers/Inertia/OAuthAppController.php
@@ -30,7 +30,7 @@ class OAuthAppController extends Controller
                 ->reject(fn (Token $token) => $token->client->revoked || $token->client->hasGrantType('personal_access'))
                 ->groupBy('client_id')
                 ->map(fn ($tokens) => [
-                    'client' => $tokens->first->client,
+                    'client' => $tokens->first()->client,
                     'scopes' => $tokens->pluck('scopes')->flatten()->unique()->all(),
                     'tokens_count' => $tokens->count(),
                 ]),

--- a/src/Http/Controllers/Inertia/OAuthAppController.php
+++ b/src/Http/Controllers/Inertia/OAuthAppController.php
@@ -22,7 +22,7 @@ class OAuthAppController extends Controller
      */
     public function index(Request $request)
     {
-        return Jetstream::inertia()->render($request, 'API/Index', [
+        return Jetstream::inertia()->render($request, 'OAuth/Index', [
             'authorizedApps' => $request->user()->tokens()
                 ->with('client')
                 ->where('revoked', false)

--- a/src/Http/Controllers/Inertia/OAuthAppController.php
+++ b/src/Http/Controllers/Inertia/OAuthAppController.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Laravel\Jetstream\Http\Controllers\Inertia;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Date;
+use Laravel\Jetstream\Jetstream;
+use Laravel\Passport\Client;
+use Laravel\Passport\Contracts\CreatesClients;
+use Laravel\Passport\Contracts\UpdatesClients;
+use Laravel\Passport\Token;
+
+class OAuthAppController extends Controller
+{
+    /**
+     * Show the user OAuth app screen.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Inertia\Response
+     */
+    public function index(Request $request)
+    {
+        return Jetstream::inertia()->render($request, 'API/Index', [
+            'authorizedApps' => $request->user()->tokens()
+                ->with('client')
+                ->where('revoked', false)
+                ->where('expires_at', '>', Date::now())
+                ->get()
+                ->reduce(function (Collection $apps, Token $token) {
+                    if ($token->client->revoked || $token->client->personal_access_client) {
+                        return $apps;
+                    }
+
+                    $app = $apps->get($token->client_id);
+
+                    if ($app) {
+                        $app['scopes'] = array_unique(array_merge($app['scopes'], $token->scopes));
+                        $app['tokens_count'] += 1;
+
+                        $apps->put($token->client_id, $app);
+                    } else {
+                        $apps->put($token->client_id, [
+                            'client' => $token->client,
+                            'scopes' => $token->scopes,
+                            'tokens_count' => 1,
+                        ]);
+                    }
+
+                    return $apps;
+                }, collect()),
+            'oauthApps' => $request->user()->clients()
+                ->where('revoked', false)
+                ->orderBy('name', 'asc')
+                ->get()
+                ->map(fn (Client $client) => $client->toArray() + [
+                    'is_confidential' => $client->confidential(),
+                    'created_date' => $client->created_at->toFormattedDateString(),
+                ]),
+        ]);
+    }
+
+    /**
+     * Create a new OAuth app.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function store(Request $request)
+    {
+        $client = app(CreatesClients::class)->create($request->all());
+
+        return back()->with('flash', [
+            'client_id' => $client->id,
+            'client_secret' => $client->plainSecret,
+        ]);
+    }
+
+    /**
+     * Update the given OAuth app.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  string  $clientId
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function update(Request $request, $clientId)
+    {
+        $client = $request->user()->clients()->findOrFail($clientId);
+
+        app(UpdatesClients::class)->update($client, $request->all());
+
+        return back(303);
+    }
+
+    /**
+     * Delete the given OAuth App.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  string  $clientId
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function destroy(Request $request, $clientId)
+    {
+        $request->user()->clients()->find($clientId)->delete();
+
+        return back(303);
+    }
+}

--- a/src/Http/Controllers/Inertia/OAuthAppController.php
+++ b/src/Http/Controllers/Inertia/OAuthAppController.php
@@ -88,11 +88,11 @@ class OAuthAppController extends Controller
         $client = $request->user()->clients()->find($clientId);
 
         $client->tokens()->each(function (Token $token) {
-            $token->refreshToken->revoke();
-            $token->revoke();
+            $token->refreshToken()->delete();
+            $token->delete();
         });
 
-        $client->revoke();
+        $client->delete();
 
         return back(303);
     }

--- a/src/Http/Controllers/Inertia/OAuthAppController.php
+++ b/src/Http/Controllers/Inertia/OAuthAppController.php
@@ -27,7 +27,7 @@ class OAuthAppController extends Controller
                 ->where('revoked', false)
                 ->where('expires_at', '>', Date::now())
                 ->get()
-                ->reject(fn (Token $token) => $token->client->revoked || $token->client->hasGrantType('personal_access'))
+                ->reject(fn (Token $token) => $token->client->revoked || $token->client->firstParty())
                 ->groupBy('client_id')
                 ->map(fn ($tokens) => [
                     'client' => $tokens->first()->client,

--- a/src/Http/Controllers/Inertia/OAuthConnectionController.php
+++ b/src/Http/Controllers/Inertia/OAuthConnectionController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Laravel\Jetstream\Http\Controllers\Inertia;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Laravel\Passport\Token;
+
+class OAuthConnectionController extends Controller
+{
+    /**
+     * Delete the given OAuth connection.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  string  $clientId
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function destroy(Request $request, $clientId)
+    {
+        $request->user()->tokens()
+            ->where('client_id', $clientId)
+            ->each(function (Token $token) {
+                $token->refreshToken->revoke();
+                $token->revoke();
+            });
+
+        return back(303);
+    }
+}

--- a/src/Http/Controllers/Inertia/OAuthConnectionController.php
+++ b/src/Http/Controllers/Inertia/OAuthConnectionController.php
@@ -15,7 +15,7 @@ class OAuthConnectionController extends Controller
      * @param  string  $clientId
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function destroy(Request $request, $clientId)
+    public function destroy(Request $request, string $clientId)
     {
         $request->user()->tokens()
             ->where('client_id', $clientId)

--- a/src/Http/Controllers/Inertia/OAuthConnectionController.php
+++ b/src/Http/Controllers/Inertia/OAuthConnectionController.php
@@ -20,8 +20,8 @@ class OAuthConnectionController extends Controller
         $request->user()->tokens()
             ->where('client_id', $clientId)
             ->each(function (Token $token) {
-                $token->refreshToken->revoke();
-                $token->revoke();
+                $token->refreshToken()->delete();
+                $token->delete();
             });
 
         return back(303);

--- a/src/Http/Controllers/Inertia/PassportApiTokenController.php
+++ b/src/Http/Controllers/Inertia/PassportApiTokenController.php
@@ -25,7 +25,7 @@ class PassportApiTokenController extends Controller
                 ->where('revoked', false)
                 ->where('expires_at', '>', Date::now())
                 ->get()
-                ->filter(fn (Token $token) => $token->client->personal_access_client)
+                ->filter(fn (Token $token) => $token->client->hasGrantType('personal_access'))
                 ->map(fn (Token $token) => $token->toArray() + [
                     'issued_ago' => $token->created_at->diffForHumans(),
                     'expires_in' => $token->expires_at->longAbsoluteDiffForHumans(),

--- a/src/Http/Controllers/Inertia/PassportApiTokenController.php
+++ b/src/Http/Controllers/Inertia/PassportApiTokenController.php
@@ -64,7 +64,7 @@ class PassportApiTokenController extends Controller
      * @param  string  $tokenId
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function destroy(Request $request, $tokenId)
+    public function destroy(Request $request, string $tokenId)
     {
         $request->user()->tokens()->find($tokenId)->delete();
 

--- a/src/Http/Controllers/Inertia/PassportApiTokenController.php
+++ b/src/Http/Controllers/Inertia/PassportApiTokenController.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Laravel\Jetstream\Http\Controllers\Inertia;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Date;
+use Laravel\Jetstream\Jetstream;
+use Laravel\Passport\Passport;
+use Laravel\Passport\Token;
+
+class PassportApiTokenController extends Controller
+{
+    /**
+     * Show the user API token screen.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Inertia\Response
+     */
+    public function index(Request $request)
+    {
+        return Jetstream::inertia()->render($request, 'API/Index', [
+            'tokens' => $request->user()->tokens()
+                ->with('client')
+                ->where('revoked', false)
+                ->where('expires_at', '>', Date::now())
+                ->get()
+                ->filter(fn (Token $token) => $token->client->personal_access_client)
+                ->map(fn (Token $token) => $token->toArray() + [
+                    'issued_ago' => $token->created_at->diffForHumans(),
+                    'expires_in' => $token->expires_at->longAbsoluteDiffForHumans(),
+                ]),
+            'availableScopes' => Passport::scopes(),
+            'defaultScopes' => Passport::defaultScopes(),
+        ]);
+    }
+
+    /**
+     * Create a new API token.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function store(Request $request)
+    {
+        $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+        ]);
+
+        $result = $request->user()->createToken(
+            $request->name,
+            Passport::validScopes($request->input('scopes', []))
+        );
+
+        return back()->with('flash', [
+            'token' => $result->accessToken,
+        ]);
+    }
+
+    /**
+     * Delete the given API token.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  string  $tokenId
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function destroy(Request $request, $tokenId)
+    {
+        $request->user()->tokens()->find($tokenId)->revoke();
+
+        return back(303);
+    }
+}

--- a/src/Http/Controllers/Inertia/PassportApiTokenController.php
+++ b/src/Http/Controllers/Inertia/PassportApiTokenController.php
@@ -66,7 +66,7 @@ class PassportApiTokenController extends Controller
      */
     public function destroy(Request $request, $tokenId)
     {
-        $request->user()->tokens()->find($tokenId)->revoke();
+        $request->user()->tokens()->find($tokenId)->delete();
 
         return back(303);
     }

--- a/src/Http/Controllers/Livewire/OAuthAppController.php
+++ b/src/Http/Controllers/Livewire/OAuthAppController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Laravel\Jetstream\Http\Controllers\Livewire;
+
+use Illuminate\Routing\Controller;
+
+class OAuthAppController extends Controller
+{
+    /**
+     * Show the user API token screen.
+     *
+     * @return \Illuminate\View\View
+     */
+    public function index()
+    {
+        return view('oauth.index');
+    }
+}

--- a/src/Http/Livewire/OAuthAppManager.php
+++ b/src/Http/Livewire/OAuthAppManager.php
@@ -4,9 +4,9 @@ namespace Laravel\Jetstream\Http\Livewire;
 
 use Illuminate\Support\Facades\Auth;
 use Illuminate\View\View;
+use Laravel\Jetstream\Contracts\CreatesOAuthClients;
+use Laravel\Jetstream\Contracts\UpdatesOAuthClients;
 use Laravel\Passport\Client;
-use Laravel\Passport\Contracts\CreatesClients;
-use Laravel\Passport\Contracts\UpdatesClients;
 use Laravel\Passport\Token;
 use Livewire\Attributes\On;
 use Livewire\Component;
@@ -118,12 +118,12 @@ class OAuthAppManager extends Component
     /**
      * Create a new OAuth Client.
      */
-    public function createOAuthApp(CreatesClients $creator): void
+    public function createOAuthApp(CreatesOAuthClients $creator): void
     {
         $this->resetErrorBag();
 
         $this->displayClientCredentials(
-            $creator->create($this->createOAuthAppForm)
+            $creator->create($this->user, $this->createOAuthAppForm)
         );
 
         $this->createOAuthAppForm['name'] = '';
@@ -164,9 +164,9 @@ class OAuthAppManager extends Component
     /**
      * Update the OAuth app.
      */
-    public function updateOAuthApp(UpdatesClients $updater): void
+    public function updateOAuthApp(UpdatesOAuthClients $updater): void
     {
-        $updater->update($this->oauthAppBeingManaged, $this->updateOAuthAppForm);
+        $updater->update($this->user, $this->oauthAppBeingManaged, $this->updateOAuthAppForm);
 
         $this->dispatch('app-updated');
 

--- a/src/Http/Livewire/OAuthAppManager.php
+++ b/src/Http/Livewire/OAuthAppManager.php
@@ -1,0 +1,280 @@
+<?php
+
+namespace Laravel\Jetstream\Http\Livewire;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Date;
+use Illuminate\View\View;
+use Laravel\Passport\Client;
+use Laravel\Passport\Contracts\CreatesClients;
+use Laravel\Passport\Contracts\UpdatesClients;
+use Laravel\Passport\Token;
+use Livewire\Attributes\On;
+use Livewire\Component;
+
+class OAuthAppManager extends Component
+{
+    /**
+     * The user's authorized apps.
+     *
+     * @var \Illuminate\Database\Eloquent\Collection<int, array>
+     */
+    public $authorizedApps;
+
+    /**
+     * The user's OAuth apps.
+     *
+     * @var \Illuminate\Database\Eloquent\Collection<int, \Laravel\Passport\Client>
+     */
+    public $oauthApps;
+
+    /**
+     * Create OAuth app form state.
+     *
+     * @var array<string, mixed>
+     */
+    public array $createOAuthAppForm = [
+        'name' => '',
+        'redirect_uri' => '',
+        'confidential' => false,
+    ];
+
+    /**
+     * Indicates if the client credentials is being displayed to the user.
+     */
+    public bool $displayingClientCredentials = false;
+
+    /**
+     * The client credentials.
+     */
+    public array $clientCredentials = [
+        'id' => null,
+        'secret' => null,
+    ];
+
+    /**
+     * Indicates if the application is confirming if a authorized app should be revoked.
+     */
+    public bool $confirmingAuthorizedAppRevocation = false;
+
+    /**
+     * The ID of the authorized app being revoked.
+     */
+    public string $authorizedAppIdBeingRevoked;
+
+    /**
+     * Indicates if the user is currently managing an OAuth app.
+     *
+     * @var bool
+     */
+    public bool $managingOAuthApp = false;
+
+    /**
+     * The OAuth app that is currently being managed.
+     *
+     * @var \Laravel\Passport\Client|null
+     */
+    public ?Client $oauthAppBeingManaged;
+
+    /**
+     * The update OAuth app form state.
+     *
+     * @var array
+     */
+    public array $updateOAuthAppForm = [
+        'name' => '',
+        'redirect_uri' => '',
+    ];
+
+    /**
+     * Indicates if the application is confirming if a OAuth app should be deleted.
+     */
+    public bool $confirmingOAuthAppDeletion = false;
+
+    /**
+     * The ID of the OAuth app being deleted.
+     */
+    public string $oauthAppIdBeingDeleted;
+
+    /**
+     * Mount the component.
+     */
+    public function mount(): void
+    {
+        $this->loadAuthorizedApps();
+        $this->loadOAuthApps();
+    }
+
+    /**
+     * Render the component.
+     */
+    public function render(): View
+    {
+        return view('oauth.oauth-app-manager');
+    }
+
+    /**
+     * Get the current user of the application.
+     *
+     * @return \Illuminate\Contracts\Auth\Authenticatable
+     */
+    public function getUserProperty()
+    {
+        return Auth::user();
+    }
+
+    /**
+     * Load the user's authorized apps.
+     */
+    #[On('authorized-app-revoked')]
+    public function loadAuthorizedApps(): void
+    {
+        $this->authorizedApps = $this->user->tokens()
+            ->with('client')
+            ->where('revoked', false)
+            ->where('expires_at', '>', Date::now())
+            ->get()
+            ->reduce(function (Collection $apps, Token $token) {
+                if ($token->client->revoked || $token->client->personal_access_client) {
+                    return $apps;
+                }
+
+                $app = $apps->get($token->client_id);
+
+                if ($app) {
+                    $app['scopes'] = array_unique(array_merge($app['scopes'], $token->scopes));
+                    $app['tokens_count'] += 1;
+
+                    $apps->put($token->client_id, $app);
+                } else {
+                    $apps->put($token->client_id, [
+                        'client' => $token->client,
+                        'scopes' => $token->scopes,
+                        'tokens_count' => 1,
+                    ]);
+                }
+
+                return $apps;
+            }, collect());
+    }
+
+    /**
+     * Load the user's OAuth apps.
+     */
+    #[On(['oauth-app-created', 'oauth-app-updated', 'oauth-app-deleted'])]
+    public function loadOAuthApps(): void
+    {
+        $this->oauthApps = $this->user->clients()
+            ->where('revoked', false)
+            ->orderBy('name', 'asc')
+            ->get();
+    }
+
+    /**
+     * Create a new OAuth Client.
+     */
+    public function createOAuthApp(CreatesClients $creator): void
+    {
+        $this->resetErrorBag();
+
+        $this->displayClientCredentials(
+            $creator->create($this->createOAuthAppForm)
+        );
+
+        $this->createOAuthAppForm['name'] = '';
+        $this->createOAuthAppForm['redirect_uri'] = '';
+        $this->createOAuthAppForm['confidential'] = false;
+
+        $this->dispatch('oauth-app-created');
+    }
+
+    /**
+     * Display the token value to the user.
+     */
+    protected function displayClientCredentials(Client $client): void
+    {
+        $this->displayingClientCredentials = true;
+
+        $this->clientCredentials = [
+            'id' => $client->id,
+            'secret' => $client->plainSecret,
+        ];
+
+        $this->dispatch('client-credentials-displayed');
+    }
+
+    /**
+     * Allow the given OAuth app to be managed.
+     */
+    public function manageOAuthApp(string $clientId): void
+    {
+        $this->managingOAuthApp = true;
+
+        $this->oauthAppBeingManaged = $this->oauthApps->find($clientId);
+
+        $this->updateOAuthAppForm['name'] = $this->oauthAppBeingManaged->name;
+        $this->updateOAuthAppForm['redirect_uri'] = $this->oauthAppBeingManaged->redirect;
+    }
+
+    /**
+     * Update the OAuth app.
+     */
+    public function updateOAuthApp(UpdatesClients $updater): void
+    {
+        $updater->update($this->oauthAppBeingManaged, $this->updateOAuthAppForm);
+
+        $this->dispatch('oauth-app-updated');
+
+        $this->managingOAuthApp = false;
+    }
+
+    /**
+     * Confirm that the given OAuth app should be deleted.
+     */
+    public function confirmOAuthAppDeletion(string $clientId): void
+    {
+        $this->confirmingOAuthAppDeletion = true;
+
+        $this->oauthAppIdBeingDeleted = $clientId;
+    }
+
+    /**
+     * Delete the OAuth app.
+     */
+    public function deleteOAuthApp(): void
+    {
+        $this->oauthApps->find($this->oauthAppIdBeingDeleted)->delete();
+
+        $this->dispatch('oauth-app-deleted');
+
+        $this->confirmingOAuthAppDeletion = false;
+    }
+
+    /**
+     * Confirm that the given authorized app should be revoked.
+     */
+    public function confirmAuthorizedAppRevocation(string $tokenId): void
+    {
+        $this->confirmingAuthorizedAppRevocation = true;
+
+        $this->authorizedAppIdBeingRevoked = $tokenId;
+    }
+
+    /**
+     * Revoke the authorized app.
+     */
+    public function revokeAuthorizedApp(): void
+    {
+        $this->user->tokens()
+            ->where('client_id', $this->authorizedAppIdBeingRevoked)
+            ->each(function (Token $token) {
+                $token->refreshToken->revoke();
+                $token->revoke();
+            });
+
+        $this->dispatch('authorized-app-revoked');
+
+        $this->confirmingAuthorizedAppRevocation = false;
+    }
+}

--- a/src/Http/Livewire/OAuthAppManager.php
+++ b/src/Http/Livewire/OAuthAppManager.php
@@ -158,7 +158,7 @@ class OAuthAppManager extends Component
         $this->oauthAppBeingManaged = $this->apps->find($clientId);
 
         $this->updateOAuthAppForm['name'] = $this->oauthAppBeingManaged->name;
-        $this->updateOAuthAppForm['redirect_uris'] = explode(',', $this->oauthAppBeingManaged->redirect);
+        $this->updateOAuthAppForm['redirect_uris'] = $this->oauthAppBeingManaged->redirect_uris;
     }
 
     /**

--- a/src/Http/Livewire/OAuthAppManager.php
+++ b/src/Http/Livewire/OAuthAppManager.php
@@ -27,7 +27,7 @@ class OAuthAppManager extends Component
      */
     public array $createOAuthAppForm = [
         'name' => '',
-        'redirect_uri' => '',
+        'redirect_uris' => [],
         'confidential' => false,
     ];
 
@@ -65,7 +65,7 @@ class OAuthAppManager extends Component
      */
     public array $updateOAuthAppForm = [
         'name' => '',
-        'redirect_uri' => '',
+        'redirect_uris' => [],
     ];
 
     /**
@@ -127,7 +127,7 @@ class OAuthAppManager extends Component
         );
 
         $this->createOAuthAppForm['name'] = '';
-        $this->createOAuthAppForm['redirect_uri'] = '';
+        $this->createOAuthAppForm['redirect_uris'] = [];
         $this->createOAuthAppForm['confidential'] = false;
 
         $this->dispatch('app-created');
@@ -158,7 +158,7 @@ class OAuthAppManager extends Component
         $this->oauthAppBeingManaged = $this->apps->find($clientId);
 
         $this->updateOAuthAppForm['name'] = $this->oauthAppBeingManaged->name;
-        $this->updateOAuthAppForm['redirect_uri'] = $this->oauthAppBeingManaged->redirect;
+        $this->updateOAuthAppForm['redirect_uris'] = explode(',', $this->oauthAppBeingManaged->redirect);
     }
 
     /**

--- a/src/Http/Livewire/OAuthAppManager.php
+++ b/src/Http/Livewire/OAuthAppManager.php
@@ -191,11 +191,11 @@ class OAuthAppManager extends Component
         $app = $this->apps->find($this->oauthAppIdBeingDeleted);
 
         $app->tokens()->each(function (Token $token) {
-            $token->refreshToken->revoke();
-            $token->revoke();
+            $token->refreshToken()->delete();
+            $token->delete();
         });
 
-        $app->revoke();
+        $app->delete();
 
         $this->dispatch('app-deleted');
 

--- a/src/Http/Livewire/OAuthConnectionManager.php
+++ b/src/Http/Livewire/OAuthConnectionManager.php
@@ -69,9 +69,10 @@ class OAuthConnectionManager extends Component
             ->groupBy('client_id')
             ->map(fn ($tokens) => [
                 'client' => $tokens->first()->client,
-                'scopes' => $tokens->pluck('scopes')->flatten()->unique()->all(),
+                'scopes' => $tokens->pluck('scopes')->flatten()->unique()->values()->all(),
                 'tokens_count' => $tokens->count(),
-            ]);
+            ])
+            ->values();
     }
 
     /**

--- a/src/Http/Livewire/OAuthConnectionManager.php
+++ b/src/Http/Livewire/OAuthConnectionManager.php
@@ -92,8 +92,8 @@ class OAuthConnectionManager extends Component
         $this->user->tokens()
             ->where('client_id', $this->connectionClientIdBeingDeleted)
             ->each(function (Token $token) {
-                $token->refreshToken->revoke();
-                $token->revoke();
+                $token->refreshToken()->delete();
+                $token->delete();
             });
 
         $this->dispatch('connection-deleted');

--- a/src/Http/Livewire/OAuthConnectionManager.php
+++ b/src/Http/Livewire/OAuthConnectionManager.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Laravel\Jetstream\Http\Livewire;
+
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Date;
+use Illuminate\View\View;
+use Laravel\Passport\Token;
+use Livewire\Attributes\On;
+use Livewire\Component;
+
+class OAuthConnectionManager extends Component
+{
+    /**
+     * The user's connections with OAuth apps.
+     *
+     * @var \Illuminate\Database\Eloquent\Collection<string, array>
+     */
+    public $connections;
+
+    /**
+     * Indicates if the application is confirming if a connection should be deleted.
+     */
+    public bool $confirmingConnectionDeletion = false;
+
+    /**
+     * The ID of the client its connection being deleted.
+     */
+    public ?string $connectionClientIdBeingDeleted;
+
+    /**
+     * Mount the component.
+     */
+    public function mount(): void
+    {
+        $this->loadConnections();
+    }
+
+    /**
+     * Render the component.
+     */
+    public function render(): View
+    {
+        return view('oauth.oauth-connection-manager');
+    }
+
+    /**
+     * Get the current user of the application.
+     *
+     * @return \Illuminate\Contracts\Auth\Authenticatable
+     */
+    public function getUserProperty()
+    {
+        return Auth::user();
+    }
+
+    /**
+     * Load the user's connections with OAuth apps.
+     */
+    #[On('connection-deleted')]
+    public function loadConnections(): void
+    {
+        $this->connections = $this->user->tokens()
+            ->with('client')
+            ->where('revoked', false)
+            ->where('expires_at', '>', Date::now())
+            ->get()
+            ->reject(fn (Token $token) => $token->client->revoked || $token->client->hasGrantType('personal_access'))
+            ->groupBy('client_id')
+            ->map(fn ($tokens) => [
+                'client' => $tokens->first->client,
+                'scopes' => $tokens->pluck('scopes')->flatten()->unique()->all(),
+                'tokens_count' => $tokens->count(),
+            ]);
+    }
+
+    /**
+     * Confirm that the given connection should be deleted.
+     */
+    public function confirmConnectionDeletion(string $clientId): void
+    {
+        $this->confirmingConnectionDeletion = true;
+
+        $this->connectionClientIdBeingDeleted = $clientId;
+    }
+
+    /**
+     * Delete the connection with the OAuth app.
+     */
+    public function deleteConnection(): void
+    {
+        $this->user->tokens()
+            ->where('client_id', $this->connectionClientIdBeingDeleted)
+            ->each(function (Token $token) {
+                $token->refreshToken->revoke();
+                $token->revoke();
+            });
+
+        $this->dispatch('connection-deleted');
+
+        $this->confirmingConnectionDeletion = false;
+        $this->connectionClientIdBeingDeleted = null;
+    }
+}

--- a/src/Http/Livewire/OAuthConnectionManager.php
+++ b/src/Http/Livewire/OAuthConnectionManager.php
@@ -65,7 +65,7 @@ class OAuthConnectionManager extends Component
             ->where('revoked', false)
             ->where('expires_at', '>', Date::now())
             ->get()
-            ->reject(fn (Token $token) => $token->client->revoked || $token->client->hasGrantType('personal_access'))
+            ->reject(fn (Token $token) => $token->client->revoked || $token->client->firstParty())
             ->groupBy('client_id')
             ->map(fn ($tokens) => [
                 'client' => $tokens->first()->client,

--- a/src/Http/Livewire/OAuthConnectionManager.php
+++ b/src/Http/Livewire/OAuthConnectionManager.php
@@ -68,7 +68,7 @@ class OAuthConnectionManager extends Component
             ->reject(fn (Token $token) => $token->client->revoked || $token->client->hasGrantType('personal_access'))
             ->groupBy('client_id')
             ->map(fn ($tokens) => [
-                'client' => $tokens->first->client,
+                'client' => $tokens->first()->client,
                 'scopes' => $tokens->pluck('scopes')->flatten()->unique()->all(),
                 'tokens_count' => $tokens->count(),
             ]);

--- a/src/Http/Livewire/PassportApiTokenManager.php
+++ b/src/Http/Livewire/PassportApiTokenManager.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Laravel\Jetstream\Http\Livewire;
+
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\View\View;
+use Laravel\Passport\Passport;
+use Laravel\Passport\PersonalAccessTokenResult;
+use Livewire\Attributes\On;
+use Livewire\Component;
+
+class PassportApiTokenManager extends Component
+{
+    /**
+     * The user's personal access tokens.
+     *
+     * @var \Illuminate\Database\Eloquent\Collection<int, \Laravel\Passport\Token>
+     */
+    public $tokens;
+
+    /**
+     * Create API token form state.
+     *
+     * @var array<string, mixed>
+     */
+    public array $createApiTokenForm = [
+        'name' => '',
+        'scopes' => [],
+    ];
+
+    /**
+     * Indicates if the token is being displayed to the user.
+     */
+    public bool $displayingToken = false;
+
+    /**
+     * The token value.
+     */
+    public ?string $tokenValue;
+
+    /**
+     * Indicates if the application is confirming if an API token should be deleted.
+     */
+    public bool $confirmingApiTokenDeletion = false;
+
+    /**
+     * The ID of the API token being deleted.
+     */
+    public string $apiTokenIdBeingDeleted;
+
+    /**
+     * Mount the component.
+     */
+    public function mount(): void
+    {
+        $this->createApiTokenForm['scopes'] = Passport::defaultScopes();
+
+        $this->loadTokens();
+    }
+
+    /**
+     * Load the user's tokens.
+     */
+    #[On(['token-created', 'token-deleted'])]
+    public function loadTokens(): void
+    {
+        $this->tokens = $this->user->tokens()
+            ->with('client')
+            ->where('revoked', false)
+            ->where('expires_at', '>', Date::now())
+            ->get()
+            ->filter(fn ($token) => $token->client->personal_access_client);
+    }
+
+    /**
+     * Create a new API token.
+     */
+    public function createApiToken(): void
+    {
+        $this->resetErrorBag();
+
+        Validator::make([
+            'name' => $this->createApiTokenForm['name'],
+        ], [
+            'name' => ['required', 'string', 'max:255'],
+        ])->validateWithBag('createApiToken');
+
+        $this->displayTokenValue($this->user->createToken(
+            $this->createApiTokenForm['name'],
+            Passport::validScopes($this->createApiTokenForm['scopes'])
+        ));
+
+        $this->createApiTokenForm['name'] = '';
+        $this->createApiTokenForm['scopes'] = Passport::defaultScopes();
+
+        $this->dispatch('token-created');
+    }
+
+    /**
+     * Display the token value to the user.
+     */
+    protected function displayTokenValue(PersonalAccessTokenResult $result): void
+    {
+        $this->displayingToken = true;
+
+        $this->tokenValue = $result->accessToken;
+
+        $this->dispatch('token-displayed');
+    }
+
+    /**
+     * Confirm that the given API token should be deleted.
+     */
+    public function confirmApiTokenDeletion(string $tokenId): void
+    {
+        $this->confirmingApiTokenDeletion = true;
+
+        $this->apiTokenIdBeingDeleted = $tokenId;
+    }
+
+    /**
+     * Delete the API token.
+     */
+    public function deleteApiToken(): void
+    {
+        $this->tokens->find($this->apiTokenIdBeingDeleted)->revoke();
+
+        $this->dispatch('token-deleted');
+
+        $this->confirmingApiTokenDeletion = false;
+    }
+
+    /**
+     * Get the current user of the application.
+     *
+     * @return \Illuminate\Contracts\Auth\Authenticatable
+     */
+    public function getUserProperty()
+    {
+        return Auth::user();
+    }
+
+    /**
+     * Render the component.
+     */
+    public function render(): View
+    {
+        return view('api.api-token-manager');
+    }
+}

--- a/src/Http/Livewire/PassportApiTokenManager.php
+++ b/src/Http/Livewire/PassportApiTokenManager.php
@@ -125,7 +125,7 @@ class PassportApiTokenManager extends Component
      */
     public function deleteApiToken(): void
     {
-        $this->tokens->find($this->apiTokenIdBeingDeleted)->revoke();
+        $this->tokens->find($this->apiTokenIdBeingDeleted)->delete();
 
         $this->dispatch('token-deleted');
 

--- a/src/Http/Livewire/PassportApiTokenManager.php
+++ b/src/Http/Livewire/PassportApiTokenManager.php
@@ -71,7 +71,7 @@ class PassportApiTokenManager extends Component
             ->where('revoked', false)
             ->where('expires_at', '>', Date::now())
             ->get()
-            ->filter(fn ($token) => $token->client->personal_access_client);
+            ->filter(fn ($token) => $token->client->hasGrantType('personal_access'));
     }
 
     /**

--- a/src/Http/Middleware/ShareInertiaData.php
+++ b/src/Http/Middleware/ShareInertiaData.php
@@ -34,6 +34,7 @@ class ShareInertiaData
                     'flash' => $request->session()->get('flash', []),
                     'hasAccountDeletionFeatures' => Jetstream::hasAccountDeletionFeatures(),
                     'hasApiFeatures' => Jetstream::hasApiFeatures(),
+                    'hasOAuthFeatures' => Jetstream::hasOAuthFeatures(),
                     'hasTeamFeatures' => Jetstream::hasTeamFeatures(),
                     'hasTermsAndPrivacyPolicyFeature' => Jetstream::hasTermsAndPrivacyPolicyFeature(),
                     'managesProfilePhotos' => Jetstream::managesProfilePhotos(),

--- a/src/Jetstream.php
+++ b/src/Jetstream.php
@@ -187,6 +187,16 @@ class Jetstream
     }
 
     /**
+     * Determine if Jetstream is supporting OAuth features.
+     *
+     * @return bool
+     */
+    public static function hasOAuthFeatures()
+    {
+        return Features::hasOAuthFeatures();
+    }
+
+    /**
      * Determine if Jetstream is supporting team features.
      *
      * @return bool

--- a/src/Jetstream.php
+++ b/src/Jetstream.php
@@ -5,11 +5,13 @@ namespace Laravel\Jetstream;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Laravel\Jetstream\Contracts\AddsTeamMembers;
+use Laravel\Jetstream\Contracts\CreatesOAuthClients;
 use Laravel\Jetstream\Contracts\CreatesTeams;
 use Laravel\Jetstream\Contracts\DeletesTeams;
 use Laravel\Jetstream\Contracts\DeletesUsers;
 use Laravel\Jetstream\Contracts\InvitesTeamMembers;
 use Laravel\Jetstream\Contracts\RemovesTeamMembers;
+use Laravel\Jetstream\Contracts\UpdatesOAuthClients;
 use Laravel\Jetstream\Contracts\UpdatesTeamNames;
 
 class Jetstream
@@ -452,6 +454,27 @@ class Jetstream
     public static function deleteUsersUsing(string $class)
     {
         return app()->singleton(DeletesUsers::class, $class);
+    }
+
+
+    /**
+     * Register a class / callback that should be used to create OAuth clients.
+     *
+     * @param  class-string<\Laravel\Jetstream\Contracts\CreatesOAuthClients>  $class
+     */
+    public static function createOAuthClientsUsing(string $class): void
+    {
+        app()->singleton(CreatesOAuthClients::class, $class);
+    }
+
+    /**
+     * Register a class / callback that should be used to update OAuth clients.
+     *
+     * @param  class-string<\Laravel\Jetstream\Contracts\UpdatesOAuthClients>  $class
+     */
+    public static function updateOAuthClientsUsing(string $class): void
+    {
+        app()->singleton(UpdatesOAuthClients::class, $class);
     }
 
     /**

--- a/src/Jetstream.php
+++ b/src/Jetstream.php
@@ -456,7 +456,6 @@ class Jetstream
         return app()->singleton(DeletesUsers::class, $class);
     }
 
-
     /**
      * Register a class / callback that should be used to create OAuth clients.
      *

--- a/src/JetstreamServiceProvider.php
+++ b/src/JetstreamServiceProvider.php
@@ -14,12 +14,14 @@ use Illuminate\View\Compilers\BladeCompiler;
 use Inertia\Inertia;
 use Laravel\Fortify\Events\PasswordUpdatedViaController;
 use Laravel\Fortify\Fortify;
-use Laravel\Jetstream\Http\Livewire\ApiTokenManager;
+use Laravel\Jetstream\Http\Livewire\ApiTokenManager as SanctumApiTokenManager;
 use Laravel\Jetstream\Http\Livewire\CreateTeamForm;
 use Laravel\Jetstream\Http\Livewire\DeleteTeamForm;
 use Laravel\Jetstream\Http\Livewire\DeleteUserForm;
 use Laravel\Jetstream\Http\Livewire\LogoutOtherBrowserSessionsForm;
 use Laravel\Jetstream\Http\Livewire\NavigationMenu;
+use Laravel\Jetstream\Http\Livewire\OAuthAppManager;
+use Laravel\Jetstream\Http\Livewire\PassportApiTokenManager;
 use Laravel\Jetstream\Http\Livewire\TeamMemberManager;
 use Laravel\Jetstream\Http\Livewire\TwoFactorAuthenticationForm;
 use Laravel\Jetstream\Http\Livewire\UpdatePasswordForm;
@@ -90,7 +92,13 @@ class JetstreamServiceProvider extends ServiceProvider
             Livewire::component('profile.delete-user-form', DeleteUserForm::class);
 
             if (Features::hasApiFeatures()) {
-                Livewire::component('api.api-token-manager', ApiTokenManager::class);
+                Livewire::component('api.api-token-manager',
+                    Features::hasOAuthFeatures() ? PassportApiTokenManager::class : SanctumApiTokenManager::class
+                );
+            }
+
+            if (Features::hasOAuthFeatures()) {
+                Livewire::component('oauth.oauth-app-manager', OAuthAppManager::class);
             }
 
             if (Features::hasTeamFeatures()) {

--- a/src/JetstreamServiceProvider.php
+++ b/src/JetstreamServiceProvider.php
@@ -249,9 +249,7 @@ class JetstreamServiceProvider extends ServiceProvider
         });
 
         if (class_exists(Passport::class)) {
-            Passport::authorizationView(function ($params) {
-                return Inertia::render('Auth/OAuth/Authorize', $params);
-            });
+            Passport::authorizationView(fn ($params) => Inertia::render('Auth/OAuth/Authorize', $params));
         }
     }
 }

--- a/src/JetstreamServiceProvider.php
+++ b/src/JetstreamServiceProvider.php
@@ -250,6 +250,8 @@ class JetstreamServiceProvider extends ServiceProvider
 
         if (class_exists(Passport::class)) {
             Passport::authorizationView(fn ($params) => Inertia::render('Auth/OAuth/Authorize', $params));
+            // Passport::deviceAuthorizationView(fn ($params) => Inertia::render('Auth/OAuth/Device/Authorize', $params));
+            // Passport::deviceUserCodeView(fn ($params) => Inertia::render('Auth/OAuth/Device/UserCode', $params));
         }
     }
 }

--- a/src/JetstreamServiceProvider.php
+++ b/src/JetstreamServiceProvider.php
@@ -21,6 +21,7 @@ use Laravel\Jetstream\Http\Livewire\DeleteUserForm;
 use Laravel\Jetstream\Http\Livewire\LogoutOtherBrowserSessionsForm;
 use Laravel\Jetstream\Http\Livewire\NavigationMenu;
 use Laravel\Jetstream\Http\Livewire\OAuthAppManager;
+use Laravel\Jetstream\Http\Livewire\OAuthConnectionManager;
 use Laravel\Jetstream\Http\Livewire\PassportApiTokenManager;
 use Laravel\Jetstream\Http\Livewire\TeamMemberManager;
 use Laravel\Jetstream\Http\Livewire\TwoFactorAuthenticationForm;
@@ -99,6 +100,7 @@ class JetstreamServiceProvider extends ServiceProvider
 
             if (Features::hasOAuthFeatures()) {
                 Livewire::component('oauth.oauth-app-manager', OAuthAppManager::class);
+                Livewire::component('oauth.oauth-connection-manager', OAuthConnectionManager::class);
             }
 
             if (Features::hasTeamFeatures()) {

--- a/src/JetstreamServiceProvider.php
+++ b/src/JetstreamServiceProvider.php
@@ -29,6 +29,7 @@ use Laravel\Jetstream\Http\Livewire\UpdatePasswordForm;
 use Laravel\Jetstream\Http\Livewire\UpdateProfileInformationForm;
 use Laravel\Jetstream\Http\Livewire\UpdateTeamNameForm;
 use Laravel\Jetstream\Http\Middleware\ShareInertiaData;
+use Laravel\Passport\Passport;
 use Livewire\Livewire;
 
 class JetstreamServiceProvider extends ServiceProvider
@@ -51,6 +52,10 @@ class JetstreamServiceProvider extends ServiceProvider
     public function boot()
     {
         Fortify::viewPrefix('auth.');
+
+        if (class_exists(Passport::class)) {
+            Passport::viewPrefix('auth.oauth.');
+        }
 
         $this->configurePublishing();
         $this->configureRoutes();
@@ -242,5 +247,18 @@ class JetstreamServiceProvider extends ServiceProvider
         Fortify::confirmPasswordView(function () {
             return Inertia::render('Auth/ConfirmPassword');
         });
+
+        if (class_exists(Passport::class)) {
+            Passport::authorizationView(function ($params) {
+                return Inertia::render('Auth/OAuth/Authorize', [
+                    'user' => $params['user'],
+                    'client' => $params['client'],
+                    'scopes' => $params['scopes'],
+                    'state' => $params['request']->state,
+                    'authToken' => $params['authToken'],
+                    'promptLoginUrl' => $params['request']->fullUrlWithQuery(['prompt' => 'login']),
+                ]);
+            });
+        }
     }
 }

--- a/src/JetstreamServiceProvider.php
+++ b/src/JetstreamServiceProvider.php
@@ -250,14 +250,7 @@ class JetstreamServiceProvider extends ServiceProvider
 
         if (class_exists(Passport::class)) {
             Passport::authorizationView(function ($params) {
-                return Inertia::render('Auth/OAuth/Authorize', [
-                    'user' => $params['user'],
-                    'client' => $params['client'],
-                    'scopes' => $params['scopes'],
-                    'state' => $params['request']->state,
-                    'authToken' => $params['authToken'],
-                    'promptLoginUrl' => $params['request']->fullUrlWithQuery(['prompt' => 'login']),
-                ]);
+                return Inertia::render('Auth/OAuth/Authorize', $params);
             });
         }
     }

--- a/src/Rules/Uri.php
+++ b/src/Rules/Uri.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Laravel\Jetstream\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+class Uri implements ValidationRule
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! filter_var($value, FILTER_VALIDATE_URL)) {
+            $fail('The :attribute field must be a valid URI.');
+        }
+    }
+}

--- a/stubs/app/Actions/Passport/CreateClient.php
+++ b/stubs/app/Actions/Passport/CreateClient.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Actions\Passport;
+
+use Illuminate\Foundation\Auth\User;
+use Illuminate\Support\Facades\Validator;
+use Laravel\Jetstream\Contracts\CreatesOAuthClients;
+use Laravel\Jetstream\Rules\Uri;
+use Laravel\Passport\Client;
+use Laravel\Passport\ClientRepository;
+
+class CreateClient implements CreatesOAuthClients
+{
+    /**
+     * Create a new action instance.
+     */
+    public function __construct(protected ClientRepository $clients)
+    {
+    }
+
+    /**
+     * Validate and create a new client.
+     *
+     * @param  array<string, mixed>  $input
+     */
+    public function create(User $user, array $input): Client
+    {
+        Validator::make($input, [
+            'name' => ['required', 'string', 'max:255'],
+            'redirect_uris' => ['required', 'list'],
+            'redirect_uris.*' => ['required', 'string', new Uri],
+            'confidential' => 'boolean',
+        ])->validateWithBag('createClient');
+
+        return $this->clients->createAuthorizationCodeGrantClient(
+            $input['name'],
+            $input['redirect_uris'],
+            (bool) ($input['confidential'] ?? false),
+            $user
+        );
+    }
+}

--- a/stubs/app/Actions/Passport/UpdateClient.php
+++ b/stubs/app/Actions/Passport/UpdateClient.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Actions\Passport;
+
+use Illuminate\Foundation\Auth\User;
+use Illuminate\Support\Facades\Validator;
+use Laravel\Jetstream\Contracts\UpdatesOAuthClients;
+use Laravel\Jetstream\Rules\Uri;
+use Laravel\Passport\Client;
+
+class UpdateClient implements UpdatesOAuthClients
+{
+    /**
+     * Validate and create a new client.
+     *
+     * @param  array<string, mixed>  $input
+     */
+    public function update(User $user, Client $client, array $input): void
+    {
+        Validator::make($input, [
+            'name' => ['required', 'string', 'max:255'],
+            'redirect_uris' => ['required', 'list'],
+            'redirect_uris.*' => ['required', 'string', new Uri],
+        ])->validateWithBag('updateClient');
+
+        $client->forceFill([
+            'name' => $input['name'],
+            'redirect_uris' => $input['redirect_uris'],
+        ])->save();
+    }
+}

--- a/stubs/app/Providers/JetstreamServiceProvider.php
+++ b/stubs/app/Providers/JetstreamServiceProvider.php
@@ -24,6 +24,11 @@ class JetstreamServiceProvider extends ServiceProvider
         $this->configurePermissions();
 
         Jetstream::deleteUsersUsing(DeleteUser::class);
+
+        if (Jetstream::hasOAuthFeatures()) {
+            Jetstream::createOAuthClientsUsing(\App\Actions\Passport\CreateClient::class);
+            Jetstream::updateOAuthClientsUsing(\App\Actions\Passport\UpdateClient::class);
+        }
     }
 
     /**

--- a/stubs/app/Providers/JetstreamWithTeamsServiceProvider.php
+++ b/stubs/app/Providers/JetstreamWithTeamsServiceProvider.php
@@ -36,6 +36,11 @@ class JetstreamServiceProvider extends ServiceProvider
         Jetstream::removeTeamMembersUsing(RemoveTeamMember::class);
         Jetstream::deleteTeamsUsing(DeleteTeam::class);
         Jetstream::deleteUsersUsing(DeleteUser::class);
+
+        if (Jetstream::hasOAuthFeatures()) {
+            Jetstream::createOAuthClientsUsing(\App\Actions\Passport\CreateClient::class);
+            Jetstream::updateOAuthClientsUsing(\App\Actions\Passport\UpdateClient::class);
+        }
     }
 
     /**

--- a/stubs/config/jetstream.php
+++ b/stubs/config/jetstream.php
@@ -61,6 +61,7 @@ return [
         // Features::termsAndPrivacyPolicy(),
         // Features::profilePhotos(),
         // Features::api(),
+        // Features::oauth(),
         // Features::teams(['invitations' => true]),
         Features::accountDeletion(),
     ],

--- a/stubs/inertia/resources/js/Layouts/AppLayout.vue
+++ b/stubs/inertia/resources/js/Layouts/AppLayout.vue
@@ -146,6 +146,10 @@ const logout = () => {
                                             API Tokens
                                         </DropdownLink>
 
+                                        <DropdownLink v-if="$page.props.jetstream.hasOAuthFeatures" :href="route('oauth-apps.index')">
+                                            OAuth Apps
+                                        </DropdownLink>
+
                                         <div class="border-t border-gray-200 dark:border-gray-600" />
 
                                         <!-- Authentication -->
@@ -220,6 +224,10 @@ const logout = () => {
 
                             <ResponsiveNavLink v-if="$page.props.jetstream.hasApiFeatures" :href="route('api-tokens.index')" :active="route().current('api-tokens.index')">
                                 API Tokens
+                            </ResponsiveNavLink>
+
+                            <ResponsiveNavLink v-if="$page.props.jetstream.hasOAuthFeatures" :href="route('oauth-apps.index')" :active="route().current('oauth-apps.index')">
+                                OAuth Apps
                             </ResponsiveNavLink>
 
                             <!-- Authentication -->

--- a/stubs/inertia/resources/js/Pages/Auth/OAuth/Authorize.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/OAuth/Authorize.vue
@@ -1,0 +1,80 @@
+<script setup>
+import { Head, Link, useForm } from '@inertiajs/vue3';
+import AuthenticationCard from '@/Components/AuthenticationCard.vue';
+import AuthenticationCardLogo from '@/Components/AuthenticationCardLogo.vue';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+import SecondaryButton from '@/Components/SecondaryButton.vue';
+
+const props = defineProps({
+    userName: String,
+    userEmail: String,
+    clientId: String,
+    clientName: String,
+    scopes: Array,
+    state: String,
+    authToken: String,
+    promptLoginUrl: String,
+});
+
+const form = useForm({
+    state: props.state,
+    client_id: props.clientId,
+    auth_token: props.authToken,
+});
+
+const approve = () => {
+    form.post(route('passport.authorizations.approve'));
+};
+const deny = () => {
+    form.transform(data => ({
+        ...data,
+        _method: 'delete',
+    })).post(route('passport.authorizations.deny'));
+};
+</script>
+
+<template>
+    <Head title="Authorization Request"/>
+
+    <AuthenticationCard>
+        <template #logo>
+            <AuthenticationCardLogo/>
+        </template>
+
+        <div class="mb-4 text-gray-600 text-center">
+            <p><strong>{{ userName }}</strong></p>
+            <p class="text-sm">{{ userEmail }}</p>
+        </div>
+
+        <div class="mb-4 text-sm text-gray-600">
+            <strong>{{ clientName }}</strong> is requesting permission to access your account.
+        </div>
+
+        <div v-if="scopes.length" class="mb-4 text-sm text-gray-600">
+            <p class="pb-1">This application will be able to:</p>
+
+            <ul class="list-inside list-disc">
+                <li v-for="scope in scopes">{{ scope.description }}</li>
+            </ul>
+        </div>
+
+        <div class="flex flex-row-reverse gap-3 mt-4 flex-wrap items-center">
+            <form @submit.prevent="approve">
+                <PrimaryButton :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
+                    Authorize
+                </PrimaryButton>
+            </form>
+
+            <form @submit.prevent="deny">
+                <SecondaryButton type="submit" :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
+                    Decline
+                </SecondaryButton>
+            </form>
+
+            <Link :href="promptLoginUrl"
+                  class="underline text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-offset-gray-800">
+                Log into another account
+            </Link>
+        </div>
+    </AuthenticationCard>
+</template>

--- a/stubs/inertia/resources/js/Pages/Auth/OAuth/Authorize.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/OAuth/Authorize.vue
@@ -9,13 +9,11 @@ const props = defineProps({
     user: Object,
     client: Object,
     scopes: Array,
-    state: String,
     authToken: String,
-    promptLoginUrl: String,
 });
 
 const form = useForm({
-    state: props.state,
+    state: route().params.state,
     client_id: props.client.id,
     auth_token: props.authToken,
 });
@@ -69,7 +67,7 @@ const deny = () => {
                 </SecondaryButton>
             </form>
 
-            <Link :href="promptLoginUrl"
+            <Link :href="route(route().current(), {...route().params, prompt: 'login'})"
                   class="underline text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-offset-gray-800">
                 Log into another account
             </Link>

--- a/stubs/inertia/resources/js/Pages/Auth/OAuth/Authorize.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/OAuth/Authorize.vue
@@ -6,10 +6,8 @@ import PrimaryButton from '@/Components/PrimaryButton.vue';
 import SecondaryButton from '@/Components/SecondaryButton.vue';
 
 const props = defineProps({
-    userName: String,
-    userEmail: String,
-    clientId: String,
-    clientName: String,
+    user: Object,
+    client: Object,
     scopes: Array,
     state: String,
     authToken: String,
@@ -18,7 +16,7 @@ const props = defineProps({
 
 const form = useForm({
     state: props.state,
-    client_id: props.clientId,
+    client_id: props.client.id,
     auth_token: props.authToken,
 });
 
@@ -42,12 +40,12 @@ const deny = () => {
         </template>
 
         <div class="mb-4 text-gray-600 text-center">
-            <p><strong>{{ userName }}</strong></p>
-            <p class="text-sm">{{ userEmail }}</p>
+            <p><strong>{{ user.name }}</strong></p>
+            <p class="text-sm">{{ user.email }}</p>
         </div>
 
         <div class="mb-4 text-sm text-gray-600">
-            <strong>{{ clientName }}</strong> is requesting permission to access your account.
+            <strong>{{ client.name }}</strong> is requesting permission to access your account.
         </div>
 
         <div v-if="scopes.length" class="mb-4 text-sm text-gray-600">

--- a/stubs/inertia/resources/js/Pages/Auth/OAuth/Authorize.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/OAuth/Authorize.vue
@@ -67,7 +67,7 @@ const deny = () => {
                 </SecondaryButton>
             </form>
 
-            <Link :href="route(route().current(), {...route().params, prompt: 'login'})"
+            <Link :href="route('passport.authorizations.authorize', {...route().params, prompt: 'login'})"
                   class="underline text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-offset-gray-800">
                 Log into another account
             </Link>

--- a/stubs/inertia/resources/js/Pages/Auth/OAuth/Device/Authorize.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/OAuth/Device/Authorize.vue
@@ -1,0 +1,71 @@
+<script setup>
+import { Head, useForm } from '@inertiajs/vue3';
+import AuthenticationCard from '@/Components/AuthenticationCard.vue';
+import AuthenticationCardLogo from '@/Components/AuthenticationCardLogo.vue';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+import SecondaryButton from '@/Components/SecondaryButton.vue';
+
+const props = defineProps({
+    user: Object,
+    client: Object,
+    scopes: Array,
+    authToken: String,
+});
+
+const form = useForm({
+    state: route().params.state,
+    client_id: props.client.id,
+    auth_token: props.authToken,
+});
+
+const approve = () => {
+    form.post(route('passport.device.authorizations.approve'));
+};
+const deny = () => {
+    form.transform(data => ({
+        ...data,
+        _method: 'delete',
+    })).post(route('passport.device.authorizations.deny'));
+};
+</script>
+
+<template>
+    <Head title="Authorization Request"/>
+
+    <AuthenticationCard>
+        <template #logo>
+            <AuthenticationCardLogo/>
+        </template>
+
+        <div class="mb-4 text-gray-600 text-center">
+            <p><strong>{{ user.name }}</strong></p>
+            <p class="text-sm">{{ user.email }}</p>
+        </div>
+
+        <div class="mb-4 text-sm text-gray-600">
+            <strong>{{ client.name }}</strong> is requesting permission to access your account.
+        </div>
+
+        <div v-if="scopes.length" class="mb-4 text-sm text-gray-600">
+            <p class="pb-1">This application will be able to:</p>
+
+            <ul class="list-inside list-disc">
+                <li v-for="scope in scopes">{{ scope.description }}</li>
+            </ul>
+        </div>
+
+        <div class="flex flex-row-reverse gap-3 mt-4 flex-wrap items-center">
+            <form @submit.prevent="approve">
+                <PrimaryButton :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
+                    Authorize
+                </PrimaryButton>
+            </form>
+
+            <form @submit.prevent="deny">
+                <SecondaryButton type="submit" :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
+                    Decline
+                </SecondaryButton>
+            </form>
+        </div>
+    </AuthenticationCard>
+</template>

--- a/stubs/inertia/resources/js/Pages/Auth/OAuth/Device/UserCode.vue
+++ b/stubs/inertia/resources/js/Pages/Auth/OAuth/Device/UserCode.vue
@@ -1,0 +1,71 @@
+<script setup>
+import { computed } from 'vue';
+import { Head, useForm } from '@inertiajs/vue3';
+import AuthenticationCard from '@/Components/AuthenticationCard.vue';
+import AuthenticationCardLogo from '@/Components/AuthenticationCardLogo.vue';
+import InputError from '@/Components/InputError.vue';
+import InputLabel from '@/Components/InputLabel.vue';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+import TextInput from '@/Components/TextInput.vue';
+
+defineProps({
+    status: String,
+});
+
+const form = useForm({
+    user_code: '',
+});
+
+const submit = () => {
+    form.get(route('passport.device.authorizations.authorize'));
+};
+
+const authorizationApproved = computed(() => props.status === 'authorization-approved');
+const authorizationDenied = computed(() => props.status === 'authorization-denied');
+</script>
+
+<template>
+    <Head title="Connect a Device" />
+
+    <AuthenticationCard>
+        <template #logo>
+            <AuthenticationCardLogo />
+        </template>
+
+        <div v-if="authorizationApproved" class="mb-4 font-medium text-sm text-green-600 dark:text-green-400">
+            Success! Continue on your device.
+        </div>
+        <div v-else-if="authorizationDenied" class="mb-4 font-medium text-sm text-red-600 dark:text-red-400">
+            Denied! Device authorization canceled.
+        </div>
+
+        <div class="mb-4 text-sm text-gray-600 dark:text-gray-400">
+            Enter the code displayed on your device.
+        </div>
+
+        <form @submit.prevent="submit">
+            <div>
+                <InputLabel for="user_code" value="Code" />
+                <TextInput
+                    id="user_code"
+                    v-model="form.user_code"
+                    type="text"
+                    class="mt-1 block w-full"
+                    required
+                    autofocus
+                    autocomplete="off"
+                    autocapitalize="characters"
+                    autocorrect="off"
+                    spellcheck="false"
+                />
+                <InputError class="mt-2" :message="form.errors.user_code" />
+            </div>
+
+            <div class="flex items-center justify-end mt-4">
+                <PrimaryButton :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
+                    Continue
+                </PrimaryButton>
+            </div>
+        </form>
+    </AuthenticationCard>
+</template>

--- a/stubs/inertia/resources/js/Pages/OAuth/Index.vue
+++ b/stubs/inertia/resources/js/Pages/OAuth/Index.vue
@@ -1,10 +1,11 @@
 <script setup>
 import OAuthAppManager from '@/Pages/OAuth/Partials/OAuthAppManager.vue';
+import OAuthConnectionManager from "@/Pages/OAuth/Partials/OAuthConnectionManager.vue";
 import AppLayout from '@/Layouts/AppLayout.vue';
 
 defineProps({
-    authorizedApps: Array,
-    oauthApps: Array,
+    connections: Array,
+    apps: Array,
 });
 </script>
 
@@ -18,10 +19,9 @@ defineProps({
 
         <div>
             <div class="max-w-7xl mx-auto py-10 sm:px-6 lg:px-8">
-                <OAuthAppManager
-                    :authorized-apps="authorizedApps"
-                    :oauth-apps="oauthApps"
-                />
+                <OAuthConnectionManager :connections="connections" />
+
+                <OAuthAppManager :apps="apps" />
             </div>
         </div>
     </AppLayout>

--- a/stubs/inertia/resources/js/Pages/OAuth/Index.vue
+++ b/stubs/inertia/resources/js/Pages/OAuth/Index.vue
@@ -1,0 +1,28 @@
+<script setup>
+import OAuthAppManager from '@/Pages/OAuth/Partials/OAuthAppManager.vue';
+import AppLayout from '@/Layouts/AppLayout.vue';
+
+defineProps({
+    authorizedApps: Array,
+    oauthApps: Array,
+});
+</script>
+
+<template>
+    <AppLayout title="OAuth Apps">
+        <template #header>
+            <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+                OAuth Apps
+            </h2>
+        </template>
+
+        <div>
+            <div class="max-w-7xl mx-auto py-10 sm:px-6 lg:px-8">
+                <OAuthAppManager
+                    :authorized-apps="authorizedApps"
+                    :oauth-apps="oauthApps"
+                />
+            </div>
+        </div>
+    </AppLayout>
+</template>

--- a/stubs/inertia/resources/js/Pages/OAuth/Partials/OAuthAppManager.vue
+++ b/stubs/inertia/resources/js/Pages/OAuth/Partials/OAuthAppManager.vue
@@ -21,13 +21,13 @@ const props = defineProps({
 
 const createOAuthAppForm = useForm({
     name: '',
-    redirect_uri: '',
+    redirect_uris: [],
     confidential: false,
 });
 
 const updateOAuthAppForm = useForm({
     name: '',
-    redirect_uri: '',
+    redirect_uris: [],
 });
 
 const deleteOAuthAppForm = useForm({});
@@ -48,7 +48,7 @@ const createOAuthApp = () => {
 
 const manageOAuthApp = (app) => {
     updateOAuthAppForm.name = app.name;
-    updateOAuthAppForm.redirect_uri = app.redirect;
+    updateOAuthAppForm.redirect_uris = app.redirect.split(',');
     oauthAppBeingManaged.value = app;
 };
 
@@ -105,12 +105,12 @@ const deleteOAuthApp = () => {
                     <InputLabel for="redirect_uri" value="Authorization Redirect URI" />
                     <TextInput
                         id="redirect_uri"
-                        v-model="createOAuthAppForm.redirect_uri"
+                        v-model="createOAuthAppForm.redirect_uris[0]"
                         type="url"
                         class="mt-1 block w-full"
                         autocomplete="off"
                     />
-                    <InputError :message="createOAuthAppForm.errors.redirect_uri" class="mt-2" />
+                    <InputError :message="createOAuthAppForm.errors.redirect_uris" class="mt-2" />
                 </div>
 
                 <!-- Confidential -->
@@ -263,12 +263,12 @@ const deleteOAuthApp = () => {
                         <InputLabel for="manage_redirect_uri" value="Authorization Redirect URI" />
                         <TextInput
                             id="manage_redirect_uri"
-                            v-model="updateOAuthAppForm.redirect_uri"
+                            v-model="updateOAuthAppForm.redirect_uris[0]"
                             type="url"
                             class="mt-1 block w-full"
                             autocomplete="off"
                         />
-                        <InputError :message="updateOAuthAppForm.errors.redirect_uri" class="mt-2" />
+                        <InputError :message="updateOAuthAppForm.errors.redirect_uris" class="mt-2" />
                     </div>
                 </div>
             </template>

--- a/stubs/inertia/resources/js/Pages/OAuth/Partials/OAuthAppManager.vue
+++ b/stubs/inertia/resources/js/Pages/OAuth/Partials/OAuthAppManager.vue
@@ -48,7 +48,7 @@ const createOAuthApp = () => {
 
 const manageOAuthApp = (app) => {
     updateOAuthAppForm.name = app.name;
-    updateOAuthAppForm.redirect_uris = app.redirect.split(',');
+    updateOAuthAppForm.redirect_uris = app.redirect_uris;
     oauthAppBeingManaged.value = app;
 };
 

--- a/stubs/inertia/resources/js/Pages/OAuth/Partials/OAuthAppManager.vue
+++ b/stubs/inertia/resources/js/Pages/OAuth/Partials/OAuthAppManager.vue
@@ -16,8 +16,7 @@ import SectionBorder from '@/Components/SectionBorder.vue';
 import TextInput from '@/Components/TextInput.vue';
 
 const props = defineProps({
-    authorizedApps: Array,
-    oauthApps: Array,
+    apps: Array,
 });
 
 const createOAuthAppForm = useForm({
@@ -33,12 +32,9 @@ const updateOAuthAppForm = useForm({
 
 const deleteOAuthAppForm = useForm({});
 
-const revokeAuthorizedAppForm = useForm({});
-
 const displayingClientCredentials = ref(false);
 const oauthAppBeingManaged = ref(null);
 const oauthAppBeingDeleted = ref(null);
-const authorizedAppBeingRevoked = ref(null);
 
 const createOAuthApp = () => {
     createOAuthAppForm.post(route('oauth-apps.store'), {
@@ -75,65 +71,10 @@ const deleteOAuthApp = () => {
         onSuccess: () => (oauthAppBeingDeleted.value = null),
     });
 };
-
-const confirmAuthorizedAppRevocation = (app) => {
-    authorizedAppBeingRevoked.value = app;
-};
-
-const revokeAuthorizedApp = () => {
-    revokeAuthorizedAppForm.delete(route('oauth-connections.destroy', authorizedAppBeingRevoked.value), {
-        preserveScroll: true,
-        preserveState: true,
-        onSuccess: () => (authorizedAppBeingRevoked.value = null),
-    });
-};
 </script>
 
 <template>
     <div>
-        <div v-if="authorizedApps.length > 0">
-            <!-- Manage Authorized Apps -->
-            <div class="mt-10 sm:mt-0">
-                <ActionSection>
-                    <template #title>
-                        Manage Authorized Apps
-                    </template>
-
-                    <template #description>
-                        Keep track of your connections to third-party apps and services.
-                    </template>
-
-                    <!-- Authorized App List -->
-                    <template #content>
-                        <div class="space-y-6">
-                            <div v-for="(app, id) in authorizedApps" :key="id" class="flex items-center justify-between">
-                                <div>
-                                    <div>
-                                        {{ app.client.name }}
-                                    </div>
-                                    <div class="text-sm italic text-gray-500">
-                                        {{ app.scopes.join(', ') }}
-                                    </div>
-                                </div>
-
-                                <div class="flex items-center ms-2">
-                                    <div class="text-sm text-gray-400">
-                                        {{ app.tokens_count }} Tokens
-                                    </div>
-
-                                    <button class="cursor-pointer ms-6 text-sm text-red-500" @click="confirmAuthorizedAppRevocation(app)">
-                                        Revoke
-                                    </button>
-                                </div>
-                            </div>
-                        </div>
-                    </template>
-                </ActionSection>
-            </div>
-
-            <SectionBorder />
-        </div>
-
         <!-- Register OAuth App -->
         <FormSection @submitted="createOAuthApp">
             <template #title>
@@ -193,7 +134,7 @@ const revokeAuthorizedApp = () => {
             </template>
         </FormSection>
 
-        <div v-if="oauthApps.length > 0">
+        <div v-if="apps.length > 0">
             <SectionBorder />
 
             <!-- Manage OAuth Apps -->
@@ -210,7 +151,7 @@ const revokeAuthorizedApp = () => {
                     <!-- OAuth App List -->
                     <template #content>
                         <div class="space-y-6">
-                            <div v-for="app in oauthApps" :key="app.id" class="flex items-center justify-between">
+                            <div v-for="app in apps" :key="app.id" class="flex items-center justify-between">
                                 <div class="dark:text-white">
                                     {{ app.name }}
                                     <span class="text-sm italic text-gray-400">
@@ -370,32 +311,6 @@ const revokeAuthorizedApp = () => {
                     @click="deleteOAuthApp"
                 >
                     Delete
-                </DangerButton>
-            </template>
-        </ConfirmationModal>
-
-        <!-- Revoke Authorized App Confirmation Modal -->
-        <ConfirmationModal :show="authorizedAppBeingRevoked != null" @close="authorizedAppBeingRevoked = null">
-            <template #title>
-                Revoke Authorized App
-            </template>
-
-            <template #content>
-                Are you sure you would like to revoke this app?
-            </template>
-
-            <template #footer>
-                <SecondaryButton @click="authorizedAppBeingRevoked = null">
-                    Cancel
-                </SecondaryButton>
-
-                <DangerButton
-                    class="ms-3"
-                    :class="{ 'opacity-25': revokeAuthorizedAppForm.processing }"
-                    :disabled="revokeAuthorizedAppForm.processing"
-                    @click="revokeAuthorizedApp"
-                >
-                    Revoke
                 </DangerButton>
             </template>
         </ConfirmationModal>

--- a/stubs/inertia/resources/js/Pages/OAuth/Partials/OAuthAppManager.vue
+++ b/stubs/inertia/resources/js/Pages/OAuth/Partials/OAuthAppManager.vue
@@ -1,0 +1,403 @@
+<script setup>
+import { ref } from 'vue';
+import { useForm } from '@inertiajs/vue3';
+import ActionMessage from '@/Components/ActionMessage.vue';
+import ActionSection from '@/Components/ActionSection.vue';
+import Checkbox from '@/Components/Checkbox.vue';
+import ConfirmationModal from '@/Components/ConfirmationModal.vue';
+import DangerButton from '@/Components/DangerButton.vue';
+import DialogModal from '@/Components/DialogModal.vue';
+import FormSection from '@/Components/FormSection.vue';
+import InputError from '@/Components/InputError.vue';
+import InputLabel from '@/Components/InputLabel.vue';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+import SecondaryButton from '@/Components/SecondaryButton.vue';
+import SectionBorder from '@/Components/SectionBorder.vue';
+import TextInput from '@/Components/TextInput.vue';
+
+const props = defineProps({
+    authorizedApps: Array,
+    oauthApps: Array,
+});
+
+const createOAuthAppForm = useForm({
+    name: '',
+    redirect_uri: '',
+    confidential: false,
+});
+
+const updateOAuthAppForm = useForm({
+    name: '',
+    redirect_uri: '',
+});
+
+const deleteOAuthAppForm = useForm({});
+
+const revokeAuthorizedAppForm = useForm({});
+
+const displayingClientCredentials = ref(false);
+const oauthAppBeingManaged = ref(null);
+const oauthAppBeingDeleted = ref(null);
+const authorizedAppBeingRevoked = ref(null);
+
+const createOAuthApp = () => {
+    createOAuthAppForm.post(route('oauth-apps.store'), {
+        preserveScroll: true,
+        onSuccess: () => {
+            displayingClientCredentials.value = true;
+            createOAuthAppForm.reset();
+        },
+    });
+};
+
+const manageOAuthApp = (app) => {
+    updateOAuthAppForm.name = app.name;
+    updateOAuthAppForm.redirect_uri = app.redirect;
+    oauthAppBeingManaged.value = app;
+};
+
+const updateOAuthApp = () => {
+    updateOAuthAppForm.put(route('oauth-apps.update', oauthAppBeingManaged.value), {
+        preserveScroll: true,
+        preserveState: true,
+        onSuccess: () => (oauthAppBeingManaged.value = null),
+    });
+};
+
+const confirmOAuthAppDeletion = (app) => {
+    oauthAppBeingDeleted.value = app;
+};
+
+const deleteOAuthApp = () => {
+    deleteOAuthAppForm.delete(route('oauth-apps.destroy', oauthAppBeingDeleted.value), {
+        preserveScroll: true,
+        preserveState: true,
+        onSuccess: () => (oauthAppBeingDeleted.value = null),
+    });
+};
+
+const confirmAuthorizedAppRevocation = (app) => {
+    authorizedAppBeingRevoked.value = app;
+};
+
+const revokeAuthorizedApp = () => {
+    revokeAuthorizedAppForm.delete(route('oauth-connections.destroy', authorizedAppBeingRevoked.value), {
+        preserveScroll: true,
+        preserveState: true,
+        onSuccess: () => (authorizedAppBeingRevoked.value = null),
+    });
+};
+</script>
+
+<template>
+    <div>
+        <div v-if="authorizedApps.length > 0">
+            <!-- Manage Authorized Apps -->
+            <div class="mt-10 sm:mt-0">
+                <ActionSection>
+                    <template #title>
+                        Manage Authorized Apps
+                    </template>
+
+                    <template #description>
+                        Keep track of your connections to third-party apps and services.
+                    </template>
+
+                    <!-- Authorized App List -->
+                    <template #content>
+                        <div class="space-y-6">
+                            <div v-for="(app, id) in authorizedApps" :key="id" class="flex items-center justify-between">
+                                <div>
+                                    <div>
+                                        {{ app.client.name }}
+                                    </div>
+                                    <div class="text-sm italic text-gray-500">
+                                        {{ app.scopes.join(', ') }}
+                                    </div>
+                                </div>
+
+                                <div class="flex items-center ms-2">
+                                    <div class="text-sm text-gray-400">
+                                        {{ app.tokens_count }} Tokens
+                                    </div>
+
+                                    <button class="cursor-pointer ms-6 text-sm text-red-500" @click="confirmAuthorizedAppRevocation(app)">
+                                        Revoke
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                    </template>
+                </ActionSection>
+            </div>
+
+            <SectionBorder />
+        </div>
+
+        <!-- Register OAuth App -->
+        <FormSection @submitted="createOAuthApp">
+            <template #title>
+                Register OAuth App
+            </template>
+
+            <template #description>
+                You may register an OAuth client to use our application's API.
+            </template>
+
+            <template #form>
+                <!-- App Name -->
+                <div class="col-span-6 sm:col-span-4">
+                    <InputLabel for="name" value="Application Name" />
+                    <TextInput
+                        id="name"
+                        v-model="createOAuthAppForm.name"
+                        type="text"
+                        class="mt-1 block w-full"
+                        autofocus
+                        autocomplete="off"
+                    />
+                    <InputError :message="createOAuthAppForm.errors.name" class="mt-2" />
+                </div>
+
+                <!-- Authorization Redirect URI -->
+                <div class="col-span-6 sm:col-span-4">
+                    <InputLabel for="redirect_uri" value="Authorization Redirect URI" />
+                    <TextInput
+                        id="redirect_uri"
+                        v-model="createOAuthAppForm.redirect_uri"
+                        type="url"
+                        class="mt-1 block w-full"
+                        autocomplete="off"
+                    />
+                    <InputError :message="createOAuthAppForm.errors.redirect_uri" class="mt-2" />
+                </div>
+
+                <!-- Confidential -->
+                <div class="col-span-6 sm:col-span-4">
+                    <label for="confidential" class="flex items-center">
+                        <Checkbox id="confidential" v-model:checked="createOAuthAppForm.confidential" />
+                        <span class="ms-2 text-sm text-gray-600 dark:text-gray-400">Confidential</span>
+                    </label>
+                    <InputError :message="createOAuthAppForm.errors.confidential" class="mt-2" />
+                </div>
+            </template>
+
+            <template #actions>
+                <ActionMessage :on="createOAuthAppForm.recentlySuccessful" class="me-3">
+                    Registered.
+                </ActionMessage>
+
+                <PrimaryButton :class="{ 'opacity-25': createOAuthAppForm.processing }" :disabled="createOAuthAppForm.processing">
+                    Register
+                </PrimaryButton>
+            </template>
+        </FormSection>
+
+        <div v-if="oauthApps.length > 0">
+            <SectionBorder />
+
+            <!-- Manage OAuth Apps -->
+            <div class="mt-10 sm:mt-0">
+                <ActionSection>
+                    <template #title>
+                        Manage OAuth Apps
+                    </template>
+
+                    <template #description>
+                        You may delete any of your existing registered apps if they are no longer needed.
+                    </template>
+
+                    <!-- OAuth App List -->
+                    <template #content>
+                        <div class="space-y-6">
+                            <div v-for="app in oauthApps" :key="app.id" class="flex items-center justify-between">
+                                <div class="dark:text-white">
+                                    {{ app.name }}
+                                    <span class="text-sm italic text-gray-400">
+                                        &ndash; {{ app.is_confidential ? 'Confidential' : 'Public' }}
+                                    </span>
+                                </div>
+
+                                <div class="flex items-center ms-2">
+                                    <div class="text-sm text-gray-400">
+                                        Created at {{ app.created_date }}
+                                    </div>
+
+                                    <button
+                                        class="cursor-pointer ms-6 text-sm text-gray-400 underline"
+                                        @click="manageOAuthApp(app)"
+                                    >
+                                        Manage
+                                    </button>
+
+                                    <button class="cursor-pointer ms-6 text-sm text-red-500" @click="confirmOAuthAppDeletion(app)">
+                                        Delete
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                    </template>
+                </ActionSection>
+            </div>
+        </div>
+
+        <!-- Client Credentials Modal -->
+        <DialogModal :show="displayingClientCredentials" @close="displayingClientCredentials = false">
+            <template #title>
+                Client Credentials
+            </template>
+
+            <template #content>
+                <div class="grid grid-cols-1 gap-4">
+                    <div>
+                        Please copy your new client credentials.
+
+                        <template v-if="$page.props.jetstream.flash.client_secret">
+                            For your security, client secret won't be shown again.
+                        </template>
+                    </div>
+
+                    <div>
+                        <div class="block font-medium text-sm text-gray-700 dark:text-gray-300">
+                            Client ID
+                        </div>
+                        <div v-if="$page.props.jetstream.flash.client_id" class="mt-1 bg-gray-100 dark:bg-gray-900 px-4 py-2 rounded font-mono text-sm text-gray-500 break-all">
+                            {{ $page.props.jetstream.flash.client_id }}
+                        </div>
+                    </div>
+
+                    <div v-if="$page.props.jetstream.flash.client_secret">
+                        <div class="block font-medium text-sm text-gray-700 dark:text-gray-300">
+                            Client Secret
+                        </div>
+                        <div class="mt-1 bg-gray-100 dark:bg-gray-900 px-4 py-2 rounded font-mono text-sm text-gray-500 break-all">
+                            {{ $page.props.jetstream.flash.client_secret }}
+                        </div>
+                    </div>
+                </div>
+            </template>
+
+            <template #footer>
+                <SecondaryButton @click="displayingClientCredentials = false">
+                    Close
+                </SecondaryButton>
+            </template>
+        </DialogModal>
+
+        <!-- OAuth App Management Modal -->
+        <DialogModal :show="oauthAppBeingManaged != null" @close="oauthAppBeingManaged = null">
+            <template #title>
+                OAuth App Management
+            </template>
+
+            <template #content>
+                <div class="grid grid-cols-1 gap-4">
+                    <!-- Client ID -->
+                    <div>
+                        <InputLabel for="manage_client_id" value="Client ID" />
+                        <TextInput
+                            id="manage_client_id"
+                            :value="oauthAppBeingManaged?.id"
+                            type="text"
+                            class="mt-1 block w-full bg-gray-100 font-mono text-gray-500 break-all"
+                            readonly
+                        />
+                    </div>
+
+                    <!-- App Name -->
+                    <div>
+                        <InputLabel for="manage_name" value="Application Name" />
+                        <TextInput
+                            id="manage_name"
+                            v-model="updateOAuthAppForm.name"
+                            type="text"
+                            class="mt-1 block w-full"
+                            autocomplete="off"
+                        />
+                        <InputError :message="updateOAuthAppForm.errors.name" class="mt-2" />
+                    </div>
+
+                    <!-- Authorization Redirect URI -->
+                    <div>
+                        <InputLabel for="manage_redirect_uri" value="Authorization Redirect URI" />
+                        <TextInput
+                            id="manage_redirect_uri"
+                            v-model="updateOAuthAppForm.redirect_uri"
+                            type="url"
+                            class="mt-1 block w-full"
+                            autocomplete="off"
+                        />
+                        <InputError :message="updateOAuthAppForm.errors.redirect_uri" class="mt-2" />
+                    </div>
+                </div>
+            </template>
+
+            <template #footer>
+                <SecondaryButton @click="oauthAppBeingManaged = null">
+                    Cancel
+                </SecondaryButton>
+
+                <PrimaryButton
+                    class="ms-3"
+                    :class="{ 'opacity-25': updateOAuthAppForm.processing }"
+                    :disabled="updateOAuthAppForm.processing"
+                    @click="updateOAuthApp"
+                >
+                    Save
+                </PrimaryButton>
+            </template>
+        </DialogModal>
+
+        <!-- Delete OAuth App Confirmation Modal -->
+        <ConfirmationModal :show="oauthAppBeingDeleted != null" @close="oauthAppBeingDeleted = null">
+            <template #title>
+                Delete OAuth App
+            </template>
+
+            <template #content>
+                Are you sure you would like to delete this app?
+            </template>
+
+            <template #footer>
+                <SecondaryButton @click="oauthAppBeingDeleted = null">
+                    Cancel
+                </SecondaryButton>
+
+                <DangerButton
+                    class="ms-3"
+                    :class="{ 'opacity-25': deleteOAuthAppForm.processing }"
+                    :disabled="deleteOAuthAppForm.processing"
+                    @click="deleteOAuthApp"
+                >
+                    Delete
+                </DangerButton>
+            </template>
+        </ConfirmationModal>
+
+        <!-- Revoke Authorized App Confirmation Modal -->
+        <ConfirmationModal :show="authorizedAppBeingRevoked != null" @close="authorizedAppBeingRevoked = null">
+            <template #title>
+                Revoke Authorized App
+            </template>
+
+            <template #content>
+                Are you sure you would like to revoke this app?
+            </template>
+
+            <template #footer>
+                <SecondaryButton @click="authorizedAppBeingRevoked = null">
+                    Cancel
+                </SecondaryButton>
+
+                <DangerButton
+                    class="ms-3"
+                    :class="{ 'opacity-25': revokeAuthorizedAppForm.processing }"
+                    :disabled="revokeAuthorizedAppForm.processing"
+                    @click="revokeAuthorizedApp"
+                >
+                    Revoke
+                </DangerButton>
+            </template>
+        </ConfirmationModal>
+    </div>
+</template>

--- a/stubs/inertia/resources/js/Pages/OAuth/Partials/OAuthConnectionManager.vue
+++ b/stubs/inertia/resources/js/Pages/OAuth/Partials/OAuthConnectionManager.vue
@@ -45,7 +45,7 @@ const deleteConnection = () => {
                     <!-- OAuth Connection List -->
                     <template #content>
                         <div class="space-y-6">
-                            <div v-for="(connection, id) in connections" :key="id" class="flex items-center justify-between">
+                            <div v-for="connection in connections" :key="connection.client.id" class="flex items-center justify-between">
                                 <div>
                                     <div>
                                         {{ connection.client.name }}

--- a/stubs/inertia/resources/js/Pages/OAuth/Partials/OAuthConnectionManager.vue
+++ b/stubs/inertia/resources/js/Pages/OAuth/Partials/OAuthConnectionManager.vue
@@ -1,0 +1,102 @@
+<script setup>
+import { ref } from 'vue';
+import { useForm } from '@inertiajs/vue3';
+import ActionSection from '@/Components/ActionSection.vue';
+import ConfirmationModal from '@/Components/ConfirmationModal.vue';
+import DangerButton from '@/Components/DangerButton.vue';
+import SecondaryButton from '@/Components/SecondaryButton.vue';
+import SectionBorder from '@/Components/SectionBorder.vue';
+
+const props = defineProps({
+    connections: Array,
+});
+
+const deleteConnectionForm = useForm({});
+
+const connectionClientBeingDeleted = ref(null);
+
+const confirmConnectionDeletion = (client) => {
+    connectionClientBeingDeleted.value = client;
+};
+
+const deleteConnection = () => {
+    deleteConnectionForm.delete(route('oauth-connections.destroy', connectionClientBeingDeleted.value), {
+        preserveScroll: true,
+        preserveState: true,
+        onSuccess: () => (connectionClientBeingDeleted.value = null),
+    });
+};
+</script>
+
+<template>
+    <div>
+        <div v-if="connections.length > 0">
+            <!-- Manage OAuth Connections -->
+            <div class="mt-10 sm:mt-0">
+                <ActionSection>
+                    <template #title>
+                        Manage Authorized Apps
+                    </template>
+
+                    <template #description>
+                        Keep track of your connections with third-party apps and services. You may delete the access you've given to any of your existing authorized apps if they are no longer needed.
+                    </template>
+
+                    <!-- OAuth Connection List -->
+                    <template #content>
+                        <div class="space-y-6">
+                            <div v-for="(connection, id) in connections" :key="id" class="flex items-center justify-between">
+                                <div>
+                                    <div>
+                                        {{ connection.client.name }}
+                                    </div>
+                                    <div class="text-sm italic text-gray-500">
+                                        {{ connection.scopes.join(', ') }}
+                                    </div>
+                                </div>
+
+                                <div class="flex items-center ms-2">
+                                    <div class="text-sm text-gray-400">
+                                        {{ connection.tokens_count }} Tokens
+                                    </div>
+
+                                    <button class="cursor-pointer ms-6 text-sm text-red-500" @click="confirmConnectionDeletion(connection.client)">
+                                        Delete
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                    </template>
+                </ActionSection>
+            </div>
+
+            <SectionBorder />
+        </div>
+
+        <!-- Delete OAuth Connection Confirmation Modal -->
+        <ConfirmationModal :show="connectionClientBeingDeleted != null" @close="connectionClientBeingDeleted = null">
+            <template #title>
+                Delete OAuth Connection
+            </template>
+
+            <template #content>
+                Are you sure you would like to delete all connections you have with this app?
+            </template>
+
+            <template #footer>
+                <SecondaryButton @click="connectionClientBeingDeleted = null">
+                    Cancel
+                </SecondaryButton>
+
+                <DangerButton
+                    class="ms-3"
+                    :class="{ 'opacity-25': deleteConnectionForm.processing }"
+                    :disabled="deleteConnectionForm.processing"
+                    @click="deleteConnection"
+                >
+                    Delete
+                </DangerButton>
+            </template>
+        </ConfirmationModal>
+    </div>
+</template>

--- a/stubs/inertia/resources/js/Pages/PassportAPI/Index.vue
+++ b/stubs/inertia/resources/js/Pages/PassportAPI/Index.vue
@@ -1,0 +1,30 @@
+<script setup>
+import ApiTokenManager from '@/Pages/API/Partials/ApiTokenManager.vue';
+import AppLayout from '@/Layouts/AppLayout.vue';
+
+defineProps({
+    tokens: Array,
+    availableScopes: Array,
+    defaultScopes: Array,
+});
+</script>
+
+<template>
+    <AppLayout title="API Tokens">
+        <template #header>
+            <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+                API Tokens
+            </h2>
+        </template>
+
+        <div>
+            <div class="max-w-7xl mx-auto py-10 sm:px-6 lg:px-8">
+                <ApiTokenManager
+                    :tokens="tokens"
+                    :available-scopes="availableScopes"
+                    :default-scopes="defaultScopes"
+                />
+            </div>
+        </div>
+    </AppLayout>
+</template>

--- a/stubs/inertia/resources/js/Pages/PassportAPI/Partials/ApiTokenManager.vue
+++ b/stubs/inertia/resources/js/Pages/PassportAPI/Partials/ApiTokenManager.vue
@@ -1,0 +1,210 @@
+<script setup>
+import { ref } from 'vue';
+import { useForm } from '@inertiajs/vue3';
+import ActionMessage from '@/Components/ActionMessage.vue';
+import ActionSection from '@/Components/ActionSection.vue';
+import Checkbox from '@/Components/Checkbox.vue';
+import ConfirmationModal from '@/Components/ConfirmationModal.vue';
+import DangerButton from '@/Components/DangerButton.vue';
+import DialogModal from '@/Components/DialogModal.vue';
+import FormSection from '@/Components/FormSection.vue';
+import InputError from '@/Components/InputError.vue';
+import InputLabel from '@/Components/InputLabel.vue';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+import SecondaryButton from '@/Components/SecondaryButton.vue';
+import SectionBorder from '@/Components/SectionBorder.vue';
+import TextInput from '@/Components/TextInput.vue';
+
+const props = defineProps({
+    tokens: Array,
+    availableScopes: Array,
+    defaultScopes: Array,
+});
+
+const createApiTokenForm = useForm({
+    name: '',
+    scopes: props.defaultScopes,
+});
+
+const deleteApiTokenForm = useForm({});
+
+const displayingToken = ref(false);
+const apiTokenBeingDeleted = ref(null);
+
+const createApiToken = () => {
+    createApiTokenForm.post(route('api-tokens.store'), {
+        preserveScroll: true,
+        onSuccess: () => {
+            displayingToken.value = true;
+            createApiTokenForm.reset();
+        },
+    });
+};
+
+const confirmApiTokenDeletion = (token) => {
+    apiTokenBeingDeleted.value = token;
+};
+
+const deleteApiToken = () => {
+    deleteApiTokenForm.delete(route('api-tokens.destroy', apiTokenBeingDeleted.value), {
+        preserveScroll: true,
+        preserveState: true,
+        onSuccess: () => (apiTokenBeingDeleted.value = null),
+    });
+};
+</script>
+
+<template>
+    <div>
+        <!-- Generate API Token -->
+        <FormSection @submitted="createApiToken">
+            <template #title>
+                Create API Token
+            </template>
+
+            <template #description>
+                Personal access tokens allow secure authentication to our application's API for your personal use.
+            </template>
+
+            <template #form>
+                <!-- Token Name -->
+                <div class="col-span-6 sm:col-span-4">
+                    <InputLabel for="name" value="Token Name" />
+                    <TextInput
+                        id="name"
+                        v-model="createApiTokenForm.name"
+                        type="text"
+                        class="mt-1 block w-full"
+                        autofocus
+                        autocomplete="off"
+                    />
+                    <InputError :message="createApiTokenForm.errors.name" class="mt-2" />
+                </div>
+
+                <!-- Token Scopes -->
+                <div v-if="availableScopes.length > 0" class="col-span-6">
+                    <fieldset>
+                        <legend class="block font-medium text-sm text-gray-700 dark:text-gray-300">
+                            Scopes
+                        </legend>
+
+                        <div class="mt-2 grid grid-cols-1 md:grid-cols-2 gap-4">
+                            <div v-for="scope in availableScopes" :key="scope.id">
+                                <label class="flex items-center">
+                                    <Checkbox v-model:checked="createApiTokenForm.scopes" :value="scope.id" />
+                                    <span class="ms-2 text-sm text-gray-600 dark:text-gray-400">{{ scope.description }}</span>
+                                </label>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+            </template>
+
+            <template #actions>
+                <ActionMessage :on="createApiTokenForm.recentlySuccessful" class="me-3">
+                    Created.
+                </ActionMessage>
+
+                <PrimaryButton :class="{ 'opacity-25': createApiTokenForm.processing }" :disabled="createApiTokenForm.processing">
+                    Create
+                </PrimaryButton>
+            </template>
+        </FormSection>
+
+        <div v-if="tokens.length > 0">
+            <SectionBorder />
+
+            <!-- Manage API Tokens -->
+            <div class="mt-10 sm:mt-0">
+                <ActionSection>
+                    <template #title>
+                        Manage API Tokens
+                    </template>
+
+                    <template #description>
+                        You may revoke any of your existing personal access tokens if they are no longer needed.
+                    </template>
+
+                    <!-- API Token List -->
+                    <template #content>
+                        <div class="space-y-6">
+                            <div v-for="token in tokens" :key="token.id" class="flex items-center justify-between">
+                                <div>
+                                    <div class="dark:text-white">
+                                        {{ token.name }}
+                                    </div>
+                                    <div class="text-sm italic text-gray-500">
+                                        {{ token.scopes.join(', ') }}
+                                    </div>
+                                </div>
+
+                                <div class="flex items-center ms-2">
+                                    <div class="text-sm text-gray-400">
+                                        Issued {{ token.issued_ago }}
+                                    </div>
+
+                                    <div class="ms-6 text-sm text-gray-400">
+                                        Expires in {{ token.expires_in }}
+                                    </div>
+
+                                    <button class="cursor-pointer ms-6 text-sm text-red-500" @click="confirmApiTokenDeletion(token)">
+                                        Revoke
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                    </template>
+                </ActionSection>
+            </div>
+        </div>
+
+        <!-- Token Value Modal -->
+        <DialogModal :show="displayingToken" @close="displayingToken = false">
+            <template #title>
+                Personal Access Token
+            </template>
+
+            <template #content>
+                <div>
+                    Please copy your new personal access token. For your security, it won't be shown again.
+                </div>
+
+                <div v-if="$page.props.jetstream.flash.token" class="mt-4 bg-gray-100 dark:bg-gray-900 px-4 py-2 rounded font-mono text-sm text-gray-500 break-all">
+                    {{ $page.props.jetstream.flash.token }}
+                </div>
+            </template>
+
+            <template #footer>
+                <SecondaryButton @click="displayingToken = false">
+                    Close
+                </SecondaryButton>
+            </template>
+        </DialogModal>
+
+        <!-- Revoke Token Confirmation Modal -->
+        <ConfirmationModal :show="apiTokenBeingDeleted != null" @close="apiTokenBeingDeleted = null">
+            <template #title>
+                Revoke API Token
+            </template>
+
+            <template #content>
+                Are you sure you would like to revoke this API token?
+            </template>
+
+            <template #footer>
+                <SecondaryButton @click="apiTokenBeingDeleted = null">
+                    Cancel
+                </SecondaryButton>
+
+                <DangerButton
+                    class="ms-3"
+                    :class="{ 'opacity-25': deleteApiTokenForm.processing }"
+                    :disabled="deleteApiTokenForm.processing"
+                    @click="deleteApiToken"
+                >
+                    Revoke
+                </DangerButton>
+            </template>
+        </ConfirmationModal>
+    </div>
+</template>

--- a/stubs/inertia/resources/js/Pages/PassportAPI/Partials/ApiTokenManager.vue
+++ b/stubs/inertia/resources/js/Pages/PassportAPI/Partials/ApiTokenManager.vue
@@ -122,7 +122,7 @@ const deleteApiToken = () => {
                     </template>
 
                     <template #description>
-                        You may revoke any of your existing personal access tokens if they are no longer needed.
+                        You may delete any of your existing personal access tokens if they are no longer needed.
                     </template>
 
                     <!-- API Token List -->
@@ -148,7 +148,7 @@ const deleteApiToken = () => {
                                     </div>
 
                                     <button class="cursor-pointer ms-6 text-sm text-red-500" @click="confirmApiTokenDeletion(token)">
-                                        Revoke
+                                        Delete
                                     </button>
                                 </div>
                             </div>
@@ -181,14 +181,14 @@ const deleteApiToken = () => {
             </template>
         </DialogModal>
 
-        <!-- Revoke Token Confirmation Modal -->
+        <!-- Delete Token Confirmation Modal -->
         <ConfirmationModal :show="apiTokenBeingDeleted != null" @close="apiTokenBeingDeleted = null">
             <template #title>
-                Revoke API Token
+                Delete API Token
             </template>
 
             <template #content>
-                Are you sure you would like to revoke this API token?
+                Are you sure you would like to delete this API token?
             </template>
 
             <template #footer>
@@ -202,7 +202,7 @@ const deleteApiToken = () => {
                     :disabled="deleteApiTokenForm.processing"
                     @click="deleteApiToken"
                 >
-                    Revoke
+                    Delete
                 </DangerButton>
             </template>
         </ConfirmationModal>

--- a/stubs/inertia/routes/web.php
+++ b/stubs/inertia/routes/web.php
@@ -14,7 +14,7 @@ Route::get('/', function () {
 });
 
 Route::middleware([
-    'auth:sanctum',
+    config('jetstream.guard') ? 'auth:'.config('jetstream.guard') : 'auth',
     config('jetstream.auth_session'),
     'verified',
 ])->group(function () {

--- a/stubs/livewire/resources/views/auth/oauth/authorize.blade.php
+++ b/stubs/livewire/resources/views/auth/oauth/authorize.blade.php
@@ -1,0 +1,59 @@
+<x-guest-layout>
+    <x-authentication-card>
+        <x-slot name="logo">
+            <x-authentication-card-logo />
+        </x-slot>
+
+        <div class="mb-4 text-gray-600 text-center">
+            <p><strong>{{ $user->name }}</strong></p>
+            <p class="text-sm">{{ $user->email }}</p>
+        </div>
+
+        <div class="mb-4 text-sm text-gray-600">
+            {{ __(':client is requesting permission to access your account.', ['client' => $client->name]) }}
+        </div>
+
+        @if (count($scopes) > 0)
+            <div class="mb-4 text-sm text-gray-600">
+                <p class="pb-1">{{ __('This application will be able to:') }}</p>
+
+                <ul class="list-inside list-disc">
+                    @foreach ($scopes as $scope)
+                        <li>{{ $scope->description }}</li>
+                    @endforeach
+                </ul>
+            </div>
+        @endif
+
+        <div class="flex flex-row-reverse gap-3 mt-4 flex-wrap items-center">
+            <form method="POST" action="{{ route('passport.authorizations.approve') }}">
+                @csrf
+
+                <input type="hidden" name="state" value="{{ $request->state }}">
+                <input type="hidden" name="client_id" value="{{ $client->getKey() }}">
+                <input type="hidden" name="auth_token" value="{{ $authToken }}">
+
+                <x-button>
+                    {{ __('Authorize') }}
+                </x-button>
+            </form>
+
+            <form method="POST" action="{{ route('passport.authorizations.deny') }}">
+                @csrf
+                @method('DELETE')
+
+                <input type="hidden" name="state" value="{{ $request->state }}">
+                <input type="hidden" name="client_id" value="{{ $client->getKey() }}">
+                <input type="hidden" name="auth_token" value="{{ $authToken }}">
+
+                <x-secondary-button type="submit">
+                    {{ __('Decline') }}
+                </x-secondary-button>
+            </form>
+
+            <a class="underline text-sm text-gray-600 hover:text-gray-900 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" href="{{ $request->fullUrlWithQuery(['prompt' => 'login']) }}">
+                {{ __('Log into another account') }}
+            </a>
+        </div>
+    </x-authentication-card>
+</x-guest-layout>

--- a/stubs/livewire/resources/views/auth/oauth/device/authorize.blade.php
+++ b/stubs/livewire/resources/views/auth/oauth/device/authorize.blade.php
@@ -1,0 +1,55 @@
+<x-guest-layout>
+    <x-authentication-card>
+        <x-slot name="logo">
+            <x-authentication-card-logo />
+        </x-slot>
+
+        <div class="mb-4 text-gray-600 text-center">
+            <p><strong>{{ $user->name }}</strong></p>
+            <p class="text-sm">{{ $user->email }}</p>
+        </div>
+
+        <div class="mb-4 text-sm text-gray-600">
+            {{ __(':client is requesting permission to access your account.', ['client' => $client->name]) }}
+        </div>
+
+        @if (count($scopes) > 0)
+            <div class="mb-4 text-sm text-gray-600">
+                <p class="pb-1">{{ __('This application will be able to:') }}</p>
+
+                <ul class="list-inside list-disc">
+                    @foreach ($scopes as $scope)
+                        <li>{{ $scope->description }}</li>
+                    @endforeach
+                </ul>
+            </div>
+        @endif
+
+        <div class="flex flex-row-reverse gap-3 mt-4 flex-wrap items-center">
+            <form method="POST" action="{{ route('passport.device.authorizations.approve') }}">
+                @csrf
+
+                <input type="hidden" name="state" value="{{ $request->state }}">
+                <input type="hidden" name="client_id" value="{{ $client->getKey() }}">
+                <input type="hidden" name="auth_token" value="{{ $authToken }}">
+
+                <x-button>
+                    {{ __('Authorize') }}
+                </x-button>
+            </form>
+
+            <form method="POST" action="{{ route('passport.device.authorizations.deny') }}">
+                @csrf
+                @method('DELETE')
+
+                <input type="hidden" name="state" value="{{ $request->state }}">
+                <input type="hidden" name="client_id" value="{{ $client->getKey() }}">
+                <input type="hidden" name="auth_token" value="{{ $authToken }}">
+
+                <x-secondary-button type="submit">
+                    {{ __('Decline') }}
+                </x-secondary-button>
+            </form>
+        </div>
+    </x-authentication-card>
+</x-guest-layout>

--- a/stubs/livewire/resources/views/auth/oauth/device/user-code.blade.php
+++ b/stubs/livewire/resources/views/auth/oauth/device/user-code.blade.php
@@ -1,0 +1,36 @@
+<x-guest-layout>
+    <x-authentication-card>
+        <x-slot name="logo">
+            <x-authentication-card-logo />
+        </x-slot>
+
+        @if (session('status') === 'authorization-approved')
+            <div class="mb-4 font-medium text-sm text-green-600 dark:text-green-400">
+                {{ __('Success! Continue on your device.') }}
+            </div>
+        @elseif(session('status') === 'authorization-denied')
+            <div class="mb-4 font-medium text-sm text-red-600 dark:text-red-400">
+                {{ __('Denied! Device authorization canceled.') }}
+            </div>
+        @endif
+
+        <div class="mb-4 text-sm text-gray-600 dark:text-gray-400">
+            {{ __('Enter the code displayed on your device.') }}
+        </div>
+
+        <x-validation-errors class="mb-4" />
+
+        <form method="GET" action="{{ route('passport.device.authorizations.authorize') }}">
+            <div class="block">
+                <x-label for="user_code" value="{{ __('Code') }}" />
+                <x-input id="user_code" class="block mt-1 w-full" type="text" name="user_code" :value="old('user_code')" required autofocus autocomplete="off" autocapitalize="characters" autocorrect="off" spellcheck="false" />
+            </div>
+
+            <div class="flex items-center justify-end mt-4">
+                <x-button>
+                    {{ __('Continue') }}
+                </x-button>
+            </div>
+        </form>
+    </x-authentication-card>
+</x-guest-layout>

--- a/stubs/livewire/resources/views/navigation-menu.blade.php
+++ b/stubs/livewire/resources/views/navigation-menu.blade.php
@@ -108,6 +108,12 @@
                                 </x-dropdown-link>
                             @endif
 
+                            @if (Laravel\Jetstream\Jetstream::hasOAuthFeatures())
+                                <x-dropdown-link href="{{ route('oauth-apps.index') }}">
+                                    {{ __('OAuth Apps') }}
+                                </x-dropdown-link>
+                            @endif
+
                             <div class="border-t border-gray-200 dark:border-gray-600"></div>
 
                             <!-- Authentication -->
@@ -168,6 +174,12 @@
                 @if (Laravel\Jetstream\Jetstream::hasApiFeatures())
                     <x-responsive-nav-link href="{{ route('api-tokens.index') }}" :active="request()->routeIs('api-tokens.index')">
                         {{ __('API Tokens') }}
+                    </x-responsive-nav-link>
+                @endif
+
+                @if (Laravel\Jetstream\Jetstream::hasOAuthFeatures())
+                    <x-responsive-nav-link href="{{ route('oauth-apps.index') }}" :active="request()->routeIs('oauth-apps.index')">
+                        {{ __('OAuth Apps') }}
                     </x-responsive-nav-link>
                 @endif
 

--- a/stubs/livewire/resources/views/oauth/index.blade.php
+++ b/stubs/livewire/resources/views/oauth/index.blade.php
@@ -7,6 +7,8 @@
 
     <div>
         <div class="max-w-7xl mx-auto py-10 sm:px-6 lg:px-8">
+            @livewire('oauth.oauth-connection-manager')
+
             @livewire('oauth.oauth-app-manager')
         </div>
     </div>

--- a/stubs/livewire/resources/views/oauth/index.blade.php
+++ b/stubs/livewire/resources/views/oauth/index.blade.php
@@ -1,0 +1,13 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            {{ __('OAuth Apps') }}
+        </h2>
+    </x-slot>
+
+    <div>
+        <div class="max-w-7xl mx-auto py-10 sm:px-6 lg:px-8">
+            @livewire('oauth.oauth-app-manager')
+        </div>
+    </div>
+</x-app-layout>

--- a/stubs/livewire/resources/views/oauth/oauth-app-manager.blade.php
+++ b/stubs/livewire/resources/views/oauth/oauth-app-manager.blade.php
@@ -20,8 +20,8 @@
             <!-- Authorization Redirect URI -->
             <div class="col-span-6 sm:col-span-4">
                 <x-label for="redirect_uri" value="{{ __('Authorization Redirect URI') }}" />
-                <x-input id="redirect_uri" type="url" class="mt-1 block w-full" wire:model="createOAuthAppForm.redirect_uri" autocomplete="off" />
-                <x-input-error for="redirect_uri" bag="createClient" class="mt-2" />
+                <x-input id="redirect_uri" type="url" class="mt-1 block w-full" wire:model="createOAuthAppForm.redirect_uris.0" autocomplete="off" />
+                <x-input-error for="redirect_uris" bag="createClient" class="mt-2" />
             </div>
 
             <!-- Confidential -->
@@ -183,8 +183,8 @@
                 <!-- Authorization Redirect URI -->
                 <div>
                     <x-label for="manage_redirect_uri" value="{{ __('Authorization Redirect URI') }}" />
-                    <x-input id="manage_redirect_uri" type="url" class="mt-1 block w-full" wire:model="updateOAuthAppForm.redirect_uri" autocomplete="off" />
-                    <x-input-error for="redirect_uri" class="mt-2" />
+                    <x-input id="manage_redirect_uri" type="url" class="mt-1 block w-full" wire:model="updateOAuthAppForm.redirect_uris.0" autocomplete="off" />
+                    <x-input-error for="redirect_uris" class="mt-2" />
                 </div>
             </div>
         </x-slot>

--- a/stubs/livewire/resources/views/oauth/oauth-app-manager.blade.php
+++ b/stubs/livewire/resources/views/oauth/oauth-app-manager.blade.php
@@ -1,0 +1,268 @@
+<div>
+    @if ($this->authorizedApps->isNotEmpty())
+        <!-- Manage Authorized Apps -->
+        <div class="mt-10 sm:mt-0">
+            <x-action-section>
+                <x-slot name="title">
+                    {{ __('Manage Authorized Apps') }}
+                </x-slot>
+
+                <x-slot name="description">
+                    {{ __('Keep track of your connections to third-party apps and services.') }}
+                </x-slot>
+
+                <!-- Authorized App List -->
+                <x-slot name="content">
+                    <div class="space-y-6">
+                        @foreach ($this->authorizedApps as $id => $app)
+                            <div class="flex items-center justify-between" wire:key="{{ $id }}">
+                                <div>
+                                    <div>
+                                        {{ $app['client']->name }}
+                                    </div>
+                                    <div class="text-sm italic text-gray-500">
+                                        {{ implode(', ', $app['scopes']) }}
+                                    </div>
+                                </div>
+
+                                <div class="flex items-center ms-2">
+                                    <div class="text-sm text-gray-400">
+                                        {{ $app['tokens_count'] }} {{ __('Tokens') }}
+                                    </div>
+
+                                    <button class="cursor-pointer ms-6 text-sm text-red-500" wire:click="confirmAuthorizedAppRevocation('{{ $id }}')">
+                                        {{ __('Revoke') }}
+                                    </button>
+                                </div>
+                            </div>
+                        @endforeach
+                    </div>
+                </x-slot>
+            </x-action-section>
+        </div>
+
+        <x-section-border />
+    @endif
+
+    <!-- Register OAuth App -->
+    <x-form-section submit="createOAuthApp">
+        <x-slot name="title">
+            {{ __('Register OAuth App') }}
+        </x-slot>
+
+        <x-slot name="description">
+            {{ __('You may register an OAuth client to use our application\'s API.') }}
+        </x-slot>
+
+        <x-slot name="form">
+            <!-- App Name -->
+            <div class="col-span-6 sm:col-span-4">
+                <x-label for="name" value="{{ __('Application Name') }}" />
+                <x-input id="name" type="text" class="mt-1 block w-full" wire:model="createOAuthAppForm.name" autofocus autocomplete="off" />
+                <x-input-error for="name" bag="createClient" class="mt-2" />
+            </div>
+
+            <!-- Authorization Redirect URI -->
+            <div class="col-span-6 sm:col-span-4">
+                <x-label for="redirect_uri" value="{{ __('Authorization Redirect URI') }}" />
+                <x-input id="redirect_uri" type="url" class="mt-1 block w-full" wire:model="createOAuthAppForm.redirect_uri" autocomplete="off" />
+                <x-input-error for="redirect_uri" bag="createClient" class="mt-2" />
+            </div>
+
+            <!-- Confidential -->
+            <div class="col-span-6 sm:col-span-4">
+                <label for="confidential" class="flex items-center">
+                    <x-checkbox id="confidential" name="confidential" wire:model="createOAuthAppForm.confidential" />
+                    <span class="ms-2 font-medium text-sm text-gray-700 dark:text-gray-400">{{ __('Confidential') }}</span>
+                </label>
+                <x-input-error for="confidential" bag="createClient" class="mt-2" />
+            </div>
+        </x-slot>
+
+        <x-slot name="actions">
+            <x-action-message class="me-3" on="oauth-app-created">
+                {{ __('Registered.') }}
+            </x-action-message>
+
+            <x-button>
+                {{ __('Register') }}
+            </x-button>
+        </x-slot>
+    </x-form-section>
+
+    @if ($this->oauthApps->isNotEmpty())
+        <x-section-border />
+
+        <!-- Manage OAuth Apps -->
+        <div class="mt-10 sm:mt-0">
+            <x-action-section>
+                <x-slot name="title">
+                    {{ __('Manage OAuth Apps') }}
+                </x-slot>
+
+                <x-slot name="description">
+                    {{ __('You may delete any of your existing registered apps if they are no longer needed.') }}
+                </x-slot>
+
+                <!-- OAuth App List -->
+                <x-slot name="content">
+                    <div class="space-y-6">
+                        @foreach ($this->oauthApps as $app)
+                            <div class="flex items-center justify-between" wire:key="{{ $app->id }}">
+                                <div class="dark:text-white">
+                                    {{ $app->name }}
+                                    <span class="text-sm italic text-gray-400">
+                                        &ndash; {{ $app->confidential() ? __('Confidential') : __('Public') }}
+                                    </span>
+                                </div>
+
+                                <div class="flex items-center ms-2">
+                                    <div class="text-sm text-gray-400">
+                                        {{ __('Created at') }} {{ $app->created_at->toFormattedDateString() }}
+                                    </div>
+
+                                    <button class="cursor-pointer ms-6 text-sm text-gray-400 underline" wire:click="manageOAuthApp('{{ $app->id }}')">
+                                        {{ __('Manage') }}
+                                    </button>
+
+                                    <button class="cursor-pointer ms-6 text-sm text-red-500" wire:click="confirmOAuthAppDeletion('{{ $app->id }}')">
+                                        {{ __('Delete') }}
+                                    </button>
+                                </div>
+                            </div>
+                        @endforeach
+                    </div>
+                </x-slot>
+            </x-action-section>
+        </div>
+    @endif
+
+    <!-- Client Credentials Modal -->
+    <x-dialog-modal wire:model.live="displayingClientCredentials">
+        <x-slot name="title">
+            {{ __('Client Credentials') }}
+        </x-slot>
+
+        <x-slot name="content">
+            <div class="grid grid-cols-1 gap-4">
+                <div>
+                    {{ __('Please copy your new client credentials.') }}
+
+                    @if ($clientCredentials['secret'])
+                        {{ __('For your security, client secret won\'t be shown again.') }}
+                    @endif
+                </div>
+
+                <div>
+                    <x-label for="client_id" value="{{ __('Client ID') }}" />
+                    <x-input x-ref="clientIdField" id="client_id" type="text" readonly :value="$clientCredentials['id']"
+                             class="mt-1 bg-gray-100 px-4 py-2 rounded font-mono text-sm text-gray-500 w-full break-all"
+                             autofocus autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"
+                             @client-credentials-displayed.window="setTimeout(() => $refs.clientIdField.select(), 250)"
+                    />
+                </div>
+
+                @if ($clientCredentials['secret'])
+                    <div>
+                        <x-label for="client_secret" value="{{ __('Client Secret') }}" />
+                        <x-input id="client_secret" type="text" readonly :value="$clientCredentials['secret']"
+                                 class="mt-1 bg-gray-100 px-4 py-2 rounded font-mono text-sm text-gray-500 w-full break-all"
+                                 autofocus autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"
+                        />
+                    </div>
+                @endif
+            </div>
+        </x-slot>
+
+        <x-slot name="footer">
+            <x-secondary-button wire:click="$set('displayingClientCredentials', false)" wire:loading.attr="disabled">
+                {{ __('Close') }}
+            </x-secondary-button>
+        </x-slot>
+    </x-dialog-modal>
+
+    <!-- Delete OAuth App Confirmation Modal -->
+    <x-confirmation-modal wire:model.live="confirmingOAuthAppDeletion">
+        <x-slot name="title">
+            {{ __('Delete OAuth App') }}
+        </x-slot>
+
+        <x-slot name="content">
+            {{ __('Are you sure you would like to delete this app?') }}
+        </x-slot>
+
+        <x-slot name="footer">
+            <x-secondary-button wire:click="$toggle('confirmingOAuthAppDeletion')" wire:loading.attr="disabled">
+                {{ __('Cancel') }}
+            </x-secondary-button>
+
+            <x-danger-button class="ms-3" wire:click="deleteOAuthApp" wire:loading.attr="disabled">
+                {{ __('Delete') }}
+            </x-danger-button>
+        </x-slot>
+    </x-confirmation-modal>
+
+    <!-- OAuth App Management Modal -->
+    <x-dialog-modal wire:model.live="managingOAuthApp">
+        <x-slot name="title">
+            {{ __('OAuth App Management') }}
+        </x-slot>
+
+        <x-slot name="content">
+            <div class="grid grid-cols-1 gap-4">
+                <!-- Client ID -->
+                <div>
+                    <x-label for="manage_client_id" value="{{ __('Client ID') }}" />
+                    <x-input id="manage_client_id" type="text" readonly :value="$oauthAppBeingManaged?->id"
+                             class="mt-1 bg-gray-100 px-4 py-2 rounded font-mono text-sm text-gray-500 w-full break-all"
+                    />
+                </div>
+
+                <!-- App Name -->
+                <div>
+                    <x-label for="manage_name" value="{{ __('Application Name') }}" />
+                    <x-input id="manage_name" type="text" class="mt-1 block w-full" wire:model="updateOAuthAppForm.name" autocomplete="off" />
+                    <x-input-error for="name" class="mt-2" />
+                </div>
+
+                <!-- Authorization Redirect URI -->
+                <div>
+                    <x-label for="manage_redirect_uri" value="{{ __('Authorization Redirect URI') }}" />
+                    <x-input id="manage_redirect_uri" type="url" class="mt-1 block w-full" wire:model="updateOAuthAppForm.redirect_uri" autocomplete="off" />
+                    <x-input-error for="redirect_uri" class="mt-2" />
+                </div>
+            </div>
+        </x-slot>
+
+        <x-slot name="footer">
+            <x-secondary-button wire:click="$set('managingOAuthApp', false)" wire:loading.attr="disabled">
+                {{ __('Cancel') }}
+            </x-secondary-button>
+
+            <x-button class="ms-3" wire:click="updateOAuthApp" wire:loading.attr="disabled">
+                {{ __('Save') }}
+            </x-button>
+        </x-slot>
+    </x-dialog-modal>
+
+    <!-- Revoke Authorized App Confirmation Modal -->
+    <x-confirmation-modal wire:model.live="confirmingAuthorizedAppRevocation">
+        <x-slot name="title">
+            {{ __('Revoke Authorized App') }}
+        </x-slot>
+
+        <x-slot name="content">
+            {{ __('Are you sure you would like to revoke this app?') }}
+        </x-slot>
+
+        <x-slot name="footer">
+            <x-secondary-button wire:click="$toggle('confirmingAuthorizedAppRevocation')" wire:loading.attr="disabled">
+                {{ __('Cancel') }}
+            </x-secondary-button>
+
+            <x-danger-button class="ms-3" wire:click="revokeAuthorizedApp" wire:loading.attr="disabled">
+                {{ __('Revoke') }}
+            </x-danger-button>
+        </x-slot>
+    </x-confirmation-modal>
+</div>

--- a/stubs/livewire/resources/views/oauth/oauth-app-manager.blade.php
+++ b/stubs/livewire/resources/views/oauth/oauth-app-manager.blade.php
@@ -1,49 +1,4 @@
 <div>
-    @if ($this->authorizedApps->isNotEmpty())
-        <!-- Manage Authorized Apps -->
-        <div class="mt-10 sm:mt-0">
-            <x-action-section>
-                <x-slot name="title">
-                    {{ __('Manage Authorized Apps') }}
-                </x-slot>
-
-                <x-slot name="description">
-                    {{ __('Keep track of your connections to third-party apps and services.') }}
-                </x-slot>
-
-                <!-- Authorized App List -->
-                <x-slot name="content">
-                    <div class="space-y-6">
-                        @foreach ($this->authorizedApps as $id => $app)
-                            <div class="flex items-center justify-between" wire:key="{{ $id }}">
-                                <div>
-                                    <div>
-                                        {{ $app['client']->name }}
-                                    </div>
-                                    <div class="text-sm italic text-gray-500">
-                                        {{ implode(', ', $app['scopes']) }}
-                                    </div>
-                                </div>
-
-                                <div class="flex items-center ms-2">
-                                    <div class="text-sm text-gray-400">
-                                        {{ $app['tokens_count'] }} {{ __('Tokens') }}
-                                    </div>
-
-                                    <button class="cursor-pointer ms-6 text-sm text-red-500" wire:click="confirmAuthorizedAppRevocation('{{ $id }}')">
-                                        {{ __('Revoke') }}
-                                    </button>
-                                </div>
-                            </div>
-                        @endforeach
-                    </div>
-                </x-slot>
-            </x-action-section>
-        </div>
-
-        <x-section-border />
-    @endif
-
     <!-- Register OAuth App -->
     <x-form-section submit="createOAuthApp">
         <x-slot name="title">
@@ -80,7 +35,7 @@
         </x-slot>
 
         <x-slot name="actions">
-            <x-action-message class="me-3" on="oauth-app-created">
+            <x-action-message class="me-3" on="app-created">
                 {{ __('Registered.') }}
             </x-action-message>
 
@@ -90,7 +45,7 @@
         </x-slot>
     </x-form-section>
 
-    @if ($this->oauthApps->isNotEmpty())
+    @if ($this->apps->isNotEmpty())
         <x-section-border />
 
         <!-- Manage OAuth Apps -->
@@ -107,7 +62,7 @@
                 <!-- OAuth App List -->
                 <x-slot name="content">
                     <div class="space-y-6">
-                        @foreach ($this->oauthApps as $app)
+                        @foreach ($this->apps as $app)
                             <div class="flex items-center justify-between" wire:key="{{ $app->id }}">
                                 <div class="dark:text-white">
                                     {{ $app->name }}
@@ -244,25 +199,4 @@
             </x-button>
         </x-slot>
     </x-dialog-modal>
-
-    <!-- Revoke Authorized App Confirmation Modal -->
-    <x-confirmation-modal wire:model.live="confirmingAuthorizedAppRevocation">
-        <x-slot name="title">
-            {{ __('Revoke Authorized App') }}
-        </x-slot>
-
-        <x-slot name="content">
-            {{ __('Are you sure you would like to revoke this app?') }}
-        </x-slot>
-
-        <x-slot name="footer">
-            <x-secondary-button wire:click="$toggle('confirmingAuthorizedAppRevocation')" wire:loading.attr="disabled">
-                {{ __('Cancel') }}
-            </x-secondary-button>
-
-            <x-danger-button class="ms-3" wire:click="revokeAuthorizedApp" wire:loading.attr="disabled">
-                {{ __('Revoke') }}
-            </x-danger-button>
-        </x-slot>
-    </x-confirmation-modal>
 </div>

--- a/stubs/livewire/resources/views/oauth/oauth-connection-manager.blade.php
+++ b/stubs/livewire/resources/views/oauth/oauth-connection-manager.blade.php
@@ -14,8 +14,8 @@
                 <!-- OAuth Connection List -->
                 <x-slot name="content">
                     <div class="space-y-6">
-                        @foreach ($this->connections as $id => $connection)
-                            <div class="flex items-center justify-between" wire:key="{{ $id }}">
+                        @foreach ($this->connections as $connection)
+                            <div class="flex items-center justify-between" wire:key="{{ $connection['client']->id }}">
                                 <div>
                                     <div>
                                         {{ $connection['client']->name }}
@@ -30,7 +30,7 @@
                                         {{ $connection['tokens_count'] }} {{ __('Tokens') }}
                                     </div>
 
-                                    <button class="cursor-pointer ms-6 text-sm text-red-500" wire:click="confirmConnectionDeletion('{{ $id }}')">
+                                    <button class="cursor-pointer ms-6 text-sm text-red-500" wire:click="confirmConnectionDeletion('{{ $connection['client']->id }}')">
                                         {{ __('Delete') }}
                                     </button>
                                 </div>

--- a/stubs/livewire/resources/views/oauth/oauth-connection-manager.blade.php
+++ b/stubs/livewire/resources/views/oauth/oauth-connection-manager.blade.php
@@ -1,5 +1,5 @@
 <div>
-    @if ($this->authorizedApps->isNotEmpty())
+    @if ($this->connections->isNotEmpty())
         <!-- Manage OAuth Connections -->
         <div class="mt-10 sm:mt-0">
             <x-action-section>

--- a/stubs/livewire/resources/views/oauth/oauth-connection-manager.blade.php
+++ b/stubs/livewire/resources/views/oauth/oauth-connection-manager.blade.php
@@ -1,0 +1,67 @@
+<div>
+    @if ($this->authorizedApps->isNotEmpty())
+        <!-- Manage OAuth Connections -->
+        <div class="mt-10 sm:mt-0">
+            <x-action-section>
+                <x-slot name="title">
+                    {{ __('Manage Authorized Apps') }}
+                </x-slot>
+
+                <x-slot name="description">
+                    {{ __('Keep track of your connections with third-party apps and services. You may delete the access you\'ve given to any of your existing authorized apps if they are no longer needed.') }}
+                </x-slot>
+
+                <!-- OAuth Connection List -->
+                <x-slot name="content">
+                    <div class="space-y-6">
+                        @foreach ($this->connections as $id => $connection)
+                            <div class="flex items-center justify-between" wire:key="{{ $id }}">
+                                <div>
+                                    <div>
+                                        {{ $connection['client']->name }}
+                                    </div>
+                                    <div class="text-sm italic text-gray-500">
+                                        {{ implode(', ', $connection['scopes']) }}
+                                    </div>
+                                </div>
+
+                                <div class="flex items-center ms-2">
+                                    <div class="text-sm text-gray-400">
+                                        {{ $connection['tokens_count'] }} {{ __('Tokens') }}
+                                    </div>
+
+                                    <button class="cursor-pointer ms-6 text-sm text-red-500" wire:click="confirmConnectionDeletion('{{ $id }}')">
+                                        {{ __('Delete') }}
+                                    </button>
+                                </div>
+                            </div>
+                        @endforeach
+                    </div>
+                </x-slot>
+            </x-action-section>
+        </div>
+
+        <x-section-border />
+    @endif
+
+    <!-- Delete OAuth Connection Confirmation Modal -->
+    <x-confirmation-modal wire:model.live="confirmingConnectionDeletion">
+        <x-slot name="title">
+            {{ __('Delete OAuth Connection') }}
+        </x-slot>
+
+        <x-slot name="content">
+            {{ __('Are you sure you would like to delete all connections you have with this app?') }}
+        </x-slot>
+
+        <x-slot name="footer">
+            <x-secondary-button wire:click="$toggle('confirmingConnectionDeletion')" wire:loading.attr="disabled">
+                {{ __('Cancel') }}
+            </x-secondary-button>
+
+            <x-danger-button class="ms-3" wire:click="deleteConnection" wire:loading.attr="disabled">
+                {{ __('Delete') }}
+            </x-danger-button>
+        </x-slot>
+    </x-confirmation-modal>
+</div>

--- a/stubs/livewire/resources/views/passport-api/api-token-manager.blade.php
+++ b/stubs/livewire/resources/views/passport-api/api-token-manager.blade.php
@@ -58,7 +58,7 @@
                 </x-slot>
 
                 <x-slot name="description">
-                    {{ __('You may revoke any of your existing personal access tokens if they are no longer needed.') }}
+                    {{ __('You may delete any of your existing personal access tokens if they are no longer needed.') }}
                 </x-slot>
 
                 <!-- API Token List -->
@@ -85,7 +85,7 @@
                                     </div>
 
                                     <button class="cursor-pointer ms-6 text-sm text-red-500" wire:click="confirmApiTokenDeletion('{{ $token->id }}')">
-                                        {{ __('Revoke') }}
+                                        {{ __('Delete') }}
                                     </button>
                                 </div>
                             </div>
@@ -121,14 +121,14 @@
         </x-slot>
     </x-dialog-modal>
 
-    <!-- Revoke Token Confirmation Modal -->
+    <!-- Delete Token Confirmation Modal -->
     <x-confirmation-modal wire:model.live="confirmingApiTokenDeletion">
         <x-slot name="title">
-            {{ __('Revoke API Token') }}
+            {{ __('Delete API Token') }}
         </x-slot>
 
         <x-slot name="content">
-            {{ __('Are you sure you would like to revoke this API token?') }}
+            {{ __('Are you sure you would like to delete this API token?') }}
         </x-slot>
 
         <x-slot name="footer">
@@ -137,7 +137,7 @@
             </x-secondary-button>
 
             <x-danger-button class="ms-3" wire:click="deleteApiToken" wire:loading.attr="disabled">
-                {{ __('Revoke') }}
+                {{ __('Delete') }}
             </x-danger-button>
         </x-slot>
     </x-confirmation-modal>

--- a/stubs/livewire/resources/views/passport-api/api-token-manager.blade.php
+++ b/stubs/livewire/resources/views/passport-api/api-token-manager.blade.php
@@ -1,0 +1,144 @@
+<div>
+    <!-- Generate API Token -->
+    <x-form-section submit="createApiToken">
+        <x-slot name="title">
+            {{ __('Create API Token') }}
+        </x-slot>
+
+        <x-slot name="description">
+            {{ __('Personal access tokens allow secure authentication to our application\'s API for your personal use.') }}
+        </x-slot>
+
+        <x-slot name="form">
+            <!-- Token Name -->
+            <div class="col-span-6 sm:col-span-4">
+                <x-label for="name" value="{{ __('Token Name') }}" />
+                <x-input id="name" type="text" class="mt-1 block w-full" wire:model="createApiTokenForm.name" autofocus autocomplete="off" />
+                <x-input-error for="name" class="mt-2" />
+            </div>
+
+            <!-- Token Scopes -->
+            @if (count($scopes = Laravel\Passport\Passport::scopes()) > 0)
+                <div class="col-span-6">
+                    <fieldset>
+                        <legend class="block font-medium text-sm text-gray-700 dark:text-gray-300">{{ __('Scopes') }}</legend>
+
+                        <div class="mt-2 grid grid-cols-1 md:grid-cols-2 gap-4">
+                            @foreach ($scopes as $scope)
+                                <label class="flex items-center" wire:key="{{ $scope->id }}">
+                                    <x-checkbox wire:model="createApiTokenForm.scopes" :value="$scope->id"/>
+                                    <span class="ms-2 text-sm text-gray-600 dark:text-gray-400">{{ $scope->description }}</span>
+                                </label>
+                            @endforeach
+                        </div>
+                    </fieldset>
+                </div>
+            @endif
+        </x-slot>
+
+        <x-slot name="actions">
+            <x-action-message class="me-3" on="token-created">
+                {{ __('Created.') }}
+            </x-action-message>
+
+            <x-button>
+                {{ __('Create') }}
+            </x-button>
+        </x-slot>
+    </x-form-section>
+
+    @if ($this->tokens->isNotEmpty())
+        <x-section-border />
+
+        <!-- Manage API Tokens -->
+        <div class="mt-10 sm:mt-0">
+            <x-action-section>
+                <x-slot name="title">
+                    {{ __('Manage API Tokens') }}
+                </x-slot>
+
+                <x-slot name="description">
+                    {{ __('You may revoke any of your existing personal access tokens if they are no longer needed.') }}
+                </x-slot>
+
+                <!-- API Token List -->
+                <x-slot name="content">
+                    <div class="space-y-6">
+                        @foreach ($this->tokens as $token)
+                            <div class="flex items-center justify-between" wire:key="{{ $token->id }}">
+                                <div>
+                                    <div class="dark:text-white">
+                                        {{ $token->name }}
+                                    </div>
+                                    <div class="text-sm italic text-gray-500">
+                                        {{ implode(', ', $token->scopes) }}
+                                    </div>
+                                </div>
+
+                                <div class="flex items-center ms-2">
+                                    <div class="text-sm text-gray-400">
+                                        {{ __('Issued') }} {{ $token->created_at->diffForHumans() }}
+                                    </div>
+
+                                    <div class="ms-6 text-sm text-gray-400">
+                                        {{ __('Expires in') }} {{ $token->expires_at->longAbsoluteDiffForHumans() }}
+                                    </div>
+
+                                    <button class="cursor-pointer ms-6 text-sm text-red-500" wire:click="confirmApiTokenDeletion('{{ $token->id }}')">
+                                        {{ __('Revoke') }}
+                                    </button>
+                                </div>
+                            </div>
+                        @endforeach
+                    </div>
+                </x-slot>
+            </x-action-section>
+        </div>
+    @endif
+
+    <!-- Token Value Modal -->
+    <x-dialog-modal wire:model.live="displayingToken">
+        <x-slot name="title">
+            {{ __('Personal Access Token') }}
+        </x-slot>
+
+        <x-slot name="content">
+            <div>
+                {{ __('Please copy your new personal access token. For your security, it won\'t be shown again.') }}
+            </div>
+
+            <x-input x-ref="tokenField" id="token" type="text" readonly :value="$tokenValue"
+                     class="mt-4 bg-gray-100 px-4 py-2 rounded font-mono text-sm text-gray-500 w-full break-all"
+                     autofocus autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"
+                     @token-displayed.window="setTimeout(() => $refs.tokenField.select(), 250)"
+            />
+        </x-slot>
+
+        <x-slot name="footer">
+            <x-secondary-button wire:click="$set('displayingToken', false)" wire:loading.attr="disabled">
+                {{ __('Close') }}
+            </x-secondary-button>
+        </x-slot>
+    </x-dialog-modal>
+
+    <!-- Revoke Token Confirmation Modal -->
+    <x-confirmation-modal wire:model.live="confirmingApiTokenDeletion">
+        <x-slot name="title">
+            {{ __('Revoke API Token') }}
+        </x-slot>
+
+        <x-slot name="content">
+            {{ __('Are you sure you would like to revoke this API token?') }}
+        </x-slot>
+
+        <x-slot name="footer">
+            <x-secondary-button wire:click="$toggle('confirmingApiTokenDeletion')" wire:loading.attr="disabled">
+                {{ __('Cancel') }}
+            </x-secondary-button>
+
+            <x-danger-button class="ms-3" wire:click="deleteApiToken" wire:loading.attr="disabled">
+                {{ __('Revoke') }}
+            </x-danger-button>
+        </x-slot>
+    </x-confirmation-modal>
+</div>

--- a/stubs/livewire/resources/views/passport-api/index.blade.php
+++ b/stubs/livewire/resources/views/passport-api/index.blade.php
@@ -1,0 +1,13 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            {{ __('API Tokens') }}
+        </h2>
+    </x-slot>
+
+    <div>
+        <div class="max-w-7xl mx-auto py-10 sm:px-6 lg:px-8">
+            @livewire('api.api-token-manager')
+        </div>
+    </div>
+</x-app-layout>


### PR DESCRIPTION
- [x] Requires laravel/passport#1771
- [x] Requires laravel/framework#55621

## Todo
* Add description for confidential checkbox.
* Add "enable device flow" checkbox.
* Fix Passport version on composer.json.
* Add tests stubs.

## Features
* First-party integration with [Laravel Passport](https://laravel.com/docs/passport).
* New OAuth option during installation: `jetstream:install --api --oauth`
* Support for both Jetstream's stacks: Inertia and Livewire.
* Manage API tokens (PATs) via Passport: list, add, and delete.
* New OAuth Features:
  * Manage OAuth connections with third-party apps and services: list and delete connections.
  * Manage OAuth apps: list, add, update, and delete apps. 
  * Fully customizable: you may easily add [more client metadata](https://www.rfc-editor.org/rfc/rfc7591.html#:~:text=logo_uri%0A%20%20%20%20%20%20URL%20string,Section%202.2.), e.g. Application logo
* Authorize View (for auth code and implicit grants)
* Device Views (for device auth grant)

## OAuth Apps

![oauth-apps](https://github.com/user-attachments/assets/86bc0742-ec30-4b28-89d6-40d6054e1072)

## API Tokens

![passport-api-tokens](https://github.com/user-attachments/assets/4986ecf9-231e-4b6c-abe0-da6d781ac17a)

## Authorize View

![laravel-jetstream](https://github.com/laravel/passport/assets/56585913/db38f169-916a-4216-84f9-057914040a6a)