### PR TITLE
allUsers may error if owner is null

### DIFF
--- a/src/Contracts/AddsTeamMembers.php
+++ b/src/Contracts/AddsTeamMembers.php
@@ -3,7 +3,7 @@
 namespace Laravel\Jetstream\Contracts;
 
 /**
- * @method void add(\Illuminate\Foundation\Auth\User $user, \Illuminate\Database\Eloquent\Model $team, string $email, string $role = null)
+ * @method void add(\Illuminate\Foundation\Auth\User|null $user, \Illuminate\Database\Eloquent\Model $team, string $email, string $role = null)
  */
 interface AddsTeamMembers
 {

--- a/src/Team.php
+++ b/src/Team.php
@@ -23,7 +23,7 @@ abstract class Team extends Model
      */
     public function allUsers()
     {
-        return $this->owner ? 
+        return $this->owner ?
             $this->users->merge([$this->owner]) :
             $this->users;
     }

--- a/src/Team.php
+++ b/src/Team.php
@@ -23,7 +23,9 @@ abstract class Team extends Model
      */
     public function allUsers()
     {
-        return $this->users->merge([$this->owner]);
+        return $this->owner ? 
+            $this->users->merge([$this->owner]) :
+            $this->users;
     }
 
     /**

--- a/stubs/app/Actions/Jetstream/AddTeamMember.php
+++ b/stubs/app/Actions/Jetstream/AddTeamMember.php
@@ -18,9 +18,11 @@ class AddTeamMember implements AddsTeamMembers
     /**
      * Add a new team member to the given team.
      */
-    public function add(User $user, Team $team, string $email, ?string $role = null): void
+    public function add(?User $user, Team $team, string $email, ?string $role = null): void
     {
-        Gate::forUser($user)->authorize('addTeamMember', $team);
+        if ($user) {
+            Gate::forUser($user)->authorize('addTeamMember', $team);
+        }
 
         $this->validate($team, $email, $role);
 


### PR DESCRIPTION
`Team->allUsers()` may error out, if `$this->owner` is `null`. This may happen if user was deleted (team owner has no foreign index ), meaning user referenced in `user_id` column will not exist in `users` table, thus returning null. In this case `$this->users->merge([null])` which errors.

On further work on my features I found more issues, for example when adding team members, the owner is expected in the stub `AddTeamMember`, I believe it should be possible to add team members to a team without owner (for example in my case I have Admin users).
