### PR TITLE
Internationalize role names and descriptions

### DIFF
--- a/stubs/app/Providers/JetstreamWithTeamsServiceProvider.php
+++ b/stubs/app/Providers/JetstreamWithTeamsServiceProvider.php
@@ -45,17 +45,17 @@ class JetstreamServiceProvider extends ServiceProvider
     {
         Jetstream::defaultApiTokenPermissions(['read']);
 
-        Jetstream::role('admin', 'Administrator', [
+        Jetstream::role('admin', __('Administrator'), [
             'create',
             'read',
             'update',
             'delete',
-        ])->description('Administrator users can perform any action.');
+        ])->description(__('Administrator users can perform any action.'));
 
-        Jetstream::role('editor', 'Editor', [
+        Jetstream::role('editor', __('Editor'), [
             'read',
             'create',
             'update',
-        ])->description('Editor users have the ability to read, create, and update.');
+        ])->description(__('Editor users have the ability to read, create, and update.'));
     }
 }


### PR DESCRIPTION
Updated the Jetstream roles to use localization functions for role names and descriptions, enhancing the application’s support for multiple languages. This change ensures that role information is consistent with localized content across the application.