### PR TITLE
[11.x] Run `composer require` with `--update-with-dependencies` 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,7 +70,7 @@ jobs:
           composer config repositories.jetstream '{"type": "path", "url": "jetstream"}' --file composer.json
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: 'jetstream'
 

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     "require": {
         "php": "^8.2.0",
         "ext-json": "*",
-        "illuminate/console": "^11.25",
-        "illuminate/support": "^11.25",
+        "illuminate/console": "^11.0",
+        "illuminate/support": "^11.0",
         "laravel/fortify": "^1.20",
         "mobiledetect/mobiledetectlib": "^4.8",
         "symfony/console": "^7.0"

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     "require": {
         "php": "^8.2.0",
         "ext-json": "*",
-        "illuminate/console": "^11.0",
-        "illuminate/support": "^11.0",
+        "illuminate/console": "^11.25",
+        "illuminate/support": "^11.25",
         "laravel/fortify": "^1.20",
         "mobiledetect/mobiledetectlib": "^4.8",
         "symfony/console": "^7.0"

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -17,7 +17,6 @@ use Symfony\Component\Finder\Finder;
 use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
 
-use function Illuminate\Support\php_binary;
 use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\multiselect;
 use function Laravel\Prompts\select;
@@ -398,7 +397,7 @@ EOF;
 
         // Middleware...
         (new Filesystem)->ensureDirectoryExists(app_path('Http/Middleware'));
-        (new Process([php_binary(), 'artisan', 'inertia:middleware', 'HandleInertiaRequests', '--force'], base_path()))
+        (new Process([$this->phpBinary(), 'artisan', 'inertia:middleware', 'HandleInertiaRequests', '--force'], base_path()))
             ->setTimeout(null)
             ->run(function ($type, $output) {
                 $this->output->write($output);
@@ -657,13 +656,13 @@ EOF;
         $composer = $this->option('composer');
 
         if ($composer !== 'global') {
-            $command = [php_binary(), $composer, 'require'];
+            $command = [$this->phpBinary(), $composer, 'require'];
         }
 
         $command = array_merge(
             $command ?? ['composer', 'require'],
             is_array($packages) ? $packages : func_get_args(),
-            ['--update-with-dependencies'],
+            ['--update-with-dependencies']
         );
 
         return ! (new Process($command, base_path(), ['COMPOSER_MEMORY_LIMIT' => '-1']))
@@ -684,7 +683,7 @@ EOF;
         $composer = $this->option('composer');
 
         if ($composer !== 'global') {
-            $command = [php_binary(), $composer, 'remove', '--dev'];
+            $command = [$this->phpBinary(), $composer, 'remove', '--dev'];
         }
 
         $command = array_merge(
@@ -710,7 +709,7 @@ EOF;
         $composer = $this->option('composer');
 
         if ($composer !== 'global') {
-            $command = [php_binary(), $composer, 'require', '--dev'];
+            $command = [$this->phpBinary(), $composer, 'require', '--dev'];
         }
 
         $command = array_merge(
@@ -763,7 +762,7 @@ EOF;
     protected function runDatabaseMigrations()
     {
         if (confirm('New database migrations were added. Would you like to re-run your migrations?', true)) {
-            (new Process([php_binary(), 'artisan', 'migrate:fresh', '--force'], base_path()))
+            (new Process([$this->phpBinary(), 'artisan', 'migrate:fresh', '--force'], base_path()))
                 ->setTimeout(null)
                 ->run(function ($type, $output) {
                     $this->output->write($output);
@@ -795,6 +794,16 @@ EOF;
         foreach ($finder as $file) {
             file_put_contents($file->getPathname(), preg_replace('/\sdark:[^\s"\']+/', '', $file->getContents()));
         }
+    }
+
+    /**
+     * Get the path to the appropriate PHP binary.
+     *
+     * @return string
+     */
+    protected function phpBinary()
+    {
+        return (new PhpExecutableFinder())->find(false) ?: 'php';
     }
 
     /**

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -17,6 +17,7 @@ use Symfony\Component\Finder\Finder;
 use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
 
+use function Illuminate\Support\php_binary;
 use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\multiselect;
 use function Laravel\Prompts\select;
@@ -397,7 +398,7 @@ EOF;
 
         // Middleware...
         (new Filesystem)->ensureDirectoryExists(app_path('Http/Middleware'));
-        (new Process([$this->phpBinary(), 'artisan', 'inertia:middleware', 'HandleInertiaRequests', '--force'], base_path()))
+        (new Process([php_binary(), 'artisan', 'inertia:middleware', 'HandleInertiaRequests', '--force'], base_path()))
             ->setTimeout(null)
             ->run(function ($type, $output) {
                 $this->output->write($output);
@@ -656,12 +657,13 @@ EOF;
         $composer = $this->option('composer');
 
         if ($composer !== 'global') {
-            $command = [$this->phpBinary(), $composer, 'require'];
+            $command = [php_binary(), $composer, 'require'];
         }
 
         $command = array_merge(
             $command ?? ['composer', 'require'],
-            is_array($packages) ? $packages : func_get_args()
+            is_array($packages) ? $packages : func_get_args(),
+            ['--update-with-dependencies'],
         );
 
         return ! (new Process($command, base_path(), ['COMPOSER_MEMORY_LIMIT' => '-1']))
@@ -682,7 +684,7 @@ EOF;
         $composer = $this->option('composer');
 
         if ($composer !== 'global') {
-            $command = [$this->phpBinary(), $composer, 'remove', '--dev'];
+            $command = [php_binary(), $composer, 'remove', '--dev'];
         }
 
         $command = array_merge(
@@ -708,7 +710,7 @@ EOF;
         $composer = $this->option('composer');
 
         if ($composer !== 'global') {
-            $command = [$this->phpBinary(), $composer, 'require', '--dev'];
+            $command = [php_binary(), $composer, 'require', '--dev'];
         }
 
         $command = array_merge(
@@ -761,7 +763,7 @@ EOF;
     protected function runDatabaseMigrations()
     {
         if (confirm('New database migrations were added. Would you like to re-run your migrations?', true)) {
-            (new Process([$this->phpBinary(), 'artisan', 'migrate:fresh', '--force'], base_path()))
+            (new Process([php_binary(), 'artisan', 'migrate:fresh', '--force'], base_path()))
                 ->setTimeout(null)
                 ->run(function ($type, $output) {
                     $this->output->write($output);
@@ -793,16 +795,6 @@ EOF;
         foreach ($finder as $file) {
             file_put_contents($file->getPathname(), preg_replace('/\sdark:[^\s"\']+/', '', $file->getContents()));
         }
-    }
-
-    /**
-     * Get the path to the appropriate PHP binary.
-     *
-     * @return string
-     */
-    protected function phpBinary()
-    {
-        return (new PhpExecutableFinder())->find(false) ?: 'php';
     }
 
     /**


### PR DESCRIPTION
fixes #1537

Latest Laravel installation will installs `laravel/prompts` 0.2.x while `livewire/livewire` isn't compatible with 0.2 at the moment causing the installation to fail.
