### PR TITLE
Have as=a for ResponsiveNavLink Component in Inertia

### DIFF
--- a/stubs/inertia/resources/js/Components/ResponsiveNavLink.vue
+++ b/stubs/inertia/resources/js/Components/ResponsiveNavLink.vue
@@ -21,6 +21,10 @@ const classes = computed(() => {
             <slot />
         </button>
 
+        <a v-else-if="as == 'a'" :class="classes" class="w-full text-start" :href="href">
+            <slot />
+        </a>
+
         <Link v-else :href="href" :class="classes">
             <slot />
         </Link>


### PR DESCRIPTION
This way,  as with **DropdownLink**, we can link to non inertia pages for example:

```js
<ResponsiveNavLink
    as="a"
    :href="route('filament.admin.pages.dashboard')">
    Admin Area
</ResponsiveNavLink>
```

Does not seem to impact the Livewire related component so I did not update that.

