### PR TITLE
Fix Text Alignment on Team Member Role Modal Descriptions

### DIFF
--- a/stubs/livewire/resources/views/teams/team-member-manager.blade.php
+++ b/stubs/livewire/resources/views/teams/team-member-manager.blade.php
@@ -196,7 +196,7 @@
                             </div>
 
                             <!-- Role Description -->
-                            <div class="mt-2 text-xs text-gray-600 dark:text-gray-400">
+                            <div class="mt-2 text-xs text-gray-600 text-start dark:text-gray-400">
                                 {{ $role->description }}
                             </div>
                         </div>


### PR DESCRIPTION
Simple fix to set the alignment of role descriptions on the role change modal, without this it may align to the center instead. Screenshots below:

Old:
![CleanShot 2024-11-07 at 10 54 23](https://github.com/user-attachments/assets/0e2e6732-3df2-4a6b-a1e3-bf7fdd156443)

New:
![CleanShot 2024-11-07 at 10 54 09](https://github.com/user-attachments/assets/68bebd5e-93d7-43c0-9255-bdd3ff227498)
