### PR TITLE
[5.x] Convert array to single line format

### DIFF
--- a/stubs/livewire/vite.config.js
+++ b/stubs/livewire/vite.config.js
@@ -4,10 +4,7 @@ import laravel from 'laravel-vite-plugin';
 export default defineConfig({
     plugins: [
         laravel({
-            input: [
-                'resources/css/app.css',
-                'resources/js/app.js',
-            ],
+            input: ['resources/css/app.css', 'resources/js/app.js'],
             refresh: true,
         }),
     ],


### PR DESCRIPTION
Similar to https://github.com/laravel/breeze/pull/436 to make Vite config consistent across starter kits. The change is not applicable to Inertia stack since there's only a single entry point for it and it deviates from the default Vite config from fresh Laravel installation.
