### PR TITLE
Update Profile Photo Accessor

### DIFF
--- a/src/HasProfilePhoto.php
+++ b/src/HasProfilePhoto.php
@@ -57,7 +57,7 @@ trait HasProfilePhoto
      *
      * @return \Illuminate\Database\Eloquent\Casts\Attribute
      */
-    public function profilePhotoUrl(): Attribute
+    protected function profilePhotoUrl(): Attribute
     {
         return Attribute::get(function (): string {
             return $this->profile_photo_path


### PR DESCRIPTION
Hi 👋🏽
This is a tiny change to fix issue with Larastan. [since accessor shouldn't be public](https://github.com/larastan/larastan/blob/526f6518cdc49b45b0ef08f78c6298d32ce64a66/src/Properties/ModelPropertyHelper.php#L176).
error, 
```
Property 'profile_photo_url' does not exist in model.  
         🪪  rules.modelAppends
```

more project info,
PHP v8.2
Laravel v11.34.2
Larastan v3.0.2 (level: 5)
Jetstream v5.3.3

----

Appreciate all the great work you guys been doing. 