### PR TITLE
Handling browser sessions in redis

### DIFF
--- a/src/Http/Controllers/Inertia/OtherBrowserSessionsController.php
+++ b/src/Http/Controllers/Inertia/OtherBrowserSessionsController.php
@@ -5,7 +5,9 @@ namespace Laravel\Jetstream\Http\Controllers\Inertia;
 use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Cookie;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Redis;
 use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Actions\ConfirmPassword;
 
@@ -32,7 +34,7 @@ class OtherBrowserSessionsController extends Controller
 
         $guard->logoutOtherDevices($request->password);
 
-        $this->deleteOtherSessionRecords($request);
+        $this->deleteOtherSessionRecords($request, $guard);
 
         return back(303);
     }
@@ -41,17 +43,46 @@ class OtherBrowserSessionsController extends Controller
      * Delete the other browser session records from storage.
      *
      * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Contracts\Auth\StatefulGuard  $guard
      * @return void
      */
-    protected function deleteOtherSessionRecords(Request $request)
+    protected function deleteOtherSessionRecords(Request $request, StatefulGuard $guard)
     {
-        if (config('session.driver') !== 'database') {
-            return;
+        $user = $request->user();
+
+        if (config('session.driver') === 'database') {
+            DB::connection(config('session.connection'))->table(config('session.table', 'sessions'))
+                ->where('user_id', $user->getAuthIdentifier())
+                ->where('id', '!=', $request->session()->getId())
+                ->delete();
         }
 
-        DB::connection(config('session.connection'))->table(config('session.table', 'sessions'))
-            ->where('user_id', $request->user()->getAuthIdentifier())
-            ->where('id', '!=', $request->session()->getId())
-            ->delete();
+        if (config('session.driver') === 'redis') {
+            $redis = Redis::connection();
+            $authKey = env('AUTH_REDIS_KEY', '_auth_redis_key_').$user->getAuthIdentifier();
+            $sessionKeys = $redis->lrange($authKey, 0, -1);
+            $currentSessionId = $request->session()->getId();
+
+            // Delete all user sessions except the current one
+            foreach ($sessionKeys as $key) {
+                $session = json_decode($key);
+                if ($session->id !== $currentSessionId) {
+                    $redis->del(config('cache.prefix').$session->id);
+                }
+            }
+
+            // Regenerate remember_token
+            $guard->logout();
+            $guard->login($user, Cookie::has($guard->getRecallerName()));
+
+            // Save current session
+            $redis->del($authKey);
+            $redis->rpush($authKey, json_encode([
+                'id' => $currentSessionId,
+                'last_activity' => now()->timestamp,
+                'ip_address' => $request->ip(),
+                'user_agent' => $request->userAgent(),
+            ]));
+        }
     }
 }

--- a/src/Http/Controllers/Inertia/UserProfileController.php
+++ b/src/Http/Controllers/Inertia/UserProfileController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Redis;
 use Laravel\Fortify\Features;
 use Laravel\Jetstream\Agent;
 use Laravel\Jetstream\Jetstream;
@@ -38,29 +39,48 @@ class UserProfileController extends Controller
      */
     public function sessions(Request $request)
     {
-        if (config('session.driver') !== 'database') {
-            return collect();
-        }
-
-        return collect(
-            DB::connection(config('session.connection'))->table(config('session.table', 'sessions'))
+        if (config('session.driver') === 'database') {
+            return collect(
+                DB::connection(config('session.connection'))->table(config('session.table', 'sessions'))
                     ->where('user_id', $request->user()->getAuthIdentifier())
                     ->orderBy('last_activity', 'desc')
                     ->get()
-        )->map(function ($session) use ($request) {
-            $agent = $this->createAgent($session);
+            )->map(function ($session) use ($request) {
+                return $this->prepareSession($request, $session);
+            });
+        }
 
-            return (object) [
-                'agent' => [
-                    'is_desktop' => $agent->isDesktop(),
-                    'platform' => $agent->platform(),
-                    'browser' => $agent->browser(),
-                ],
-                'ip_address' => $session->ip_address,
-                'is_current_device' => $session->id === $request->session()->getId(),
-                'last_active' => Carbon::createFromTimestamp($session->last_activity)->diffForHumans(),
-            ];
-        });
+        if (config('session.driver') === 'redis') {
+
+            $authKey = env('AUTH_REDIS_KEY', '_auth_redis_key_').$request->user()->getAuthIdentifier();
+
+            $redis = Redis::connection();
+            $sessions = $redis->lrange($authKey, 0, -1);
+
+            return collect($sessions)->map(function ($session) use ($request) {
+                $session = json_decode($session);
+
+                return $this->prepareSession($request, $session);
+            });
+        }
+
+        return collect();
+    }
+
+    public function prepareSession(Request $request, $session)
+    {
+        $agent = $this->createAgent($session);
+
+        return (object) [
+            'agent' => [
+                'is_desktop' => $agent->isDesktop(),
+                'platform' => $agent->platform(),
+                'browser' => $agent->browser(),
+            ],
+            'ip_address' => $session->ip_address,
+            'is_current_device' => $session->id === $request->session()->getId(),
+            'last_active' => Carbon::createFromTimestamp($session->last_activity)->diffForHumans(),
+        ];
     }
 
     /**

--- a/src/Http/Middleware/RedisSessionsMiddleware.php
+++ b/src/Http/Middleware/RedisSessionsMiddleware.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Laravel\Jetstream\Http\Middleware;
+
+use Closure;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Redis;
+
+class RedisSessionsMiddleware
+{
+    public function handle($request, Closure $next)
+    {
+        if (config('session.driver') !== 'redis') {
+            return $next($request);
+        }
+
+        [$currentSessionId, $userId] = $this->getSessionAndUserId($request);
+
+        // Process the request
+        $response = $next($request);
+
+        [$newSessionId, $newUserId] = $this->getSessionAndUserId($request);
+
+        // Use newUserId if it's not null
+        if ($newUserId !== null) {
+            $userId = $newUserId;
+        }
+
+        // Check if the session ID has changed
+        if ($currentSessionId !== $newSessionId && $userId) {
+            $this->updateUserSessions($userId, $currentSessionId, $newSessionId, $request);
+        }
+
+        return $response;
+    }
+
+    private function getSessionAndUserId($request)
+    {
+        if (Auth::check()) {
+            return [$request->session()->getId(), Auth::id()];
+        }
+
+        return [null, null];
+    }
+
+    private function updateUserSessions($userId, $currentSessionId, $newSessionId, $request)
+    {
+        $authKey = env('AUTH_REDIS_KEY', '_auth_redis_key_').$userId;
+
+        // Load current list of sessions
+        $sessions = Redis::lrange($authKey, 0, -1);
+
+        // Delete current list of sessions
+        Redis::del($authKey);
+
+        // Form a new list of sessions
+        foreach ($sessions as $session) {
+            $sessionData = json_decode($session, true);
+            if ($sessionData['id'] !== $currentSessionId) {
+                Redis::rpush($authKey, $session);
+            }
+        }
+
+        // Add new session
+        if ($newSessionId) {
+            Redis::rpush($authKey, json_encode([
+                'id' => $newSessionId,
+                'last_activity' => now()->timestamp,
+                'user_agent' => $request->userAgent(),
+                'ip_address' => $request->ip(),
+            ]));
+        }
+    }
+}

--- a/src/JetstreamServiceProvider.php
+++ b/src/JetstreamServiceProvider.php
@@ -25,6 +25,7 @@ use Laravel\Jetstream\Http\Livewire\TwoFactorAuthenticationForm;
 use Laravel\Jetstream\Http\Livewire\UpdatePasswordForm;
 use Laravel\Jetstream\Http\Livewire\UpdateProfileInformationForm;
 use Laravel\Jetstream\Http\Livewire\UpdateTeamNameForm;
+use Laravel\Jetstream\Http\Middleware\RedisSessionsMiddleware;
 use Laravel\Jetstream\Http\Middleware\ShareInertiaData;
 use Livewire\Livewire;
 
@@ -183,6 +184,7 @@ class JetstreamServiceProvider extends ServiceProvider
         $kernel = $this->app->make(Kernel::class);
 
         $kernel->appendMiddlewareToGroup('web', ShareInertiaData::class);
+        $kernel->appendMiddlewareToGroup('web', RedisSessionsMiddleware::class);
         $kernel->appendToMiddlewarePriority(ShareInertiaData::class);
 
         if (class_exists(HandleInertiaRequests::class)) {


### PR DESCRIPTION
This update allows managing browser sessions even when using Redis for session storage. It doesn't change existing functionality but adds new capabilities.

Moreover, it works correctly with the remember_me flag by ending all sessions on other devices except the current one.

The principle is simple: sessions are stored as usual, but we also save session IDs and other parameters in Redis for every user. This allows us to quickly find and end all active user sessions if needed.

The benefit of this update is confirmed by numerous requests for this improvement
[https://github.com/laravel/jetstream/issues/350](https://github.com/laravel/jetstream/issues/350) 
[https://github.com/laravel/jetstream/issues/1270](https://github.com/laravel/jetstream/issues/1270)  
