### PR TITLE
Add prefix to routes

### DIFF
--- a/config/jetstream.php
+++ b/config/jetstream.php
@@ -7,4 +7,5 @@ return [
     'middleware' => ['web'],
     'features' => [Features::accountDeletion()],
     'profile_photo_disk' => 'public',
+    'prefix' => '',
 ];

--- a/routes/inertia.php
+++ b/routes/inertia.php
@@ -14,7 +14,7 @@ use Laravel\Jetstream\Http\Controllers\Inertia\UserProfileController;
 use Laravel\Jetstream\Http\Controllers\TeamInvitationController;
 use Laravel\Jetstream\Jetstream;
 
-Route::group(['middleware' => config('jetstream.middleware', ['web'])], function () {
+Route::group(['middleware' => config('jetstream.middleware', ['web']), 'prefix' => config('jetstream.prefix', '')], function () {
     if (Jetstream::hasTermsAndPrivacyPolicyFeature()) {
         Route::get('/terms-of-service', [TermsOfServiceController::class, 'show'])->name('terms.show');
         Route::get('/privacy-policy', [PrivacyPolicyController::class, 'show'])->name('policy.show');

--- a/routes/livewire.php
+++ b/routes/livewire.php
@@ -10,7 +10,7 @@ use Laravel\Jetstream\Http\Controllers\Livewire\UserProfileController;
 use Laravel\Jetstream\Http\Controllers\TeamInvitationController;
 use Laravel\Jetstream\Jetstream;
 
-Route::group(['middleware' => config('jetstream.middleware', ['web'])], function () {
+Route::group(['middleware' => config('jetstream.middleware', ['web']), 'prefix' => config('jetstream.prefix', '')], function () {
     if (Jetstream::hasTermsAndPrivacyPolicyFeature()) {
         Route::get('/terms-of-service', [TermsOfServiceController::class, 'show'])->name('terms.show');
         Route::get('/privacy-policy', [PrivacyPolicyController::class, 'show'])->name('policy.show');

--- a/stubs/config/jetstream.php
+++ b/stubs/config/jetstream.php
@@ -33,6 +33,8 @@ return [
 
     'auth_session' => AuthenticateSession::class,
 
+    'prefix' => '',
+
     /*
     |--------------------------------------------------------------------------
     | Jetstream Guard


### PR DESCRIPTION
This pull request introduces a new configuration option for setting a route prefix in Jetstream. The changes ensure that the prefix can be configured and applied consistently across different route files.

Configuration changes:

* [`config/jetstream.php`](diffhunk://#diff-f5342b1c9f71250ab049b8975c52a48af5984fb8ed8671258f6947b89c52ae66R10): Added a new `'prefix'` configuration option with a default value of an empty string.
* [`stubs/config/jetstream.php`](diffhunk://#diff-ab0cf39b6e3614fffa83df14f7ed6acffcea7a84bb18a33d6f51ac8f1a882db2R36-R37): Added the `'prefix'` option to the configuration stub file.

Route changes:

* [`routes/inertia.php`](diffhunk://#diff-751292d7e9936dfa3b4ab72cab3920cede141bf27c8bf4feefa19532907697b1L17-R17): Updated the route group to include the new `'prefix'` configuration option.
* [`routes/livewire.php`](diffhunk://#diff-bd59ed674ab20a784e8bda2f4c129a359ee384668a7249e132411c9cf899cfd3L13-R13): Updated the route group to include the new `'prefix'` configuration option.