### PR TITLE
Disallowed create users if feature is disabled

### DIFF
--- a/stubs/app/Actions/Fortify/CreateNewUser.php
+++ b/stubs/app/Actions/Fortify/CreateNewUser.php
@@ -19,6 +19,9 @@ class CreateNewUser implements CreatesNewUsers
      */
     public function create(array $input): User
     {
+        if (!Features::enabled(Features::registration())) {
+            abort(401);
+        }
         Validator::make($input, [
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],

--- a/stubs/app/Actions/Fortify/CreateNewUserWithTeams.php
+++ b/stubs/app/Actions/Fortify/CreateNewUserWithTeams.php
@@ -21,6 +21,9 @@ class CreateNewUser implements CreatesNewUsers
      */
     public function create(array $input): User
     {
+        if (!Features::enabled(Features::registration())) {
+            abort(401);
+        }
         Validator::make($input, [
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],


### PR DESCRIPTION
I noticed that removing `Features::registration()` from `config/fortify.php` still allows external users to create accounts.

I'm not sure if is a bug related to fortify (the repo seems to be fine), but is very hard to go deeper with this quantity of dependencies.

Anyways, this behavior must be controlled by the final application, just like these cases that the feature removal is not working (you can just access to /register and create an account).

The website I'm creating (and for sure, a lot of websites created with laravel) must disable the registration.

So this is more a workaround than a true fix, but I don't know how to fix it correctly, additional supoprt would be welcome.