### PR TITLE
Allow users to create a Page hierarchy inside the Pages directory

### DIFF
--- a/config/jetstream.php
+++ b/config/jetstream.php
@@ -6,5 +6,6 @@ return [
     'stack' => 'inertia',
     'middleware' => ['web'],
     'features' => [Features::accountDeletion()],
+    'page_prefix' => '',
     'profile_photo_disk' => 'public',
 ];

--- a/src/Http/Controllers/Inertia/ApiTokenController.php
+++ b/src/Http/Controllers/Inertia/ApiTokenController.php
@@ -16,7 +16,7 @@ class ApiTokenController extends Controller
      */
     public function index(Request $request)
     {
-        return Jetstream::inertia()->render($request, 'API/Index', [
+        return Jetstream::inertia()->render($request, config('jetstream.page_prefix').'API/Index', [
             'tokens' => $request->user()->tokens->map(function ($token) {
                 return $token->toArray() + [
                     'last_used_ago' => optional($token->last_used_at)->diffForHumans(),

--- a/src/Http/Controllers/Inertia/TeamController.php
+++ b/src/Http/Controllers/Inertia/TeamController.php
@@ -29,7 +29,7 @@ class TeamController extends Controller
 
         Gate::authorize('view', $team);
 
-        return Jetstream::inertia()->render($request, 'Teams/Show', [
+        return Jetstream::inertia()->render($request, config('jetstream.page_prefix').'Teams/Show', [
             'team' => $team->load('owner', 'users', 'teamInvitations'),
             'availableRoles' => array_values(Jetstream::$roles),
             'availablePermissions' => Jetstream::$permissions,
@@ -54,7 +54,7 @@ class TeamController extends Controller
     {
         Gate::authorize('create', Jetstream::newTeamModel());
 
-        return Jetstream::inertia()->render($request, 'Teams/Create');
+        return Jetstream::inertia()->render($request, config('jetstream.page_prefix').'Teams/Create');
     }
 
     /**

--- a/src/Http/Controllers/Inertia/UserProfileController.php
+++ b/src/Http/Controllers/Inertia/UserProfileController.php
@@ -24,7 +24,7 @@ class UserProfileController extends Controller
     {
         $this->validateTwoFactorAuthenticationState($request);
 
-        return Jetstream::inertia()->render($request, 'Profile/Show', [
+        return Jetstream::inertia()->render($request, config('jetstream.page_prefix').'Profile/Show', [
             'confirmsTwoFactorAuthentication' => Features::optionEnabled(Features::twoFactorAuthentication(), 'confirm'),
             'sessions' => $this->sessions($request)->all(),
         ]);

--- a/stubs/config/jetstream.php
+++ b/stubs/config/jetstream.php
@@ -67,6 +67,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Page Prefix
+    |--------------------------------------------------------------------------
+    |
+    | This configuration value determines the default location of the inertia
+    | pages inside the "resources/js/Pages" directory. Typically this will
+    | be "" but you adjust this so they are in a subdirectory "Members".
+    |
+    */
+
+    'page_prefix' => '',
+
+    /*
+    |--------------------------------------------------------------------------
     | Profile Photo Disk
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
This will support Inertia's advocated way of not constantly reloading the Layout component for Member Pages, for example.

Currently, the Jetstream-created Pages, while being adaptable, are loaded from the "Pages/Team/...vue" directory, for example. If one has an Inertia page resolve function that loads and applies a page's layout based on page name prefix (e.g. "Members/Teams/...vue") then the hardcoded paths in the src/Http/Controllers/Inertia/...Controller.php files will not be able to find the pages inside the subdirectories.

This change allows users to set a page prefix so that pages are loaded from the correct subdirectory.

The default value is an empty string.