### PR TITLE
Specify event to be faked for test

### DIFF
--- a/stubs/pest-tests/EmailVerificationTest.php
+++ b/stubs/pest-tests/EmailVerificationTest.php
@@ -19,7 +19,7 @@ test('email verification screen can be rendered', function () {
 }, 'Email verification not enabled.');
 
 test('email can be verified', function () {
-    Event::fake();
+    Event::fake(Verified::class);
 
     $user = User::factory()->create([
         'email_verified_at' => null,


### PR DESCRIPTION
The `EmailVerificationTest` only depends on the `Illuminate\Auth\Events\Verified` event to be faked and asserted on.

In the current situation all events are being faked, this includes Eloquent model events as well. When the user fills some (required) attributes on listening to the `creating` model event for example, these will not be filled since `User::factory()->create()` will be called on the next line.