### PR TITLE
Disable two factor authentication confirm button when form is processing

### DIFF
--- a/stubs/inertia/resources/js/Pages/Profile/Partials/TwoFactorAuthenticationForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/Partials/TwoFactorAuthenticationForm.vue
@@ -202,8 +202,8 @@ const disableTwoFactorAuthentication = () => {
                             v-if="confirming"
                             type="button"
                             class="me-3"
-                            :class="{ 'opacity-25': enabling }"
-                            :disabled="enabling"
+                            :class="{ 'opacity-25': enabling || confirmationForm.processing }"
+                            :disabled="enabling || confirmationForm.processing"
                         >
                             Confirm
                         </PrimaryButton>


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

If you change the behavior of the Inertia stack you're expected to update the Livewire stack as well and vice versa.
-->

In the Inertia stack, disable the two factor authentication confirmation button when the `confirmationForm` is processing. This prevents the button from being submitted while a request is already in progress.

Before:
<img src="https://github.com/user-attachments/assets/80375885-2e48-47ca-bba3-14719a0d823e" alt="inertia-disable-two-factor-authentication-confirm-button-before" width="500">

After:
<img src="https://github.com/user-attachments/assets/0a0078ee-a8d5-4629-971e-997547db6e5d" alt="inertia-disable-two-factor-authentication-confirm-button-after" width="500">

The Livewire stack already has this behavior:
<img src="https://github.com/user-attachments/assets/486afcb1-34ef-4081-bc53-78de78942090" alt="livewire-disable-two-factor-authentication-confirm-button" width="500">