### PR TITLE
[5.x] Bump Livewire to 3.6.4

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -150,7 +150,7 @@ class InstallCommand extends Command implements PromptsForMissingInput
     protected function installLivewireStack()
     {
         // Install Livewire...
-        if (! $this->requireComposerPackages('livewire/livewire:^3.0')) {
+        if (! $this->requireComposerPackages('livewire/livewire:^3.6.4')) {
             return false;
         }
 


### PR DESCRIPTION
Probably best to bump the Livewire version to 3.6.4 to address https://github.com/livewire/livewire/security/advisories/GHSA-29cq-5w36-x7w3