### PR TITLE
fix(hasTeamRole): prevent null membership role from causing error

### DIFF
--- a/src/HasTeams.php
+++ b/src/HasTeams.php
@@ -166,9 +166,19 @@ trait HasTeams
             return true;
         }
 
-        return $this->belongsToTeam($team) && optional(Jetstream::findRole($team->users->where(
+        if (! $this->belongsToTeam($team)) {
+            return false;
+        }
+
+        $roleKey = $team->users->where(
             'id', $this->id
-        )->first()->membership->role))->key === $role;
+        )->first()->membership->role;
+
+        if (! $roleKey) {
+            return false;
+        }
+
+        return Jetstream::findRole($roleKey)?->key === $role;
     }
 
     /**


### PR DESCRIPTION
The [migration allows `team_user.role` to be `null`](https://github.com/laravel/jetstream/blob/e01b945c9e89d272e7aa10ad2e58a54b194f008c/database/migrations/2020_05_21_200000_create_team_user_table.php#L18) and the `HasTeam::hasTeamRole()` method passed the value directly into the [`Jetstream::findRole()` method which does not allow `null`](https://github.com/laravel/jetstream/blob/e01b945c9e89d272e7aa10ad2e58a54b194f008c/src/Jetstream.php#L96) which can result in an error.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

If you change the behavior of the Inertia stack you're expected to update the Livewire stack as well and vice versa.
-->
