### PR TITLE
Guard against null role in hasTeamRole to prevent Jetstream::findRole error

### DIFF
--- a/src/HasTeams.php
+++ b/src/HasTeams.php
@@ -166,9 +166,19 @@ trait HasTeams
             return true;
         }
 
-        return $this->belongsToTeam($team) && optional(Jetstream::findRole($team->users->where(
+        if (! $this->belongsToTeam($team)) {
+            return false;
+        }
+
+        $roleKey = $team->users->where(
             'id', $this->id
-        )->first()->membership->role))->key === $role;
+        )->first()->membership->role;
+
+        if (! $roleKey) {
+            return false;
+        }
+
+        return Jetstream::findRole($roleKey)?->key === $role;
     }
 
     /**

--- a/tests/HasTeamsTest.php
+++ b/tests/HasTeamsTest.php
@@ -108,4 +108,13 @@ class HasTeamsTest extends OrchestraTestCase
 
         $this->assertSame([], $team->users->first()->teamPermissions($team));
     }
+
+    public function test_hasTeamRole_returns_false_when_member_pivot_role_is_null(): void
+    {
+        $team = Team::factory()->create();
+        $user = UserFixture::find(User::factory()->create()->id);
+        $user->teams()->attach($team);
+
+        $this->assertFalse($user->hasTeamRole($team, 'admin'));
+    }
 }


### PR DESCRIPTION
### Summary

The [`team_user.role` column allows `null`](https://github.com/laravel/jetstream/blob/e01b945c9e89d272e7aa10ad2e58a54b194f008c/database/migrations/2020_05_21_200000_create_team_user_table.php#L18), but the `HasTeams::hasTeamRole()` method passed the value directly into [`Jetstream::findRole()`](https://github.com/laravel/jetstream/blob/e01b945c9e89d272e7aa10ad2e58a54b194f008c/src/Jetstream.php#L96), which does not accept `null`.

This could cause an error when a team member record exists without an assigned role.

This PR introduces null checks to ensure that the role is valid before attempting to look it up.

---

### Changes

- Added an early return if the user does not belong to the team.
- Extracted the role key lookup into a separate variable for readability.
- Added a null check to safely handle the case where a user’s `membership->role` is `null`.
- Used the null-safe operator (`?->`) to avoid potential errors when resolving the role.

---

### Impact / Benefits to End Users

This fix improves application stability when handling team users without roles. Instead of triggering a fatal error, the method now safely returns `false`.

For developers, this makes the `hasTeamRole()` method more predictable and robust when working with incomplete or transitional team data.

---

### Backward Compatibility

* No existing functionality is broken.  
* The method behaviour remains the same for users with valid team roles.  
* The method now gracefully handles `null` roles, improving error tolerance.

---

### Inertia / Livewire Stack Consistency

No changes to frontend behaviour are introduced.  
This update applies to shared backend logic and does not affect Inertia or Livewire stacks differently.

---

### Tests

Tests cover the following cases:

- Returns `false` if the user’s role is `null`.