### PR TITLE
Query team_id on delete

### DIFF
--- a/src/Http/Livewire/TeamMemberManager.php
+++ b/src/Http/Livewire/TeamMemberManager.php
@@ -130,7 +130,9 @@ class TeamMemberManager extends Component
         if (! empty($invitationId)) {
             $model = Jetstream::teamInvitationModel();
 
-            $model::whereKey($invitationId)->delete();
+            $model::whereKey($invitationId)
+                ->where('team_id', $team->id)
+                ->delete();
         }
 
         $this->team = $this->team->fresh();

--- a/src/Http/Livewire/TeamMemberManager.php
+++ b/src/Http/Livewire/TeamMemberManager.php
@@ -131,7 +131,7 @@ class TeamMemberManager extends Component
             $model = Jetstream::teamInvitationModel();
 
             $model::whereKey($invitationId)
-                ->where('team_id', $team->id)
+                ->where('team_id', $this->team->id)
                 ->delete();
         }
 


### PR DESCRIPTION
Change
Validate invitation belongs to team when deleting it

Reason
It’s currently possible to delete invitations from other teams by changing the id in `cancelTeamInvitation(...)`. There is no validation to ensure the user has permission to delete that invitation. 

Security Issue: Minor