### PR TITLE
Fix hasTeamRole to handle null role values

### DIFF
--- a/src/HasTeams.php
+++ b/src/HasTeams.php
@@ -166,9 +166,13 @@ trait HasTeams
             return true;
         }
 
-        return $this->belongsToTeam($team) && optional(Jetstream::findRole($team->users->where(
-            'id', $this->id
-        )->first()->membership->role))->key === $role;
+        if (! $this->belongsToTeam($team)) {
+            return false;
+        }
+
+        $roleKey = $team->users->where('id', $this->id)->first()->membership->role;
+
+        return $roleKey && optional(Jetstream::findRole($roleKey))->key === $role;
     }
 
     /**

--- a/tests/HasTeamsTest.php
+++ b/tests/HasTeamsTest.php
@@ -108,4 +108,66 @@ class HasTeamsTest extends OrchestraTestCase
 
         $this->assertSame([], $team->users->first()->teamPermissions($team));
     }
+
+    public function test_hasTeamRole_returns_false_when_role_is_null(): void
+    {
+        Jetstream::role('admin', 'Admin', [
+            'read',
+            'create',
+        ])->description('Admin Description');
+
+        $team = Team::factory()->create();
+        $user = UserFixture::find(User::factory()->create()->id);
+        $user->teams()->attach($team, ['role' => null]);
+
+        $this->assertFalse($user->hasTeamRole($team, 'admin'));
+    }
+
+    public function test_hasTeamRole_returns_true_for_team_owner(): void
+    {
+        Jetstream::role('admin', 'Admin', [
+            'read',
+            'create',
+        ])->description('Admin Description');
+
+        $team = Team::factory()->create();
+
+        $this->assertTrue($team->owner->hasTeamRole($team, 'admin'));
+    }
+
+    public function test_hasTeamRole_returns_true_when_user_has_matching_role(): void
+    {
+        Jetstream::role('admin', 'Admin', [
+            'read',
+            'create',
+        ])->description('Admin Description');
+
+        $team = Team::factory()
+            ->hasAttached(User::factory(), [
+                'role' => 'admin',
+            ])
+            ->create();
+
+        $this->assertTrue($team->users->first()->hasTeamRole($team, 'admin'));
+    }
+
+    public function test_hasTeamRole_returns_false_when_user_has_different_role(): void
+    {
+        Jetstream::role('admin', 'Admin', [
+            'read',
+            'create',
+        ])->description('Admin Description');
+
+        Jetstream::role('editor', 'Editor', [
+            'read',
+        ])->description('Editor Description');
+
+        $team = Team::factory()
+            ->hasAttached(User::factory(), [
+                'role' => 'editor',
+            ])
+            ->create();
+
+        $this->assertFalse($team->users->first()->hasTeamRole($team, 'admin'));
+    }
 }


### PR DESCRIPTION
## Summary

This PR fixes issue #1585 where `hasTeamRole()` throws a `TypeError` when the `team_user.role` column is `null`.

The [Jetstream migration allows the role column to be nullable](https://github.com/laravel/jetstream/blob/e01b945c9e89d272e7aa10ad2e58a54b194f008c/database/migrations/2020_05_21_200000_create_team_user_table.php#L18), but the `hasTeamRole()` method was passing the value directly to `Jetstream::findRole()`, which requires a string (cannot accept null).

## Changes

1. **Added null check**: Check if `roleKey` is not null before calling `Jetstream::findRole()`
2. **Improved readability**: Extract the role key lookup into a separate variable
3. **Early return**: Return false early if user doesn't belong to the team
4. **Better structure**: Clearer control flow that's easier to understand and maintain

## Impact / Benefits

- **Prevents runtime errors**: The method now gracefully handles null roles instead of throwing a TypeError
- **Maintains backward compatibility**: No changes to existing behavior when roles are properly set
- **Improved stability**: Applications won't crash when team members exist without assigned roles

## Tests

Added comprehensive test coverage for `hasTeamRole()`:
- ✅ Returns `false` when user's role is `null`
- ✅ Returns `true` for team owners (regardless of role parameter)
- ✅ Returns `true` when user has the matching role
- ✅ Returns `false` when user has a different role

## Inertia / Livewire Stack Consistency

This fix applies to shared backend logic and does not affect either stack differently.

Fixes #1585