### PR TITLE
Use dynamic foreign key in `cancelTeamInvitation`

### DIFF
--- a/src/Http/Livewire/TeamMemberManager.php
+++ b/src/Http/Livewire/TeamMemberManager.php
@@ -130,8 +130,10 @@ class TeamMemberManager extends Component
         if (! empty($invitationId)) {
             $model = Jetstream::teamInvitationModel();
 
+            $foreignKey = (new $model)->team()->getForeignKeyName();
+
             $model::whereKey($invitationId)
-                ->where('team_id', $this->team->id)
+                ->where($foreignKey, $this->team->id)
                 ->delete();
         }
 


### PR DESCRIPTION
Since #1587, `TeamMemberManager::cancelTeamInvitation()` has `team_id` hardcoded as the foreign key. This causes issues when customizing the `TeamInvitation` model to use different naming conventions (e.g., `company_id`).

I've replaced the hardcoded string with a dynamic lookup that resolves the key name directly from the model's relationship.