### PR TITLE
fix: handle null role in hasTeamRole method

### DIFF
--- a/src/HasTeams.php
+++ b/src/HasTeams.php
@@ -166,9 +166,13 @@ trait HasTeams
             return true;
         }
 
-        return $this->belongsToTeam($team) && optional(Jetstream::findRole($team->users->where(
-            'id', $this->id
-        )->first()->membership->role))->key === $role;
+        if (! $this->belongsToTeam($team)) {
+            return false;
+        }
+
+        $memberRole = $team->users->where('id', $this->id)->first()->membership->role;
+
+        return $memberRole && optional(Jetstream::findRole($memberRole))->key === $role;
     }
 
     /**


### PR DESCRIPTION
## Summary

This PR fixes a bug where `hasTeamRole()` throws an error when the `team_user.role` column is `null`.

### The Problem

The [Jetstream migration allows the role column to be nullable](https://github.com/laravel/jetstream/blob/e01b945c9e89d272e7aa10ad2e58a54b194f008c/database/migrations/2020_05_21_200000_create_team_user_table.php#L18), but `hasTeamRole()` passes the role value directly to `Jetstream::findRole()` which doesn't accept `null`.

### The Fix

Add a null check before calling `Jetstream::findRole()`. This is consistent with how `teamRole()` already handles null roles at line 153:

```php
return $role ? Jetstream::findRole($role) : null;
```

The new implementation:
1. Returns early if user doesn't belong to team
2. Gets the member role value
3. Only calls `Jetstream::findRole()` if role is not null

Fixes #1585

## Test plan

```php
public function test_hasTeamRole_returns_false_when_member_pivot_role_is_null(): void
{
    $team = Team::factory()->create();
    $user = User::factory()->create();
    $user->teams()->attach($team, ['role' => null]);

    $this->assertFalse($user->hasTeamRole($team, 'admin'));
}
```

🤖 Generated with [Claude Code](https://claude.ai/code)