### PR TITLE
Bump @vitejs/plugin-vue to suport Vite 7

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -358,7 +358,7 @@ EOF;
                 '@inertiajs/vue3' => '^2.0',
                 '@tailwindcss/forms' => '^0.5.7',
                 '@tailwindcss/typography' => '^0.5.10',
-                '@vitejs/plugin-vue' => '^5.0.0',
+                '@vitejs/plugin-vue' => '^6.0.4',
                 'autoprefixer' => '^10.4.16',
                 'postcss' => '^8.4.32',
                 'tailwindcss' => '^3.4.0',


### PR DESCRIPTION
Currently, there is an issue when installing Jetstream on a new Laravel 12 project which uses Vite 7:

```
npm error code ERESOLVE
npm error ERESOLVE unable to resolve dependency tree
npm error
npm error While resolving: undefined@undefined
npm error Found: vite@7.3.1
npm error node_modules/vite
npm error   dev vite@"^7.0.7" from the root project
npm error
npm error Could not resolve dependency:
npm error peer vite@"^5.0.0 || ^6.0.0" from @vitejs/plugin-vue@5.2.4
npm error node_modules/@vitejs/plugin-vue
npm error   dev @vitejs/plugin-vue@"^5.0.0" from the root project
npm error
npm error Fix the upstream dependency conflict, or retry
npm error this command with --force or --legacy-peer-deps
npm error to accept an incorrect (and potentially broken) dependency resolution.
npm error
npm error
npm error For a full report see:
npm error /Users/ostap/.npm/_logs/2026-02-16T18_32_44_533Z-eresolve-report.txt
npm error A complete log of this run can be found in: /Users/ostap/.npm/_logs/2026-02-16T18_32_44_533Z-debug-0.log
```