### PR TITLE
Fix stubs workflow in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,7 @@ jobs:
       fail-fast: true
       matrix:
         stack: [inertia, livewire]
-        laravel: ['11.x-dev', 'dev-master']
+        laravel: ['11.x-dev', '12.x-dev']
 
     name: Test Stubs - Laravel ${{ matrix.laravel }} - ${{ matrix.stack }}
 


### PR DESCRIPTION
Since Livewire doesn't work with Laravel 13, it might be a good idea to limit this test to 12.x to prevent failure.