### PR TITLE
Fix hasTeamRole() throwing when team_user.role is null

### DIFF
--- a/src/HasTeams.php
+++ b/src/HasTeams.php
@@ -166,9 +166,11 @@ trait HasTeams
             return true;
         }
 
-        return $this->belongsToTeam($team) && optional(Jetstream::findRole($team->users->where(
-            'id', $this->id
-        )->first()->membership->role))->key === $role;
+        $memberRole = $this->belongsToTeam($team)
+            ? $team->users->where('id', $this->id)->first()->membership->role
+            : null;
+
+        return $memberRole && optional(Jetstream::findRole($memberRole))->key === $role;
     }
 
     /**

--- a/tests/HasTeamsTest.php
+++ b/tests/HasTeamsTest.php
@@ -108,4 +108,18 @@ class HasTeamsTest extends OrchestraTestCase
 
         $this->assertSame([], $team->users->first()->teamPermissions($team));
     }
+
+    public function test_hasTeamRole_returns_false_when_role_is_null(): void
+    {
+        Jetstream::role('admin', 'Admin', [
+            'read',
+            'create',
+        ])->description('Admin Description');
+
+        $team = Team::factory()
+            ->has(User::factory())
+            ->create();
+
+        $this->assertFalse($team->users->first()->hasTeamRole($team, 'admin'));
+    }
 }


### PR DESCRIPTION
Fixes #1585

## Summary

`hasTeamRole()` in the `HasTeams` trait passes the pivot `role` value directly to `Jetstream::findRole(string $key)`, which throws a `TypeError` when the role is `null`. The [migration allows `role` to be nullable](https://github.com/laravel/jetstream/blob/e01b945c9e89d272e7aa10ad2e58a54b194f008c/database/migrations/2020_05_21_200000_create_team_user_table.php#L18), so this is a valid database state.

The sibling method `teamRole()` already handles this correctly by checking for null before calling `findRole()`. This fix applies the same pattern to `hasTeamRole()` — extracting the role value first and returning `false` when it is `null`.

## Regression test

Added `test_hasTeamRole_returns_false_when_role_is_null` to `HasTeamsTest.php`. The test creates a team member with a null role (using `->has(User::factory())` with no pivot role specified) and asserts that `hasTeamRole()` returns `false` instead of throwing a `TypeError`.

This mirrors the existing test `test_teamRole_returns_null_if_the_user_does_not_have_a_role_on_the_site` which already covers the same null-role scenario for the `teamRole()` method — confirming that `teamRole()` handles null gracefully while `hasTeamRole()` did not.

### Related existing tests in `HasTeamsTest.php`
- `test_teamRole_returns_null_if_the_user_does_not_have_a_role_on_the_site` — verifies `teamRole()` returns null when role is null (passing)
- `test_teamRole_returns_the_matching_role` — verifies `teamRole()` with a valid role (passing)
- No equivalent test existed for `hasTeamRole()` with a null role — this PR adds one

## Test plan

- [x] `test_hasTeamRole_returns_false_when_role_is_null` — regression test for the fix
- [x] Existing `teamRole()` null tests continue to pass
- [x] `hasTeamRole()` still returns `true` for team owners
- [x] `hasTeamRole()` still returns correct result for members with assigned roles

🤖 Generated with [Claude Code](https://claude.com/claude-code)