### PR TITLE
[5.x] Expand symfony/console version to include 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "illuminate/support": "^11.0|^12.0|^13.0",
         "laravel/fortify": "^1.20",
         "mobiledetect/mobiledetectlib": "^4.8.08",
-        "symfony/console": "^7.0"
+        "symfony/console": "^7.0|^8.0"
     },
     "require-dev": {
         "inertiajs/inertia-laravel": "^2.0",


### PR DESCRIPTION
## Why?

Installing Jetstream in a Laravel 13 project fails because L13 would have installed symfony/console v8.0.7

<details>
  <summary>Your requirements could not be resolved to an installable set of packages</summary>

```
Problem 1
    - Root composer.json requires laravel/jetstream * -> satisfiable by laravel/jetstream[v0.0.1, ..., v0.7.3, v1.0.0, ..., v1.7.2, v2.0.0, ..., v2.16.2, v3.0.0, ..., v3.3.3, v4.0.0, ..., v4.3.1, v5.0.0, ..., v5.5.1].
    - laravel/jetstream[v0.0.1, ..., v0.7.3, v1.0.0, ..., v1.5.3] require php ^7.3 -> your php version (8.5.4) does not satisfy that requirement.
    - laravel/jetstream[v1.6.0, ..., v1.6.7, v2.0.0, ..., v2.5.1] require illuminate/support ^8.0 -> found illuminate/support[v8.0.0, ..., v8.83.27] but these were not loaded, likely because it conflicts with another require.
    - laravel/jetstream[v2.10.0, ..., v2.10.1] require illuminate/support ^9.0 -> found illuminate/support[v9.0.0, ..., v9.52.16] but these were not loaded, likely because it conflicts with another require.
    - laravel/jetstream[v2.10.2, ..., v2.14.1] require illuminate/console ^9.21 -> found illuminate/console[v9.21.0, ..., v9.52.16] but these were not loaded, likely because it conflicts with another require.
    - laravel/jetstream[v1.7.0, ..., v1.7.2, v2.6.0, ..., v2.6.6] require illuminate/support ^8.0|^9.0 -> found illuminate/support[v8.0.0, ..., v8.83.27, v9.0.0, ..., v9.52.16] but these were not loaded, likely because it conflicts with another require.
    - laravel/jetstream[v2.6.7, ..., v2.9.0] require illuminate/support ^8.37|^9.0 -> found illuminate/support[v8.37.0, ..., v8.83.27, v9.0.0, ..., v9.52.16] but these were not loaded, likely because it conflicts with another require.
    - laravel/jetstream[v2.15.0, ..., v2.16.2, v3.0.0, ..., v3.0.2] require illuminate/console ^9.21|^10.0 -> found illuminate/console[v9.21.0, ..., v9.52.16, v10.0.0, ..., v10.49.0] but these were not loaded, likely because it conflicts with another require.
    - laravel/jetstream[v3.1.0, ..., v3.2.5] require illuminate/console ^10.0 -> found illuminate/console[v10.0.0, ..., v10.49.0] but these were not loaded, likely because it conflicts with another require.
    - laravel/jetstream[v3.3.0, ..., v3.3.3, v4.0.0, ..., v4.3.1] require illuminate/console ^10.17 -> found illuminate/console[v10.17.0, ..., v10.49.0] but these were not loaded, likely because it conflicts with another require.
    - laravel/jetstream[v5.0.0, ..., v5.3.4] require illuminate/console ^11.0 -> found illuminate/console[v11.0.0, ..., v11.50.0] but these were not loaded, likely because it conflicts with another require.
    - laravel/jetstream[v5.3.5, ..., v5.4.0] require illuminate/console ^11.0|^12.0 -> found illuminate/console[v11.0.0, ..., v11.50.0, v12.0.0, ..., v12.55.1] but these were not loaded, likely because it conflicts with another require.
    - laravel/jetstream[v5.5.0, ..., v5.5.1] require symfony/console ^7.0 -> found symfony/console[v7.0.0, ..., v7.4.7] but the package is fixed to v8.0.7 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
```
</details>

## How about symfony/console ^7.0 constraint?

The constraint was added by #1455 and in 16baa106dd77fb363d6180f5aab28207e4e2d23f. 

Since Jetstream already depends on `illuminate/console` that has a `symphony/console` dependency ([13.x](https://github.com/illuminate/console/blob/dc5a81a0491c542477a2b099aa70cac6564beeea/composer.json#L26), [12.x](https://github.com/illuminate/console/blob/55508f214a538599235935fa018824900f68b5bb/composer.json#L26) && [11.x](https://github.com/illuminate/console/blob/977b4123476fd0c5ea55c144271205a4b9666ff7/composer.json#L26) ) an argument can be made to let `illuminate/console` pin the supported version.

Ultimately, I left this call up to the team.