### PR TITLE
add `accept="image/*"` to restrect file upload input to images only

### DIFF
--- a/stubs/inertia/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
@@ -93,8 +93,8 @@ const clearPhotoFileInput = () => {
                     id="photo"
                     ref="photoInput"
                     type="file"
-                    class="hidden"
                     accept="image/*"
+                    class="hidden"
                     @change="updatePhotoPreview"
                 >
 

--- a/stubs/inertia/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
@@ -94,6 +94,7 @@ const clearPhotoFileInput = () => {
                     ref="photoInput"
                     type="file"
                     class="hidden"
+                    accept="image/*"
                     @change="updatePhotoPreview"
                 >
 

--- a/stubs/livewire/resources/views/profile/update-profile-information-form.blade.php
+++ b/stubs/livewire/resources/views/profile/update-profile-information-form.blade.php
@@ -12,7 +12,7 @@
         @if (Laravel\Jetstream\Jetstream::managesProfilePhotos())
             <div x-data="{photoName: null, photoPreview: null}" class="col-span-6 sm:col-span-4">
                 <!-- Profile Photo File Input -->
-                <input type="file" id="photo" class="hidden"
+                <input type="file" accept="image/*" id="photo" class="hidden"
                             wire:model.live="photo"
                             x-ref="photo"
                             x-on:change="


### PR DESCRIPTION
This PR is just to restrict the  file input to images only.

for `UpdateProfileInformationForm.vue`  and `update-profile-information-form.blade.php` components  for inertia and livewire respectively the file `input` is only used to select profile photo but it's not restricted to show images only.

