### PR TITLE
Fix: Remove bootstrap.js import for Laravel 13+ in Inertia stack

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -445,6 +445,7 @@ EOF;
         // Assets...
         copy(__DIR__.'/../../stubs/resources/css/app.css', resource_path('css/app.css'));
         copy(__DIR__.'/../../stubs/inertia/resources/js/app.js', resource_path('js/app.js'));
+
         if (version_compare(\Illuminate\Foundation\Application::VERSION, '13.0.0', '>=')) {
             $this->replaceInFile("import './bootstrap';", '', resource_path('js/app.js'));
         }

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -445,6 +445,9 @@ EOF;
         // Assets...
         copy(__DIR__.'/../../stubs/resources/css/app.css', resource_path('css/app.css'));
         copy(__DIR__.'/../../stubs/inertia/resources/js/app.js', resource_path('js/app.js'));
+        if (version_compare(\Illuminate\Foundation\Application::VERSION, '13.0.0', '>=')) {
+            $this->replaceInFile("import './bootstrap';", '', resource_path('js/app.js'));
+        }
 
         // Tests...
         $stubs = $this->getTestStubsPath();


### PR DESCRIPTION
When installing the Jetstream Inertia stack on a fresh Laravel 13 application, the installation currently fails when running `npm run build`. 

Because Laravel 13 no longer includes the `resources/js/bootstrap.js` file by default, the Jetstream installer stubbing out `import './bootstrap';` in `resources/js/app.js` causes Vite to throw an `[UNRESOLVED_IMPORT]` error.

This PR adds a version check during the Inertia installation process. If the application is running Laravel 13 or higher, the import line is dynamically removed from the copied `app.js` file, allowing Vite to build successfully.

**Note regarding the Livewire stack:** I only applied this change to the Inertia installation logic. The Livewire stack does not copy a custom `app.js` stub (it relies on the default framework skeleton), so it does not suffer from this bug and did not need to be updated.